### PR TITLE
feat: ajout page /en-maintenance 

### DIFF
--- a/ui/components/AlertMessage/AlertMessage.jsx
+++ b/ui/components/AlertMessage/AlertMessage.jsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { Box, Alert, AlertIcon, AlertTitle, AlertDescription, Text, Link } from "@chakra-ui/react";
+import { Box, Text, Link } from "@chakra-ui/react";
 import ReactMarkdown from "react-markdown";
 import ChakraUIMarkdownRenderer from "chakra-ui-markdown-renderer";
 
+import Ribbons from "../Ribbons/Ribbons";
 import useMaintenanceMessages from "../../hooks/useMaintenanceMessages";
 
 const chakraUIMarkdownRendererTheme = {
@@ -35,22 +36,18 @@ const AlertMessage = () => {
   return (
     <Box>
       {messagesAlertEnabled.length > 0 && (
-        <Alert status="error">
-          <AlertIcon />
-          <AlertTitle mr={3}>Alerte</AlertTitle>
-          <AlertDescription>
+        <Ribbons variant="warning">
+          <Text color="grey.800">
             <Messages messages={messagesAlertEnabled} />
-          </AlertDescription>
-        </Alert>
+          </Text>
+        </Ribbons>
       )}
       {messagesInfoEnabled.length > 0 && (
-        <Alert status="info">
-          <AlertIcon />
-          <AlertTitle mr={3}>Info</AlertTitle>
-          <AlertDescription>
+        <Ribbons variant="info">
+          <Text color="grey.800">
             <Messages messages={messagesInfoEnabled} />
-          </AlertDescription>
-        </Alert>
+          </Text>
+        </Ribbons>
       )}
     </Box>
   );

--- a/ui/components/AlertMessage/AlertMessage.jsx
+++ b/ui/components/AlertMessage/AlertMessage.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Box, Alert, AlertIcon, AlertTitle, AlertDescription, Text, Link } from "@chakra-ui/react";
+import ReactMarkdown from "react-markdown";
+import ChakraUIMarkdownRenderer from "chakra-ui-markdown-renderer";
+
+import useMaintenanceMessages from "../../hooks/useMaintenanceMessages";
+
+const chakraUIMarkdownRendererTheme = {
+  // we override anchors to reformat the link (aka remove the '##') and add an icon.
+  a: ({ children, href, ...rest }) => (
+    <Link textDecoration={"underline"} fontSize="md" isExternal {...rest} href={href.replace(/^##/, "")}>
+      {children}
+    </Link>
+  ),
+  p: ({ children }) => <p>{children}</p>,
+};
+const Messages = ({ messages }) => (
+  <>
+    {messages.map((element) => (
+      <Text as="div" key={element._id}>
+        <ReactMarkdown components={ChakraUIMarkdownRenderer(chakraUIMarkdownRendererTheme)} skipHtml>
+          {element?.msg}
+        </ReactMarkdown>
+      </Text>
+    ))}
+  </>
+);
+
+const AlertMessage = () => {
+  const { messagesAlert, messagesInfo, loading } = useMaintenanceMessages();
+  const messagesAlertEnabled = messagesAlert?.filter((message) => message.enabled);
+  const messagesInfoEnabled = messagesInfo?.filter((message) => message.enabled);
+
+  if (loading || (!messagesAlertEnabled.length && !messagesInfoEnabled.length)) return null;
+  return (
+    <Box>
+      {messagesAlertEnabled.length > 0 && (
+        <Alert status="error">
+          <AlertIcon />
+          <AlertTitle mr={3}>Alerte</AlertTitle>
+          <AlertDescription>
+            <Messages messages={messagesAlertEnabled} />
+          </AlertDescription>
+        </Alert>
+      )}
+      {messagesInfoEnabled.length > 0 && (
+        <Alert status="info">
+          <AlertIcon />
+          <AlertTitle mr={3}>Info</AlertTitle>
+          <AlertDescription>
+            <Messages messages={messagesInfoEnabled} />
+          </AlertDescription>
+        </Alert>
+      )}
+    </Box>
+  );
+};
+
+export default AlertMessage;

--- a/ui/components/UserWrapper/UserWrapper.jsx
+++ b/ui/components/UserWrapper/UserWrapper.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, createContext } from "react";
 import { useRouter } from "next/router";
-import { Box, Text, Spinner } from "@chakra-ui/react";
+import { Flex, Box, Text, Spinner } from "@chakra-ui/react";
 
 import { _get, _post, _put } from "../../common/httpClient";
 import useAuth from "../../hooks/useAuth";
@@ -140,7 +140,11 @@ const UserWrapper = ({ children, ssrAuth }) => {
   }, []);
 
   if (isLoading || isLoadingMessageMaintenance) {
-    return <Spinner />;
+    return (
+      <Flex height="100vh" alignItems="center" justifyContent="center">
+        <Spinner />
+      </Flex>
+    );
   }
 
   return (

--- a/ui/components/UserWrapper/UserWrapper.jsx
+++ b/ui/components/UserWrapper/UserWrapper.jsx
@@ -1,14 +1,17 @@
 import React, { useState, useEffect, useRef, createContext } from "react";
 import { useRouter } from "next/router";
 import { Box, Text, Spinner } from "@chakra-ui/react";
+
 import { _get, _post, _put } from "../../common/httpClient";
 import useAuth from "../../hooks/useAuth";
+import useMaintenanceMessages from "../../hooks/useMaintenanceMessages";
 import { Cgu, cguVersion } from "../legal/Cgu";
 import AcknowledgeModal from "../../components/Modals/AcknowledgeModal";
 import { anonymous } from "../../common/anonymous";
 import { emitter } from "../../common/emitter";
+import { isUserAdmin } from "../../common/utils/rolesUtils";
 
-const AccountWrapper = ({ children }) => {
+const AccountWrapper = ({ children, messageMaintenance }) => {
   let [auth] = useAuth();
   const router = useRouter();
 
@@ -28,11 +31,15 @@ const AccountWrapper = ({ children }) => {
             router.push(`/auth/modifier-mot-de-passe?passwordToken=${token}`);
           } else if (auth.account_status.includes("FORCE_COMPLETE_PROFILE") && router.asPath !== "/auth/finalisation") {
             router.push(`/auth/finalisation`);
+          } else {
+            if (messageMaintenance?.enabled && router.asPath !== "/en-maintenance" && !isUserAdmin(auth)) {
+              router.push(`/en-maintenance`);
+            }
           }
         }
       }
     })();
-  }, [auth, router]);
+  }, [auth, router, messageMaintenance]);
 
   return <>{children}</>;
 };
@@ -102,6 +109,7 @@ const UserWrapper = ({ children, ssrAuth }) => {
   const [token, setToken] = useState();
   const [auth, setAuth] = useState(ssrAuth ?? anonymous);
   const [isLoading, setIsLoading] = useState(!ssrAuth);
+  const { messageMaintenance, loading: isLoadingMessageMaintenance } = useMaintenanceMessages();
 
   useEffect(() => {
     async function getUser() {
@@ -131,13 +139,13 @@ const UserWrapper = ({ children, ssrAuth }) => {
     return () => emitter.off("http:error", handler);
   }, []);
 
-  if (isLoading) {
+  if (isLoading || isLoadingMessageMaintenance) {
     return <Spinner />;
   }
 
   return (
     <AuthenticationContext.Provider value={{ auth, token, setAuth, setToken }}>
-      <AccountWrapper>
+      <AccountWrapper messageMaintenance={messageMaintenance}>
         <ForceAcceptCGU>{children}</ForceAcceptCGU>
       </AccountWrapper>
     </AuthenticationContext.Provider>

--- a/ui/hooks/useMaintenanceMessages.js
+++ b/ui/hooks/useMaintenanceMessages.js
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { _get } from "../common/httpClient";
+
+const useMaintenanceMessages = () => {
+  const {
+    data: messages,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery(["maintenanceMessages"], () => _get(`/api/v1/maintenanceMessages`));
+
+  const messageMaintenance = messages?.find((d) => d.context === "maintenance");
+  const messageAutomatique = messages?.find((d) => d.context === "automatique" && d.msg);
+  const messagesAlert = messages?.filter((d) => d.type === "alert" && d.context === "manuel");
+  const messagesInfo = messages?.filter((d) => d.type === "info");
+
+  return {
+    messages,
+    loading: isLoading,
+    error,
+    refetch,
+    messageAutomatique,
+    messageMaintenance,
+    messagesAlert,
+    messagesInfo,
+  };
+};
+
+export default useMaintenanceMessages;

--- a/ui/pages/_app.jsx
+++ b/ui/pages/_app.jsx
@@ -9,6 +9,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import Fonts from "../theme/Fonts";
 import theme from "../theme/index";
 import UserWrapper from "../components/UserWrapper/UserWrapper";
+import AlertMessage from "../components/AlertMessage/AlertMessage";
 
 const queryClient = new QueryClient();
 
@@ -18,6 +19,7 @@ function MyApp({ Component, pageProps }) {
       <ChakraProvider theme={theme} resetCSS>
         <Fonts />
         <QueryClientProvider client={queryClient}>
+          <AlertMessage />
           <UserWrapper ssrAuth={pageProps.auth}>
             <Component {...pageProps} />
           </UserWrapper>

--- a/ui/pages/admin/maintenance.jsx
+++ b/ui/pages/admin/maintenance.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useQuery } from "@tanstack/react-query";
 import { useFormik } from "formik";
 import Head from "next/head";
 import NavLink from "next/link";
@@ -27,7 +26,8 @@ import {
   useToast,
 } from "@chakra-ui/react";
 
-import { _post, _get, _put, _delete } from "../../common/httpClient";
+import { _post, _put, _delete } from "../../common/httpClient";
+import useMaintenanceMessages from "../../hooks/useMaintenanceMessages";
 import { ArrowDropRightLine, Trash } from "../../theme/components/icons";
 import Table from "../../components/tables/Table";
 import { Page } from "../../components/Page/Page";
@@ -40,14 +40,13 @@ export const getServerSideProps = async (context) => ({ props: { ...(await getAu
 
 const Message = () => {
   const {
-    data: messages,
-    isLoading,
+    messages,
+    messageMaintenance,
+    messageAutomatique,
+    loading,
     refetch: refetchMaintenanceMessages,
-  } = useQuery(["maintenanceMessages"], () => _get(`/api/v1/maintenanceMessages`), {
-    refetchOnWindowFocus: false,
-  });
-  const messageAutomatique = messages?.filter((d) => d.context === "automatique" && d.msg)?.[0];
-  const messageMaintenance = messages?.filter((d) => d.context === "maintenance")?.[0];
+  } = useMaintenanceMessages();
+
   const toast = useToast();
   // TODO hook custom qui gère les raccourci de toasts
   const toastSuccess = (title) =>
@@ -168,7 +167,7 @@ const Message = () => {
               {messages?.length > 0 && (
                 <Table
                   headers={["Messages précédents", "Context", "Type", "Actif", "Supprimer"]}
-                  loading={isLoading}
+                  loading={loading}
                   error={null}
                 >
                   <Tbody>


### PR DESCRIPTION
Une PR pour afficher les messages d'info et de maintenance sur la partie public. 

J'ai récupéré le meme mécanisme que le projet Cerfa. Et un peu adapté pour supporter le markdown dans les messages d'alertes, et pour améliorer l'affichage des liens.

Par contre, impossible de comprendre ou s'affiche le message automatique dans Cerfa. Je me serais attendu a ce que cela soit dans AlertMessage, mais on ne selectionne que les msgs manuels (cf [ici](https://github.com/mission-apprentissage/cerfa/blob/1441717f6cd444f70ced4d2cac65e25fd71564c1/ui/components/Layout/components/AlertMessage.jsx#L40)).

<img width="438" alt="Screenshot 2023-01-06 at 16 48 38" src="https://user-images.githubusercontent.com/966303/211047608-84de3172-1c48-434f-9486-631f25018f8c.png">
<img width="1245" alt="Screenshot 2023-01-06 at 16 48 06" src="https://user-images.githubusercontent.com/966303/211047612-7df476f0-0981-4b54-8e00-b8ddc41cc2f6.png">
