### PR TITLE
fix(server): dateConverter toIsoString in hydrateEffectifs

### DIFF
--- a/server/src/common/actions/engine/engine.actions.js
+++ b/server/src/common/actions/engine/engine.actions.js
@@ -55,8 +55,11 @@ export const hydrateEffectif = async (effectifData, options) => {
 
   const dateConverter = (date) => {
     // TODO If more than year 4000 error
-    const date_ISO = dateStringToLuxon(dateFormatter(date)).toISO();
-    return date_ISO ?? date;
+    if (date instanceof Date) return date.toISOString();
+    else {
+      const date_ISO = dateStringToLuxon(dateFormatter(date)).toISO();
+      return date_ISO ?? date;
+    }
   };
 
   if (effectifData.apprenant.date_de_naissance) {


### PR DESCRIPTION
Il y'avait une erreur dans le hydrateEffectifs qui fait que les effectifs sont vides en recette. 

Dans le dateConverter, on passait des dates au format string et d'autre en date.