### PR TITLE
fix: branch dans le wortkflow cron-recette.yml

### DIFF
--- a/.github/workflows/cron-recette.yml
+++ b/.github/workflows/cron-recette.yml
@@ -1,7 +1,7 @@
 name: Cron Job pour import dossiers apprenants en Recette
 on:
   # Note: only schedules in default branch (i.e master) are run
-  schedule: 
+  schedule:
     - cron: "0 4 * * *"
 env:
   API_URL: https://cfas-recette.apprentissage.beta.gouv.fr
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: sven/recette/send-dossiers-apprenant
+          ref: develop
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
 


### PR DESCRIPTION
Un fix rapide pour mettre a jour le nom de la branche qui est utilisé pour le cron de creation du jeu de test en recette.