### PR TITLE
feat: ajout page /admin/maintenance

### DIFF
--- a/server/src/common/actions/maintenances.actions.js
+++ b/server/src/common/actions/maintenances.actions.js
@@ -10,7 +10,7 @@ import { defaultValuesMaintenanceMessage } from "../model/next.toKeep.models/mai
  * @returns
  */
 export const createMaintenanceMessage = async ({ name, msg, type, context, time, enabled }) => {
-  const { insertedId } = await maintenanceMessageDb().insertOne({
+  const data = {
     ...defaultValuesMaintenanceMessage(),
     type,
     name,
@@ -18,9 +18,9 @@ export const createMaintenanceMessage = async ({ name, msg, type, context, time,
     msg,
     enabled: enabled || false,
     time: time,
-  });
-
-  return insertedId;
+  };
+  const { insertedId } = await maintenanceMessageDb().insertOne(data);
+  return { _id: insertedId, ...data };
 };
 
 /**

--- a/server/src/common/model/next.toKeep.models/maintenanceMessages.model.js
+++ b/server/src/common/model/next.toKeep.models/maintenanceMessages.model.js
@@ -10,7 +10,7 @@ export const schema = object(
   {
     _id: objectId(),
     msg: string({ description: "Message de maintenance" }),
-    name: string({ description: "email du créteur du message" }),
+    name: string({ description: "email du créateur du message" }),
     type: string({ enum: ["alert", "info"] }),
     context: string({ enum: ["manuel", "automatique", "maintenance"] }),
     time: date({ description: "Date de mise en place du message" }),

--- a/server/src/http/middlewares/authMiddleware.js
+++ b/server/src/http/middlewares/authMiddleware.js
@@ -54,6 +54,7 @@ export const authMiddleware = () => {
     async (req, res, next) => {
       const activeSession = await sessions.findJwt(req.cookies[COOKIE_NAME]);
       if (!activeSession) {
+        // TDB change to 401?
         return res.status(400).json({ error: "Accès non autorisé" });
       }
       if (req.user.invalided_token) {

--- a/server/src/http/middlewares/authMiddleware.js
+++ b/server/src/http/middlewares/authMiddleware.js
@@ -54,8 +54,7 @@ export const authMiddleware = () => {
     async (req, res, next) => {
       const activeSession = await sessions.findJwt(req.cookies[COOKIE_NAME]);
       if (!activeSession) {
-        // TDB change to 401?
-        return res.status(400).json({ error: "Accès non autorisé" });
+        return res.status(401).json({ error: "Accès non autorisé" });
       }
       if (req.user.invalided_token) {
         await sessions.removeJwt(req.cookies[COOKIE_NAME]);

--- a/server/src/http/middlewares/pageAccessMiddleware.js
+++ b/server/src/http/middlewares/pageAccessMiddleware.js
@@ -6,8 +6,7 @@ export const pageAccessMiddleware = (acl = []) => {
     const current = pick(user?.permissions, Object.keys(permissions));
 
     if (!(isEqual(current, permissions) || acl.every((page) => user?.acl.includes(page)))) {
-      // TBD: change to 403 ?
-      return res.status(401).json({ message: "Accès non autorisé" });
+      return res.status(403).json({ message: "Accès non autorisé" });
     }
 
     next();

--- a/server/src/http/middlewares/pageAccessMiddleware.js
+++ b/server/src/http/middlewares/pageAccessMiddleware.js
@@ -6,6 +6,7 @@ export const pageAccessMiddleware = (acl = []) => {
     const current = pick(user?.permissions, Object.keys(permissions));
 
     if (!(isEqual(current, permissions) || acl.every((page) => user?.acl.includes(page)))) {
+      // TBD: change to 403 ?
       return res.status(401).json({ message: "Accès non autorisé" });
     }
 

--- a/server/src/http/routes/admin.routes/maintenances.routes.js
+++ b/server/src/http/routes/admin.routes/maintenances.routes.js
@@ -33,7 +33,7 @@ export default () => {
         time: new Date(),
       });
 
-      return res.json(newMaintenanceMessage);
+      return res.status(201).json(newMaintenanceMessage);
     })
   );
 

--- a/server/src/http/server.js
+++ b/server/src/http/server.js
@@ -62,7 +62,7 @@ export default async (services) => {
   app.use("/api/v1/auth", auth());
   app.use("/api/v1/auth", register(services));
   app.use("/api/v1/password", password(services));
-  app.use("/api/v1/maintenanceMessage", maintenancesRoutes());
+  app.use("/api/v1/maintenanceMessages", maintenancesRoutes());
 
   // private access
   app.use("/api/v1/session", checkJwtToken, session());

--- a/server/tests/integration/http/maintenances.route.test.js
+++ b/server/tests/integration/http/maintenances.route.test.js
@@ -1,0 +1,195 @@
+import { strict as assert } from "assert";
+
+import { startServer, createAdminUser, createSimpleUser } from "../../utils/testUtils.js";
+
+const ADMIN_MAINTENANCE_ENDPOINT = "/api/v1/admin/maintenanceMessages";
+const PUBLIC_MAINTENANCE_ENDPOINT = "/api/v1/maintenanceMessages";
+const SAMPLE_VALID_MAINTENANCE_MESSAGE = { msg: "Message d'alerte", type: "alert", context: "manuel", enabled: false };
+
+describe("Maintenances Route", () => {
+  describe("POST /admin/maintenanceMessages", () => {
+    it("sends a 401 HTTP response when user is not authenticated", async () => {
+      const { httpClient } = await startServer();
+      const response = await httpClient.post(ADMIN_MAINTENANCE_ENDPOINT, {});
+
+      assert.equal(response.status, 401);
+    });
+
+    it("sends a 401 HTTP response when user is not admin", async () => {
+      const { httpClient, logUser } = await startServer();
+
+      const { email, password } = await createSimpleUser();
+      const { cookie } = await logUser(email, password);
+      const response = await httpClient.post(ADMIN_MAINTENANCE_ENDPOINT, {}, { headers: { cookie } });
+
+      assert.equal(response.status, 401);
+    });
+
+    it("sends a 400 HTTP response if data are not valid", async () => {
+      const { httpClient, logUser } = await startServer();
+      const { email, password } = await createAdminUser();
+      const { cookie } = await logUser(email, password);
+      const response = await httpClient.post(ADMIN_MAINTENANCE_ENDPOINT, {}, { headers: { cookie } });
+
+      assert.deepEqual(response.data, {
+        statusCode: 400,
+        error: "Bad Request",
+        message: "Erreur de validation",
+        details: [
+          {
+            message: '"msg" is required',
+            path: ["msg"],
+            type: "any.required",
+            context: { label: "msg", key: "msg" },
+          },
+          {
+            message: '"type" is required',
+            path: ["type"],
+            type: "any.required",
+            context: { label: "type", key: "type" },
+          },
+          {
+            message: '"enabled" is required',
+            path: ["enabled"],
+            type: "any.required",
+            context: { label: "enabled", key: "enabled" },
+          },
+          {
+            message: '"context" is required',
+            path: ["context"],
+            type: "any.required",
+            context: { label: "context", key: "context" },
+          },
+        ],
+      });
+    });
+
+    it("sends a 201 HTTP response if a message maintenance is created", async () => {
+      const { httpClient, logUser } = await startServer();
+
+      const { email, password } = await createAdminUser();
+      const { cookie } = await logUser(email, password);
+
+      const response = await httpClient.post(ADMIN_MAINTENANCE_ENDPOINT, SAMPLE_VALID_MAINTENANCE_MESSAGE, {
+        headers: { cookie },
+      });
+      assert.equal(response.status, 201);
+      assert.deepEqual(response.data, {
+        ...SAMPLE_VALID_MAINTENANCE_MESSAGE,
+        name: "admin@test.beta.gouv.fr",
+        _id: response.data._id,
+        time: response.data.time,
+      });
+    });
+  });
+
+  describe("PUT /admin/maintenanceMessages", () => {
+    it("sends a 401 HTTP response when user is not authenticated", async () => {
+      const { httpClient } = await startServer();
+      const response = await httpClient.post(`${ADMIN_MAINTENANCE_ENDPOINT}/1`, {});
+
+      assert.equal(response.status, 401);
+    });
+
+    it("sends a 401 HTTP response when user is not admin", async () => {
+      const { httpClient, logUser } = await startServer();
+
+      const { email, password } = await createSimpleUser();
+      const { cookie } = await logUser(email, password);
+      const response = await httpClient.post(`${ADMIN_MAINTENANCE_ENDPOINT}/1`, {}, { headers: { cookie } });
+
+      assert.equal(response.status, 401);
+    });
+
+    it("sends a 200 HTTP response if a message maintenance is updated", async () => {
+      const { httpClient, logUser } = await startServer();
+
+      const { email, password } = await createAdminUser();
+      const { cookie } = await logUser(email, password);
+
+      const createResponse = await httpClient.post(ADMIN_MAINTENANCE_ENDPOINT, SAMPLE_VALID_MAINTENANCE_MESSAGE, {
+        headers: { cookie },
+      });
+      assert.equal(createResponse.status, 201);
+      const _id = createResponse.data._id;
+
+      const updateResponse = await httpClient.put(
+        `${ADMIN_MAINTENANCE_ENDPOINT}/${_id}`,
+        { ...SAMPLE_VALID_MAINTENANCE_MESSAGE, msg: "Message d'alerte MAJ" },
+        {
+          headers: { cookie },
+        }
+      );
+      assert.equal(updateResponse.status, 200);
+      assert.deepEqual(updateResponse.data, {
+        ...SAMPLE_VALID_MAINTENANCE_MESSAGE,
+        msg: "Message d'alerte MAJ",
+        name: "admin@test.beta.gouv.fr",
+        _id,
+        time: createResponse.data.time,
+      });
+    });
+  });
+
+  describe("DELETE /admin/maintenanceMessages", () => {
+    it("sends a 401 HTTP response when user is not authenticated", async () => {
+      const { httpClient } = await startServer();
+      const response = await httpClient.delete(`${ADMIN_MAINTENANCE_ENDPOINT}/1`, {});
+
+      assert.equal(response.status, 401);
+    });
+
+    it("sends a 401 HTTP response when user is not admin", async () => {
+      const { httpClient, logUser } = await startServer();
+
+      const { email, password } = await createSimpleUser();
+      const { cookie } = await logUser(email, password);
+      const response = await httpClient.delete(`${ADMIN_MAINTENANCE_ENDPOINT}/1`, {}, { headers: { cookie } });
+
+      assert.equal(response.status, 401);
+    });
+
+    it("sends a 200 HTTP response if a message maintenance is deleted", async () => {
+      const { httpClient, logUser } = await startServer();
+
+      const { email, password } = await createAdminUser();
+      const { cookie } = await logUser(email, password);
+
+      const createResponse = await httpClient.post(ADMIN_MAINTENANCE_ENDPOINT, SAMPLE_VALID_MAINTENANCE_MESSAGE, {
+        headers: { cookie },
+      });
+      assert.equal(createResponse.status, 201);
+      const _id = createResponse.data._id;
+
+      const deleteResponse = await httpClient.delete(`${ADMIN_MAINTENANCE_ENDPOINT}/${_id}`, {
+        headers: { cookie },
+      });
+      assert.equal(deleteResponse.status, 200);
+    });
+  });
+
+  describe("GET /maintenanceMessages", () => {
+    before(async () => {
+      const { httpClient, logUser } = await startServer();
+      const { email, password } = await createAdminUser();
+      const { cookie } = await logUser(email, password);
+      await httpClient.post(ADMIN_MAINTENANCE_ENDPOINT, SAMPLE_VALID_MAINTENANCE_MESSAGE, {
+        headers: { cookie },
+      });
+    });
+
+    it("sends a 200 HTTP response when user is not authenticated", async () => {
+      const { httpClient } = await startServer();
+      const response = await httpClient.get(PUBLIC_MAINTENANCE_ENDPOINT, {});
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(response.data.length, 1);
+      assert.deepEqual(response.data[0], {
+        ...SAMPLE_VALID_MAINTENANCE_MESSAGE,
+        name: "admin@test.beta.gouv.fr",
+        _id: response.data[0]._id,
+        time: response.data[0].time,
+      });
+    });
+  });
+});

--- a/server/tests/utils/testUtils.js
+++ b/server/tests/utils/testUtils.js
@@ -5,6 +5,7 @@ import { configureDbSchemaValidation } from "../../src/common/mongodb.js";
 import redisFakeClient from "./redisClientMock.js";
 import { modelDescriptors } from "../../src/common/model/collections.js";
 import { createUserLegacy } from "../../src/common/actions/legacy/users.legacy.actions.js";
+import { createUser } from "../../src/common/actions/users.actions.js";
 
 export const startServer = async () => {
   const components = await createComponents();
@@ -37,6 +38,22 @@ export const startServer = async () => {
       return { cookie: response.headers["set-cookie"].join(";") };
     },
   };
+};
+
+export const createSimpleUser = async () => {
+  const data = { email: "test@test.beta.gouv.fr", password: "password" };
+  await createUser(data, {
+    permissions: { is_admin: false, is_cross_organismes: true },
+  });
+  return data;
+};
+
+export const createAdminUser = async () => {
+  const data = { email: "admin@test.beta.gouv.fr", password: "password" };
+  await createUser(data, {
+    permissions: { is_admin: true, is_cross_organismes: true },
+  });
+  return data;
 };
 
 export const wait = async (time) => {

--- a/ui/pages/admin/maintenance.jsx
+++ b/ui/pages/admin/maintenance.jsx
@@ -43,7 +43,7 @@ const Message = () => {
     data: messages,
     isLoading,
     refetch: refetchMaintenanceMessages,
-  } = useQuery(["maintenanceMessages"], () => _get(`/api/v1/maintenanceMessage`), {
+  } = useQuery(["maintenanceMessages"], () => _get(`/api/v1/maintenanceMessages`), {
     refetchOnWindowFocus: false,
   });
   const messageAutomatique = messages?.filter((d) => d.context === "automatique" && d.msg)?.[0];


### PR DESCRIPTION
Cette PR ajoute un page de maintenance dans la console d'admin pour pouvoir créer / mettre a jour des messages de maintenance. 

Video: https://youtu.be/65yyOI4q-8E
A venir: une autre PR pour afficher les messages sur le site.

[EDIT] petit erreur de push, le commit a été envoyé dans refacto [ici](https://github.com/mission-apprentissage/flux-retour-cfas/commit/7a6e3d48ed96c89ec3dc3cfab9e68cdd5502bedf), et cette PR ne contient plus que les tests. Sorry!
