### PR TITLE
fix: fix nginx error "Failed to fully parse request body due to large argument count"

### DIFF
--- a/reverse_proxy/app/nginx/templates/modsecurity.d/modsecurity-override.conf.template
+++ b/reverse_proxy/app/nginx/templates/modsecurity.d/modsecurity-override.conf.template
@@ -1,0 +1,11 @@
+#
+# Note: la regle 200007 de mod-security empeche de poster des objects json 
+# avec plus de 1000 champs au total. (Par exemple, 55 dossiers apprenants avec 18 champs chacun = 990 champs)
+# du coup, on la supprime et on la remplace par une regle qui permet de poster jusqu'a 2000 champs.
+# regles par defaut: https://github.com/SpiderLabs/ModSecurity/blob/v3/master/modsecurity.conf-recommended
+#
+SecRuleRemoveById 200007
+SecArgumentsLimit 2000
+SecRule &ARGS "@ge 2000" \
+"id:'1200007', phase:2,t:none,log,deny,status:400,msg:'Failed to fully parse request body due to large argument count',severity:2"
+


### PR DESCRIPTION
Jusqu'a recemment le script `node server/tests/recette/jobs/send-dossiers-apprenants/index.js` permettait d'envoyer 100 records au server de recette, mais depuis peu nginx bloque la requete (sur recette, et reproduit en local) et renvoie l'erreur "Failed to fully parse request body due to large argument count".

Cette erreur est en fait renvoyée par la regle mod-security 200007 (cf [ici](https://github.com/SpiderLabs/ModSecurity/blob/5dfc0a256a27ea6245a972a2a6ab9c1a4edd2599/modsecurity.conf-recommended#L68)), qui bloque la requete quand celle ci contient un message json contenant plus de 1000 champs a parser.

➡️  Cette PR supprime la regle 200007 et en crée une nouvelle pour permettre l'envoi de jusqu'à 2000 champs.

J'imagine que des nouveaux champs ont été introduit avec le refactoring, donc a priori cette erreur n'a pas du etre rencontrée par les organismes en production. Par contre cette PR est à merger avant la prochaine MEP.
