### PR TITLE
feat: ajout d'un cron job pour import dossiers apprenants sur platforme recette

### DIFF
--- a/.github/workflows/cron-recette.yml
+++ b/.github/workflows/cron-recette.yml
@@ -1,0 +1,31 @@
+name: Cron Job pour import dossiers apprenants en Recette
+on:
+  # Note: only schedules in default branch (i.e master) are run
+  schedule: 
+    - cron: "0 4 * * *"
+env:
+  API_URL: https://cfas-recette.apprentissage.beta.gouv.fr
+  API_USERNAME: ${{ secrets.API_RECETTE_USERNAME }}
+  API_PASSWORD: ${{ secrets.API_RECETTE_PASSWORD }}
+jobs:
+  cron:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: sven/recette/send-dossiers-apprenant
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+          fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install deps
+        run: |
+          make install-server
+          echo "installed"
+
+      - name: Run Job to send "dossiers apprenants" to recette plaform
+        run: |
+          node server/tests/recette/jobs/send-dossiers-apprenants/index.js

--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -1,11 +1,29 @@
 {
   "root": true,
-  "extends": ["eslint:recommended", "plugin:node/recommended-module", "plugin:prettier/recommended"],
-  "plugins": ["mocha", "import"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:node/recommended-module",
+    "plugin:prettier/recommended"
+  ],
+  "plugins": [
+    "mocha",
+    "import"
+  ],
   "rules": {
     "import/no-unresolved": 2,
     "import/no-commonjs": 2,
-    "import/extensions": [2, "ignorePackages"]
+    "import/extensions": [
+      2,
+      "ignorePackages"
+    ],
+    "no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ]
   },
   "env": {
     "es2021": true,

--- a/server/tests/data/randomizedSample.js
+++ b/server/tests/data/randomizedSample.js
@@ -35,9 +35,10 @@ const getRandomDateNaissance = () => faker.date.birthdate({ min: 18, max: 25, mo
 export const createRandomDossierApprenant = (params = {}) => {
   const annee_scolaire = getRandomAnneeScolaire();
   const periode_formation = getRandomPeriodeFormation(annee_scolaire);
+  const isStudentPresent = isPresent();
 
   return {
-    ine_apprenant: isPresent() ? getRandomIne() : null,
+    ine_apprenant: isStudentPresent ? getRandomIne() : null,
     nom_apprenant: faker.name.lastName().toUpperCase(),
     prenom_apprenant: faker.name.firstName(),
     email_contact: faker.internet.email(),
@@ -45,12 +46,12 @@ export const createRandomDossierApprenant = (params = {}) => {
     formation_cfd: getRandomFormationCfd(),
     libelle_long_formation: faker.datatype.boolean() ? faker.helpers.arrayElement(sampleLibelles).intitule_long : null,
     uai_etablissement: getRandomUaiEtablissement(),
-    siret_etablissement: isPresent() ? getRandomSiretEtablissement() : null,
+    siret_etablissement: isStudentPresent ? getRandomSiretEtablissement() : null,
     nom_etablissement: `ETABLISSEMENT ${faker.random.word()}`.toUpperCase(),
 
     statut_apprenant: getRandomStatutApprenant(),
     date_metier_mise_a_jour_statut: faker.date.past(),
-    periode_formation: isPresent() ? periode_formation : null,
+    periode_formation: isStudentPresent ? periode_formation : null,
     annee_formation: getRandomAnneeFormation(),
     annee_scolaire,
     id_erp_apprenant: faker.datatype.uuid(),
@@ -69,13 +70,14 @@ export const createRandomDossierApprenant = (params = {}) => {
 export const createRandomEffectifApprenant = (params = {}) => {
   const annee_scolaire = getRandomAnneeScolaire();
   const periode_formation = getRandomPeriodeFormation(annee_scolaire);
+  const isStudentPresent = isPresent();
 
   return {
     dossierApprenantId: faker.datatype.uuid(),
     uai_etablissement: getRandomUaiEtablissement(),
     nom_etablissement: `ETABLISSEMENT ${faker.random.word()}`.toUpperCase(),
     formation_cfd: getRandomFormationCfd(),
-    periode_formation: isPresent() ? periode_formation : null,
+    periode_formation: isStudentPresent ? periode_formation : null,
     annee_formation: getRandomAnneeFormation(),
     annee_scolaire,
     code_commune_insee_apprenant: faker.datatype.boolean() ? faker.address.zipCode() : null,
@@ -93,9 +95,10 @@ export const createRandomEffectifApprenant = (params = {}) => {
 export const createRandomDossierApprenantApiInput = (params = {}) => {
   const annee_scolaire = getRandomAnneeScolaire();
   const periode_formation = getRandomPeriodeFormation(annee_scolaire);
+  const isStudentPresent = isPresent();
 
   return {
-    ine_apprenant: isPresent() ? getRandomIne() : null,
+    ine_apprenant: isStudentPresent ? getRandomIne() : null,
     nom_apprenant: faker.name.lastName().toUpperCase(),
     prenom_apprenant: faker.name.firstName(),
     date_de_naissance_apprenant: getRandomDateNaissance().toISOString().slice(0, -5),
@@ -105,13 +108,13 @@ export const createRandomDossierApprenantApiInput = (params = {}) => {
     id_formation: getRandomFormationCfd(),
     libelle_long_formation: faker.datatype.boolean() ? faker.helpers.arrayElement(sampleLibelles).intitule_long : null,
     uai_etablissement: getRandomUaiEtablissement(),
-    siret_etablissement: isPresent() ? getRandomSiretEtablissement() : "",
+    siret_etablissement: isStudentPresent ? getRandomSiretEtablissement() : "",
     nom_etablissement: `ETABLISSEMENT ${faker.random.word()}`.toUpperCase(),
 
     statut_apprenant: getRandomStatutApprenant(),
     date_metier_mise_a_jour_statut: faker.date.past().toISOString(),
     annee_formation: getRandomAnneeFormation(),
-    periode_formation: isPresent() ? periode_formation.join("-") : "",
+    periode_formation: isStudentPresent ? periode_formation.join("-") : "",
     annee_scolaire,
     id_erp_apprenant: faker.datatype.uuid(),
     tel_apprenant: faker.datatype.boolean() ? faker.phone.number() : null,

--- a/server/tests/recette/jobs/send-dossiers-apprenants/index.js
+++ b/server/tests/recette/jobs/send-dossiers-apprenants/index.js
@@ -1,6 +1,7 @@
 const assert = require("assert");
 const { format } = require("date-fns");
 
+const { createRandomDossierApprenant } = require("../../../data/randomizedSample");
 const {
   getJwtForUser,
   getHttpClient,
@@ -31,42 +32,56 @@ async function main() {
     console.error(JSON.stringify(testResponse, null, 2));
     throw new Error("Error while testing dossiers apprenants connection");
   }
+  // we send 100 dossiers apprenants,
+  // 1 with all fields for "Donald Duck", and 99 with random data
+  const dossiersApprenants = [
+    {
+      // required fields
+      nom_apprenant: "Duck",
+      prenom_apprenant: "Donald",
+      date_de_naissance_apprenant: format(new Date(), "yyyy-MM-dd"),
+      uai_etablissement: "0142321X",
+      nom_etablissement: "LE MANS Entreprise",
+      statut_apprenant: 2,
+      id_formation: "32031213",
+      annee_scolaire: "2021-2022",
+      date_metier_mise_a_jour_statut: new Date().toISOString(),
+      id_erp_apprenant: "1121321321231",
+      // optional fields
+      ine_apprenant: "061322157SS",
+      email_contact: "test@mail.com",
+      tel_apprenant: "0169044455",
+      code_commune_insee_apprenant: "91700",
+      siret_etablissement: "",
+      etablissement_formateur_geo_coordonnees: "49.413655,1.073591",
+      etablissement_formateur_code_commune_insee: "54357",
+      libelle_court_formation: "BTS Management Commercial Opérationnel",
+      libelle_long_formation: "BTS Management Commercial Opérationnel",
+      formation_rncp: "RNCP12345",
+      periode_formation: "2020-2022",
+      annee_formation: 1,
+      contrat_date_debut: "2020-01-30T00:00:00.000Z",
+      contrat_date_fin: "2020-12-30T00:00:00.000Z",
+      contrat_date_rupture: "2020-04-30T00:00:00.000Z",
+      date_entree_formation: "2020-02-30T00:00:00.000Z",
+    },
+    ...Array.from({ length: 99 })
+      .map((_undefined, idx) =>
+        createRandomDossierApprenant({
+          id_formation: "32031213",
+          email_contact: `test+${idx}@mail.com`,
+        })
+      )
+      .map((dossier) => ({
+        ...dossier,
+        periode_formation: dossier.periode_formation?.join("-"),
+      })),
+  ];
 
   const response = await postDossiersApprenants({
     httpClient,
     token,
-    data: [
-      {
-        // required fields
-        nom_apprenant: "Duck",
-        prenom_apprenant: "Donald",
-        date_de_naissance_apprenant: format(new Date(), "yyyy-MM-dd"),
-        uai_etablissement: "0142321X",
-        nom_etablissement: "LE MANS Entreprise",
-        statut_apprenant: 2,
-        id_formation: "32031213",
-        annee_scolaire: "2021-2022",
-        date_metier_mise_a_jour_statut: new Date().toISOString(),
-        id_erp_apprenant: "1121321321231",
-        // optional fields
-        ine_apprenant: "061322157SS",
-        email_contact: "test@mail.com",
-        tel_apprenant: "0169044455",
-        code_commune_insee_apprenant: "91700",
-        siret_etablissement: "",
-        etablissement_formateur_geo_coordonnees: "49.413655,1.073591",
-        etablissement_formateur_code_commune_insee: "54357",
-        libelle_court_formation: "BTS Management Commercial Opérationnel",
-        libelle_long_formation: "BTS Management Commercial Opérationnel",
-        formation_rncp: "RNCP12345",
-        periode_formation: "2020-2022",
-        annee_formation: 1,
-        contrat_date_debut: "2020-01-30T00:00:00.000Z",
-        contrat_date_fin: "2020-12-30T00:00:00.000Z",
-        contrat_date_rupture: "2020-04-30T00:00:00.000Z",
-        date_entree_formation: "2020-02-30T00:00:00.000Z",
-      },
-    ],
+    data: dossiersApprenants,
   });
   console.info(JSON.stringify(response, null, 2));
 

--- a/server/tests/recette/jobs/send-dossiers-apprenants/index.js
+++ b/server/tests/recette/jobs/send-dossiers-apprenants/index.js
@@ -1,7 +1,7 @@
 const assert = require("assert");
 const { format } = require("date-fns");
 
-const { createRandomDossierApprenant } = require("../../../data/randomizedSample");
+const { createRandomDossierApprenantApiInput } = require("../../../data/randomizedSample");
 const {
   getJwtForUser,
   getHttpClient,
@@ -65,17 +65,7 @@ async function main() {
       contrat_date_rupture: "2020-04-30T00:00:00.000Z",
       date_entree_formation: "2020-02-30T00:00:00.000Z",
     },
-    ...Array.from({ length: 99 })
-      .map((_undefined, idx) =>
-        createRandomDossierApprenant({
-          id_formation: "32031213",
-          email_contact: `test+${idx}@mail.com`,
-        })
-      )
-      .map((dossier) => ({
-        ...dossier,
-        periode_formation: dossier.periode_formation?.join("-"),
-      })),
+    ...Array.from({ length: 99 }).map((_undefined, _idx) => createRandomDossierApprenantApiInput()),
   ];
 
   const response = await postDossiersApprenants({

--- a/server/tests/recette/jobs/send-dossiers-apprenants/index.js
+++ b/server/tests/recette/jobs/send-dossiers-apprenants/index.js
@@ -1,0 +1,78 @@
+const assert = require("assert");
+const { format } = require("date-fns");
+
+const {
+  getJwtForUser,
+  getHttpClient,
+  postDossiersApprenantsTest,
+  postDossiersApprenants,
+} = require("../../../utils/api");
+
+/**
+ * Ce script permet d'envoyer des dossiers apprenants de tests toutes les nuits
+ * à la plateforme de recette.
+ */
+async function main() {
+  console.info("Run send-dossiers-apprenants Job");
+
+  assert(process.env.API_URL, "API_URL is required");
+  assert(process.env.API_USERNAME, "API_USERNAME is required");
+  assert(process.env.API_PASSWORD, "API_PASSWORD is required");
+
+  const httpClient = getHttpClient(process.env.API_URL);
+  const token = await getJwtForUser({
+    httpClient,
+    username: process.env.API_USERNAME,
+    password: process.env.API_PASSWORD,
+  });
+
+  const testResponse = await postDossiersApprenantsTest({ httpClient, token });
+  if (testResponse.data?.msg !== "ok") {
+    console.error(JSON.stringify(testResponse, null, 2));
+    throw new Error("Error while testing dossiers apprenants connection");
+  }
+
+  const response = await postDossiersApprenants({
+    httpClient,
+    token,
+    data: [
+      {
+        // required fields
+        nom_apprenant: "Duck",
+        prenom_apprenant: "Donald",
+        date_de_naissance_apprenant: format(new Date(), "yyyy-MM-dd"),
+        uai_etablissement: "0142321X",
+        nom_etablissement: "LE MANS Entreprise",
+        statut_apprenant: 2,
+        id_formation: "32031213",
+        annee_scolaire: "2021-2022",
+        date_metier_mise_a_jour_statut: new Date().toISOString(),
+        id_erp_apprenant: "1121321321231",
+        // optional fields
+        ine_apprenant: "061322157SS",
+        email_contact: "test@mail.com",
+        tel_apprenant: "0169044455",
+        code_commune_insee_apprenant: "91700",
+        siret_etablissement: "",
+        etablissement_formateur_geo_coordonnees: "49.413655,1.073591",
+        etablissement_formateur_code_commune_insee: "54357",
+        libelle_court_formation: "BTS Management Commercial Opérationnel",
+        libelle_long_formation: "BTS Management Commercial Opérationnel",
+        formation_rncp: "RNCP12345",
+        periode_formation: "2020-2022",
+        annee_formation: 1,
+        contrat_date_debut: "2020-01-30T00:00:00.000Z",
+        contrat_date_fin: "2020-12-30T00:00:00.000Z",
+        contrat_date_rupture: "2020-04-30T00:00:00.000Z",
+        date_entree_formation: "2020-02-30T00:00:00.000Z",
+      },
+    ],
+  });
+  console.info(JSON.stringify(response, null, 2));
+
+  if (response.data?.status !== "OK") {
+    throw new Error("Error while sending dossiers apprenants");
+  }
+}
+
+main();

--- a/server/tests/utils/api.js
+++ b/server/tests/utils/api.js
@@ -1,0 +1,43 @@
+const axios = require("axios");
+
+const getHttpClient = (baseURL) =>
+  axios.create({
+    baseURL,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    validateStatus: function () {
+      return true;
+    },
+  });
+
+const getAuthorizationHeader = (token) => ({ headers: { Authorization: `Bearer ${token}` } });
+
+const getJwtForUser = async ({ httpClient, username, password }) => {
+  const { data } = await httpClient.post("/api/login", {
+    username,
+    password,
+  });
+  return data.access_token;
+};
+
+const postDossiersApprenantsTest = async ({ httpClient, token }) => {
+  const { status, data } = await httpClient.post("/api/dossiers-apprenants/test", {}, getAuthorizationHeader(token));
+  return { status, data };
+};
+
+const postDossiersApprenants = async ({ httpClient, token, data: dossierApprenants }) => {
+  const { status, data } = await httpClient.post(
+    "/api/dossiers-apprenants",
+    dossierApprenants,
+    getAuthorizationHeader(token)
+  );
+  return { status, data };
+};
+
+module.exports = {
+  getHttpClient,
+  getJwtForUser,
+  postDossiersApprenantsTest,
+  postDossiersApprenants,
+};


### PR DESCRIPTION
Cette PR ajoute un job de test pour la plateforme recette, pour importer toutes les nuits un jeu de dossiers apprenants de test en recette.

Le job est executé toutes les nuits à 04h00 à l'aide de github actions. C'est une proposition de workflow, si pas possible, on peut bien sur en discuter pour trouver une alternative. 

J'ai ajouté un helper server/tests/utils/api.js pour appeler l'api, avec l'idée qu'on pourrait réutiliser ce helper dans les tests d'integration dans le futur.

**TODO**
ajouter 2 gh secrets pour se connecter à la recette:
- API_RECETTE_USERNAME
- API_RECETTE_PASSWORD
