### PR TITLE
chore(server): build organisme formations tree on createOrganisme

### DIFF
--- a/server/src/common/actions/engine/engine.actions.js
+++ b/server/src/common/actions/engine/engine.actions.js
@@ -15,7 +15,7 @@ import {
   findOrganismeByUai,
   findOrganismeByUaiAndSiret,
   insertOrganisme,
-} from "../organismes.actions.js";
+} from "../organismes/organismes.actions.js";
 import { mapFiabilizedOrganismeUaiSiretCouple } from "./engine.organismes.utils.js";
 
 /**

--- a/server/src/common/actions/organismes/organismes.actions.js
+++ b/server/src/common/actions/organismes/organismes.actions.js
@@ -1,16 +1,16 @@
 import { ObjectId } from "mongodb";
-import { getMetiersBySirets } from "../apis/apiLba.js";
-import { organismesDb } from "../model/collections.js";
-import { defaultValuesOrganisme, validateOrganisme } from "../model/next.toKeep.models/organismes.model.js";
-import { buildAdresseFromApiEntreprise } from "../utils/adresseUtils.js";
-import { buildTokenizedString } from "../utils/buildTokenizedString.js";
-import { generateKey } from "../utils/cryptoUtils.js";
-import { buildAdresseFromUai } from "../utils/uaiUtils.js";
-import { siretSchema } from "../utils/validationUtils.js";
-import { mapFiabilizedOrganismeUaiSiretCouple } from "./engine/engine.organismes.utils.js";
-import { createPermission, hasPermission } from "./permissions.actions.js";
-import { findRolePermissionById } from "./roles.actions.js";
-import { getUser } from "./users.actions.js";
+import { getMetiersBySirets } from "../../apis/apiLba.js";
+import { organismesDb } from "../../model/collections.js";
+import { defaultValuesOrganisme, validateOrganisme } from "../../model/next.toKeep.models/organismes.model.js";
+import { buildAdresseFromApiEntreprise } from "../../utils/adresseUtils.js";
+import { buildTokenizedString } from "../../utils/buildTokenizedString.js";
+import { generateKey } from "../../utils/cryptoUtils.js";
+import { buildAdresseFromUai } from "../../utils/uaiUtils.js";
+import { siretSchema } from "../../utils/validationUtils.js";
+import { mapFiabilizedOrganismeUaiSiretCouple } from "../engine/engine.organismes.utils.js";
+import { createPermission, hasPermission } from "../permissions.actions.js";
+import { findRolePermissionById } from "../roles.actions.js";
+import { getUser } from "../users.actions.js";
 
 /**
  * Méthode de création d'un organisme qui applique en entrée des filtres / rejection

--- a/server/src/common/actions/organismes/organismes.actions.js
+++ b/server/src/common/actions/organismes/organismes.actions.js
@@ -11,6 +11,7 @@ import { mapFiabilizedOrganismeUaiSiretCouple } from "../engine/engine.organisme
 import { createPermission, hasPermission } from "../permissions.actions.js";
 import { findRolePermissionById } from "../roles.actions.js";
 import { getUser } from "../users.actions.js";
+import { getFormationsTreeForOrganisme } from "./organismes.formations.actions.js";
 
 /**
  * Méthode de création d'un organisme qui applique en entrée des filtres / rejection
@@ -83,6 +84,9 @@ export const createOrganisme = async ({ uai, sirets = [], nom, ...data }) => {
     }
   }
 
+  // Construction de l'arbre des formations de l'organisme
+  const { formations } = await getFormationsTreeForOrganisme(uai);
+
   // TODO Call Api Entreprise to get address
 
   const { insertedId } = await organismesDb().insertOne(
@@ -92,6 +96,7 @@ export const createOrganisme = async ({ uai, sirets = [], nom, ...data }) => {
       ...defaultValuesOrganisme(),
       sirets,
       metiers,
+      formations,
       ...data,
     })
   );

--- a/server/src/common/actions/organismes/organismes.formations.actions.js
+++ b/server/src/common/actions/organismes/organismes.formations.actions.js
@@ -1,0 +1,140 @@
+import { getCatalogFormationsForOrganisme } from "../../apis/apiCatalogueMna.js";
+import { asyncForEach } from "../../utils/asyncUtils.js";
+import { NATURE_ORGANISME_DE_FORMATION } from "../../utils/validationsUtils/organisme-de-formation/nature.js";
+import { createFormation, getFormationWithCfd } from "../formations.actions.js";
+import { findOrganismeByUai } from "./organismes.actions.js";
+
+/**
+ * Méthode de récupération de l'arbre des formations issues du catalogue liées à un organisme
+ * @param {*} uai
+ */
+export const getFormationsTreeForOrganisme = async (uai) => {
+  // Récupération des formations liés à l'organisme
+  const catalogFormationsForOrganisme = await getCatalogFormationsForOrganisme(uai);
+
+  // Construction d'une liste de formations pour cet organisme
+  let formationsForOrganismeArray = [];
+  let nbFormationsCreatedForOrganisme = 0;
+  // let nbFormationsUpdatedForOrganisme = 0;
+  let nbFormationsNotCreatedForOrganisme = 0;
+
+  if (catalogFormationsForOrganisme.length > 0) {
+    await asyncForEach(catalogFormationsForOrganisme, async (currentFormation) => {
+      let currentFormationId;
+
+      // Récupération de la formation du catalogue dans le TDB, si pas présente on la créé
+      // On count les formations créés / non crées (erreur)
+      const formationFoundInTdb = await getFormationWithCfd(currentFormation.cfd);
+      if (!formationFoundInTdb) {
+        try {
+          currentFormationId = await createFormation(currentFormation);
+          nbFormationsCreatedForOrganisme++;
+        } catch (error) {
+          nbFormationsNotCreatedForOrganisme++;
+        }
+      } else {
+        currentFormationId = formationFoundInTdb._id;
+      }
+
+      // Ajout à la liste des formation de l'organisme d'un item contenant
+      // formation_id si trouvé dans le tdb
+      // année & durée trouvé dans le catalog & formatted
+      // ainsi que la liste des organismes construite depuis l'API Catalogue
+      formationsForOrganismeArray.push({
+        ...(currentFormationId ? { formation_id: currentFormationId } : {}),
+        annee_formation: parseInt(currentFormation.annee) || -1,
+        duree_formation_theorique: parseInt(currentFormation.duree) || -1,
+        organismes: await buildOrganismesListFromFormationFromCatalog(currentFormation),
+      });
+    });
+  }
+
+  return {
+    formations: formationsForOrganismeArray,
+    nbFormationsCreatedForOrganisme,
+    nbFormationsNotCreatedForOrganisme,
+  };
+};
+
+/**
+ * Méthode de construction de la liste des organismes avec leur nature, rattachés à une formation du catalogue
+ * @param {*} formationCatalog
+ * @returns
+ */
+const buildOrganismesListFromFormationFromCatalog = async (formationCatalog) => {
+  let organismesLinkedToFormation = [];
+
+  // Récupération du responsable (gestionnaire)
+  if (formationCatalog.etablissement_gestionnaire_uai) {
+    const organismeInTdb = await findOrganismeByUai(formationCatalog.etablissement_gestionnaire_uai);
+
+    organismesLinkedToFormation.push({
+      ...(organismeInTdb ? { organisme_id: organismeInTdb._id } : {}), // Si organisme trouvé dans le tdb
+      ...(organismeInTdb ? { adresse: organismeInTdb.adresse } : {}), // Si organisme trouvé dans le tdb on son adresse
+      nature: getOrganismeNature(
+        NATURE_ORGANISME_DE_FORMATION.RESPONSABLE,
+        formationCatalog,
+        organismesLinkedToFormation
+      ),
+      uai: formationCatalog.etablissement_gestionnaire_uai,
+      siret: formationCatalog.etablissement_gestionnaire_siret,
+    });
+
+    // TODO Voir ce qu'on fait si on ne trouve pas l'OF dans le tdb ? on le créé ? on logge l'anomalie ?
+    // TODO Si pas d'organisme depuis le Tdb on récupère l'adresse from référentiel ?
+  }
+
+  // Gestion du formateur si nécessaire
+  if (formationCatalog.etablissement_formateur_uai) {
+    const organismeInTdb = await findOrganismeByUai(formationCatalog.etablissement_formateur_uai);
+
+    organismesLinkedToFormation.push({
+      ...(organismeInTdb ? { organisme_id: organismeInTdb._id } : {}), // Si organisme trouvé dans le tdb
+      ...(organismeInTdb ? { adresse: organismeInTdb.adresse } : {}), // Si organisme trouvé dans le tdb on son adresse
+      nature: getOrganismeNature(
+        NATURE_ORGANISME_DE_FORMATION.FORMATEUR,
+        formationCatalog,
+        organismesLinkedToFormation
+      ),
+      uai: formationCatalog.etablissement_formateur_uai,
+      siret: formationCatalog.etablissement_formateur_siret,
+    });
+
+    // TODO Voir ce qu'on fait si on ne trouve pas l'OF dans le tdb ? on le créé ? on logge l'anomalie ?
+    // TODO Si pas d'organisme depuis le Tdb on récupère l'adresse from référentiel ?
+  }
+
+  // Gestion du lieu de formation
+  // TODO WIP
+  organismesLinkedToFormation.push({
+    nature: NATURE_ORGANISME_DE_FORMATION.LIEU,
+    // uai: formationCatalog.XXXX, // TODO non récupérée par RCO donc pas présent dans le catalogue (vu avec Quentin)
+    ...(formationCatalog.lieu_formation_siret ? { siret: formationCatalog.lieu_formation_siret } : {}),
+    // TODO On récupère l'adresse depuis le référentiel en appelant avec le siret ?
+  });
+
+  return organismesLinkedToFormation;
+};
+
+/**
+ * Vérifie la nature, si on détecte un uai formateur = responsable alors on est dans le cas d'un responsable_formateur
+ * sinon on renvoi la nature default
+ * @param {*} defaultNature
+ * @param {*} formationCatalog
+ * @param {*} organismesLinkedToFormation
+ * @returns
+ */
+const getOrganismeNature = (defaultNature, formationCatalog, organismesLinkedToFormation) => {
+  // Vérification si OF a la fois identifié gestionnaire (responsable) & formateur
+  const isResponsableEtFormateur =
+    formationCatalog.etablissement_gestionnaire_uai === formationCatalog.etablissement_formateur_uai;
+
+  // Vérification s'il n'est pas déja dans la liste
+  const isNotAlreadyInOrganismesLinkedToFormation = !organismesLinkedToFormation.some(
+    (item) => item.uai === formationCatalog.etablissement_gestionnaire_uai
+  );
+
+  return isResponsableEtFormateur && isNotAlreadyInOrganismesLinkedToFormation
+    ? NATURE_ORGANISME_DE_FORMATION.RESPONSABLE_FORMATEUR
+    : defaultNature;
+};

--- a/server/src/common/actions/organismes/organismes.formations.actions.js
+++ b/server/src/common/actions/organismes/organismes.formations.actions.js
@@ -18,7 +18,7 @@ export const getFormationsTreeForOrganisme = async (uai) => {
   // let nbFormationsUpdatedForOrganisme = 0;
   let nbFormationsNotCreatedForOrganisme = 0;
 
-  if (catalogFormationsForOrganisme.length > 0) {
+  if (catalogFormationsForOrganisme?.length > 0) {
     await asyncForEach(catalogFormationsForOrganisme, async (currentFormation) => {
       let currentFormationId;
 

--- a/server/src/common/actions/organismes/organismes.formations.actions.js
+++ b/server/src/common/actions/organismes/organismes.formations.actions.js
@@ -40,12 +40,20 @@ export const getFormationsTreeForOrganisme = async (uai) => {
       // formation_id si trouvé dans le tdb
       // année & durée trouvé dans le catalog & formatted
       // ainsi que la liste des organismes construite depuis l'API Catalogue
-      formationsForOrganismeArray.push({
-        ...(currentFormationId ? { formation_id: currentFormationId } : {}),
-        annee_formation: parseInt(currentFormation.annee) || -1,
-        duree_formation_theorique: parseInt(currentFormation.duree) || -1,
-        organismes: await buildOrganismesListFromFormationFromCatalog(currentFormation),
-      });
+      // unicité sur la formation_id
+
+      const formationAlreadyInOrganismeArray = formationsForOrganismeArray.some(
+        (item) => item.formation_id.toString() === currentFormationId.toString()
+      );
+
+      if (currentFormationId && !formationAlreadyInOrganismeArray) {
+        formationsForOrganismeArray.push({
+          ...(currentFormationId ? { formation_id: currentFormationId } : {}),
+          annee_formation: parseInt(currentFormation.annee) || -1,
+          duree_formation_theorique: parseInt(currentFormation.duree) || -1,
+          organismes: await buildOrganismesListFromFormationFromCatalog(currentFormation),
+        });
+      }
     });
   }
 

--- a/server/src/common/actions/sifa.actions/sifa.actions.js
+++ b/server/src/common/actions/sifa.actions/sifa.actions.js
@@ -2,7 +2,7 @@ import { Parser } from "json2csv";
 import { DateTime } from "luxon";
 import { findEffectifs } from "../effectifs.actions.js";
 import { findFormationById } from "../formations.actions.js";
-import { findOrganismeById } from "../organismes.actions.js";
+import { findOrganismeById } from "../organismes/organismes.actions.js";
 import { SIFA_FIELDS } from "./sifaCsvFields.js";
 
 /**

--- a/server/src/common/actions/users.afterCreate.actions.js
+++ b/server/src/common/actions/users.afterCreate.actions.js
@@ -1,4 +1,8 @@
-import { addContributeurOrganisme, findOrganismeByUai, findOrganismesByQuery } from "./organismes.actions.js";
+import {
+  addContributeurOrganisme,
+  findOrganismeByUai,
+  findOrganismesByQuery,
+} from "./organismes/organismes.actions.js";
 import {
   createPermission,
   findActivePermissionsByRoleName,

--- a/server/src/http/middlewares/permissionsOrganismeMiddleware.js
+++ b/server/src/http/middlewares/permissionsOrganismeMiddleware.js
@@ -3,7 +3,7 @@ import Boom from "boom";
 import tryCatch from "./tryCatchMiddleware.js";
 import { findRolePermissionById, hasAclsByRoleId } from "../../common/actions/roles.actions.js";
 import { hasPermission } from "../../common/actions/permissions.actions.js";
-import { findOrganismeById } from "../../common/actions/organismes.actions.js";
+import { findOrganismeById } from "../../common/actions/organismes/organismes.actions.js";
 
 const hasRightsTo = async (role, acls) => {
   const hasRight = await hasAclsByRoleId(role, acls);

--- a/server/src/http/middlewares/requireJwtAuthentication.js
+++ b/server/src/http/middlewares/requireJwtAuthentication.js
@@ -3,7 +3,7 @@ import { Strategy as JwtStrategy, ExtractJwt } from "passport-jwt";
 import config from "../../config.js";
 import { tdbRoles } from "../../common/roles.js";
 import { getUserLegacy } from "../../common/actions/legacy/users.legacy.actions.js";
-import { findOrganismeByUai } from "../../common/actions/organismes.actions.js";
+import { findOrganismeByUai } from "../../common/actions/organismes/organismes.actions.js";
 
 export default () => {
   const findUserOrCfa = async (usernameOrUai) => {

--- a/server/src/http/routes/specific.routes/espace.routes.js
+++ b/server/src/http/routes/specific.routes/espace.routes.js
@@ -1,6 +1,6 @@
 import express from "express";
 import tryCatch from "../../middlewares/tryCatchMiddleware.js";
-import { findOrganismesByQuery } from "../../../common/actions/organismes.actions.js";
+import { findOrganismesByQuery } from "../../../common/actions/organismes/organismes.actions.js";
 import { pageAccessMiddleware } from "../../middlewares/pageAccessMiddleware.js";
 
 export default () => {

--- a/server/src/http/routes/specific.routes/old/dossiers-apprenants.route.js
+++ b/server/src/http/routes/specific.routes/old/dossiers-apprenants.route.js
@@ -18,7 +18,7 @@ import { sendTransformedPaginatedJsonStream } from "../../../../common/utils/htt
 import { createUserEvent } from "../../../../common/actions/userEvents.actions.js";
 import { runEngine } from "../../../../common/actions/engine/engine.actions.js";
 import { structureEffectifFromDossierApprenant } from "../../../../common/actions/effectifs.actions.js";
-import { structureOrganismeFromDossierApprenant } from "../../../../common/actions/organismes.actions.js";
+import { structureOrganismeFromDossierApprenant } from "../../../../common/actions/organismes/organismes.actions.js";
 import {
   findDossierApprenantByQuery,
   insertDossierApprenant,

--- a/server/src/http/routes/specific.routes/organisme.routes.js
+++ b/server/src/http/routes/specific.routes/organisme.routes.js
@@ -2,7 +2,11 @@ import express from "express";
 import Joi from "joi";
 import tryCatch from "../../middlewares/tryCatchMiddleware.js";
 import permissionsOrganismeMiddleware from "../../middlewares/permissionsOrganismeMiddleware.js";
-import { findOrganismeById, getContributeurs, updateOrganisme } from "../../../common/actions/organismes.actions.js";
+import {
+  findOrganismeById,
+  getContributeurs,
+  updateOrganisme,
+} from "../../../common/actions/organismes/organismes.actions.js";
 import { findEffectifs } from "../../../common/actions/effectifs.actions.js";
 import { generateSifa } from "../../../common/actions/sifa.actions/sifa.actions.js";
 import { updatePermissionPending } from "../../../common/actions/permissions.actions.js";

--- a/server/src/jobs/hydrate/_toRemove/organismes/hydrate-organismes-formations.js
+++ b/server/src/jobs/hydrate/_toRemove/organismes/hydrate-organismes-formations.js
@@ -7,7 +7,7 @@ import {
   findOrganismeById,
   findOrganismeByUai,
   updateOrganisme,
-} from "../../../../common/actions/organismes.actions.js";
+} from "../../../../common/actions/organismes/organismes.actions.js";
 import { NATURE_ORGANISME_DE_FORMATION } from "../../../../common/utils/validationsUtils/organisme-de-formation/nature.js";
 import { getFormationWithCfd } from "../../../../common/actions/formations.actions.js";
 import { createJobEvent } from "../../../../common/actions/jobEvents.actions.js";

--- a/server/src/jobs/hydrate/_toRemove/organismes/hydrate-organismes-referentiel.js
+++ b/server/src/jobs/hydrate/_toRemove/organismes/hydrate-organismes-referentiel.js
@@ -2,7 +2,11 @@ import cliProgress from "cli-progress";
 import logger from "../../../../common/logger.js";
 import { asyncForEach } from "../../../../common/utils/asyncUtils.js";
 import { fetchOrganismes } from "../../../../common/apis/apiReferentielMna.js";
-import { createOrganisme, findOrganismeByUai, updateOrganisme } from "../../../../common/actions/organismes.actions.js";
+import {
+  createOrganisme,
+  findOrganismeByUai,
+  updateOrganisme,
+} from "../../../../common/actions/organismes/organismes.actions.js";
 import { buildAdresseFromUai } from "../../../../common/utils/uaiUtils.js";
 import { createJobEvent } from "../../../../common/actions/jobEvents.actions.js";
 

--- a/server/src/jobs/hydrate/_toRemove/reseaux/hydrate-reseaux.js
+++ b/server/src/jobs/hydrate/_toRemove/reseaux/hydrate-reseaux.js
@@ -5,7 +5,11 @@ import { asyncForEach } from "../../../../common/utils/asyncUtils.js";
 import path from "path";
 import { __dirname } from "../../../../common/utils/esmUtils.js";
 import { readJsonFromCsvFile } from "../../../../common/utils/fileUtils.js";
-import { createOrganisme, findOrganismeByUai, updateOrganisme } from "../../../../common/actions/organismes.actions.js";
+import {
+  createOrganisme,
+  findOrganismeByUai,
+  updateOrganisme,
+} from "../../../../common/actions/organismes/organismes.actions.js";
 import { ERPS } from "../../../../common/constants/erpsConstants.js";
 import { buildAdresseFromUai } from "../../../../common/utils/uaiUtils.js";
 import { downloadIfNeededFileTo } from "../../../../common/utils/ovhStorageUtils.js";

--- a/server/src/jobs/hydrate/organismes/hydrate-organismes-and-formations.js
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes-and-formations.js
@@ -33,6 +33,8 @@ const REFERENTIEL_FIELDS_TO_FETCH = [
 ];
 
 /**
+ * TODO : Supprimer la construction du tree formations ici et faire l'appel depuis organismes.formations.actions.js
+ * TODO : Keeping uniquement pour les log pour l'instant
  * Script qui initialise les organismes
  * 1. On va créer tous les organismes "stock" non présents dans le tdb mais existants dans le référentiel
  * sur la base de l'UAI, en ajoutant l'arbre des formations récupéré depuis le catalogue.
@@ -223,12 +225,19 @@ export const getFormationsTreeForOrganisme = async (organisme) => {
       // formation_id si trouvé dans le tdb
       // année & durée trouvé dans le catalog & formatted
       // ainsi que la liste des organismes construite depuis l'API Catalogue
-      formationsForOrganismeArray.push({
-        ...(currentFormationId ? { formation_id: currentFormationId } : {}),
-        annee_formation: parseInt(currentFormation.annee) || -1,
-        duree_formation_theorique: parseInt(currentFormation.duree) || -1,
-        organismes: await buildOrganismesListFromFormationFromCatalog(currentFormation),
-      });
+
+      const formationAlreadyInOrganismeArray = formationsForOrganismeArray.some(
+        (item) => item.formation_id.toString() === currentFormationId.toString()
+      );
+
+      if (currentFormationId && !formationAlreadyInOrganismeArray) {
+        formationsForOrganismeArray.push({
+          ...(currentFormationId ? { formation_id: currentFormationId } : {}),
+          annee_formation: parseInt(currentFormation.annee) || -1,
+          duree_formation_theorique: parseInt(currentFormation.duree) || -1,
+          organismes: await buildOrganismesListFromFormationFromCatalog(currentFormation),
+        });
+      }
     });
   } else {
     // Log & store cases

--- a/server/src/jobs/hydrate/organismes/hydrate-organismes-and-formations.js
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes-and-formations.js
@@ -2,7 +2,11 @@ import cliProgress from "cli-progress";
 import logger from "../../../common/logger.js";
 import { asyncForEach } from "../../../common/utils/asyncUtils.js";
 import { fetchOrganismes } from "../../../common/apis/apiReferentielMna.js";
-import { createOrganisme, findOrganismeByUai, updateOrganisme } from "../../../common/actions/organismes.actions.js";
+import {
+  createOrganisme,
+  findOrganismeByUai,
+  updateOrganisme,
+} from "../../../common/actions/organismes/organismes.actions.js";
 import { buildAdresseFromUai } from "../../../common/utils/uaiUtils.js";
 import { createJobEvent } from "../../../common/actions/jobEvents.actions.js";
 import { getCatalogFormationsForOrganisme } from "../../../common/apis/apiCatalogueMna.js";

--- a/server/src/jobs/hydrate/reseaux/hydrate-reseaux-new-format.js
+++ b/server/src/jobs/hydrate/reseaux/hydrate-reseaux-new-format.js
@@ -8,7 +8,7 @@ import {
   findOrganismeByUaiAndSiret,
   findOrganismesBySiret,
   updateOrganisme,
-} from "../../../common/actions/organismes.actions.js";
+} from "../../../common/actions/organismes/organismes.actions.js";
 import { updateDossiersApprenantsNetworksIfNeeded } from "./hydrate-reseaux.actions.js";
 
 const INPUT_FILE_COLUMN_NAMES = {

--- a/server/src/jobs/patches/refacto-migration/dossiersApprenants/dossiersApprenants.migration.js
+++ b/server/src/jobs/patches/refacto-migration/dossiersApprenants/dossiersApprenants.migration.js
@@ -6,7 +6,7 @@ import {
   dossiersApprenantsMigrationDb,
   effectifsDb,
 } from "../../../../common/model/collections.js";
-import { createOrganisme, findOrganismeByUai } from "../../../../common/actions/organismes.actions.js";
+import { createOrganisme, findOrganismeByUai } from "../../../../common/actions/organismes/organismes.actions.js";
 import { buildAdresseFromUai } from "../../../../common/utils/uaiUtils.js";
 import { createJobEvent } from "../../../../common/actions/jobEvents.actions.js";
 import { createDossierApprenantMigrationFromDossierApprenant } from "../../../../common/actions/dossiersApprenants.migration.actions.js";

--- a/server/src/jobs/patches/refacto-migration/organismes/organismes.migration.job.actions.js
+++ b/server/src/jobs/patches/refacto-migration/organismes/organismes.migration.job.actions.js
@@ -1,5 +1,5 @@
 import { omit } from "lodash-es";
-import { buildAdresseForOrganisme } from "../../../../common/actions/organismes.actions.js";
+import { buildAdresseForOrganisme } from "../../../../common/actions/organismes/organismes.actions.js";
 import { RESEAUX_CFAS } from "../../../../common/constants/networksConstants.js";
 import { organismesDb } from "../../../../common/model/collections.js";
 import {

--- a/server/src/jobs/patches/refacto-migration/organismes/organismes.migration.js
+++ b/server/src/jobs/patches/refacto-migration/organismes/organismes.migration.js
@@ -6,7 +6,7 @@ import { getLocalisationInfoFromUai } from "../../../../common/utils/uaiUtils.js
 import Joi from "joi";
 import { siretSchema } from "../../../../common/utils/validationUtils.js";
 import { createOrganismeFromCfa, mapCfaPropsToOrganismeProps } from "./organismes.migration.job.actions.js";
-import { updateOrganismeApiKey } from "../../../../common/actions/organismes.actions.js";
+import { updateOrganismeApiKey } from "../../../../common/actions/organismes/organismes.actions.js";
 import { createJobEvent } from "../../../../common/actions/jobEvents.actions.js";
 
 const loadingBar = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);

--- a/server/src/jobs/seed/samples/seedSample.js
+++ b/server/src/jobs/seed/samples/seedSample.js
@@ -3,7 +3,7 @@ import { fullSampleWithUpdates } from "../../../../tests/data/sample.js";
 import { createRandomDossierApprenantList, createRandomOrganisme } from "../../../../tests/data/randomizedSample.js";
 import { asyncForEach } from "../../../common/utils/asyncUtils.js";
 import { createDossierApprenant } from "../../../common/actions/dossiersApprenants.actions.js";
-import { createOrganisme } from "../../../common/actions/organismes.actions.js";
+import { createOrganisme } from "../../../common/actions/organismes/organismes.actions.js";
 
 /**
  * Remplissage de données de tests

--- a/server/src/jobs/seed/start/index.js
+++ b/server/src/jobs/seed/start/index.js
@@ -1,5 +1,5 @@
 import logger from "../../../common/logger.js";
-import { createUser } from "../../../common/actions/users.actions.js";
+import { createUser, getUser } from "../../../common/actions/users.actions.js";
 import defaultRolesAcls from "./fixtures/defaultRolesAcls.js";
 import { createRole, findRoleByName } from "../../../common/actions/roles.actions.js";
 import {
@@ -162,91 +162,101 @@ export const seedSampleUsers = async () => {
   await seedRoles();
 
   // Create user Pilot
-  const userPilot = await createUser(
-    { email: "pilot@test.fr", password: "Secret!Password1" },
-    {
-      nom: "pilot",
-      prenom: "test",
-      description: "DREETS AUVERGNE-RHONES-ALPES",
-      permissions: { is_cross_organismes: true },
-      roles: ["pilot"],
-      account_status: "FORCE_RESET_PASSWORD",
-      siret: "13000992100011",
-      codes_region: ["84"],
-      organisation: "DREETS",
-    }
-  );
-  await userAfterCreate({ user: userPilot, pending: false, notify: false });
-  logger.info(`User pilot created`);
+  if (!(await getUser("pilot@test.fr"))) {
+    const userPilot = await createUser(
+      { email: "pilot@test.fr", password: "Secret!Password1" },
+      {
+        nom: "pilot",
+        prenom: "test",
+        description: "DREETS AUVERGNE-RHONES-ALPES",
+        permissions: { is_cross_organismes: true },
+        roles: ["pilot"],
+        account_status: "FORCE_RESET_PASSWORD",
+        siret: "13000992100011",
+        codes_region: ["84"],
+        organisation: "DREETS",
+      }
+    );
+    await userAfterCreate({ user: userPilot, pending: false, notify: false });
+    logger.info(`User pilot created`);
+  }
 
   // Create user OF
-  const userOf = await createUser(
-    { email: "of@test.fr", password: "Secret!Password1" },
-    {
-      nom: "of",
-      prenom: "test",
-      description: "Aden formation Caen - direction",
-      roles: ["of"],
-      account_status: "FORCE_RESET_PASSWORD",
-      siret: "44492238900010",
-      uai: "0142321X",
-      organisation: "ORGANISME_FORMATION",
-    }
-  );
-  await userAfterCreate({ user: userOf, pending: false, notify: false, asRole: "organisme.admin" });
-  logger.info(`User off created`);
+  if (!(await getUser("of@test.fr"))) {
+    const userOf = await createUser(
+      { email: "of@test.fr", password: "Secret!Password1" },
+      {
+        nom: "of",
+        prenom: "test",
+        description: "Aden formation Caen - direction",
+        roles: ["of"],
+        account_status: "FORCE_RESET_PASSWORD",
+        siret: "44492238900010",
+        uai: "0142321X",
+        organisation: "ORGANISME_FORMATION",
+      }
+    );
+    await userAfterCreate({ user: userOf, pending: false, notify: false, asRole: "organisme.admin" });
+    logger.info(`User off created`);
+  }
 
   // Create user OFR
-  const userOfR = await createUser(
-    { email: "ofr@test.fr", password: "Secret!Password1" },
-    {
-      nom: "ofr",
-      prenom: "test",
-      description: "ADEN Formations (Damigny)",
-      roles: ["of"],
-      account_status: "FORCE_RESET_PASSWORD",
-      siret: "44492238900044",
-      uai: "0611309S",
-      organisation: "ORGANISME_FORMATION",
-    }
-  );
-  await userAfterCreate({ user: userOfR, pending: false, notify: false, asRole: "organisme.admin" });
-  // Get organisme id for user
-  const organismeOff = await findOrganismeByUai("0142321X");
-  await addContributeurOrganisme(organismeOff._id, userOfR.email, "organisme.admin", false);
-  logger.info(`User ofr created`);
+  if (!(await getUser("ofr@test.fr"))) {
+    const userOfR = await createUser(
+      { email: "ofr@test.fr", password: "Secret!Password1" },
+      {
+        nom: "ofr",
+        prenom: "test",
+        description: "ADEN Formations (Damigny)",
+        roles: ["of"],
+        account_status: "FORCE_RESET_PASSWORD",
+        siret: "44492238900044",
+        uai: "0611309S",
+        organisation: "ORGANISME_FORMATION",
+      }
+    );
+    await userAfterCreate({ user: userOfR, pending: false, notify: false, asRole: "organisme.admin" });
+    // Get organisme id for user
+    const organismeOff = await findOrganismeByUai("0142321X");
+    await addContributeurOrganisme(organismeOff._id, userOfR.email, "organisme.admin", false);
+    logger.info(`User ofr created`);
+  }
 
   // Create user Reseau
-  const userReseau = await createUser(
-    { email: "reseau@test.fr", password: "Secret!Password1" },
-    {
-      nom: "reseau",
-      prenom: "test",
-      description: "CCI paris",
-      roles: ["reseau_of"],
-      account_status: "FORCE_RESET_PASSWORD",
-      siret: "13001727000013",
-      reseau: "CCI",
-      organisation: "TETE_DE_RESEAU",
-    }
-  );
-  await userAfterCreate({ user: userReseau, pending: false, notify: false });
-  logger.info(`User reseau created`);
+  if (!(await getUser("reseau@test.fr"))) {
+    const userReseau = await createUser(
+      { email: "reseau@test.fr", password: "Secret!Password1" },
+      {
+        nom: "reseau",
+        prenom: "test",
+        description: "CCI paris",
+        roles: ["reseau_of"],
+        account_status: "FORCE_RESET_PASSWORD",
+        siret: "13001727000013",
+        reseau: "CCI",
+        organisation: "TETE_DE_RESEAU",
+      }
+    );
+    await userAfterCreate({ user: userReseau, pending: false, notify: false });
+    logger.info(`User reseau created`);
+  }
 
   // Create user ERP
-  const userErp = await createUser(
-    { email: "erp@test.fr", password: "Secret!Password1" },
-    {
-      nom: "erp",
-      prenom: "test",
-      description: "Erp ymag salarié",
-      roles: ["erp"],
-      account_status: "FORCE_RESET_PASSWORD",
-      siret: "31497933700081",
-      erp: "YMAG",
-      organisation: "ERP",
-    }
-  );
-  await userAfterCreate({ user: userErp, pending: false, notify: false });
-  logger.info(`User erp created`);
+  if (!(await getUser("erp@test.fr"))) {
+    const userErp = await createUser(
+      { email: "erp@test.fr", password: "Secret!Password1" },
+      {
+        nom: "erp",
+        prenom: "test",
+        description: "Erp ymag salarié",
+        roles: ["erp"],
+        account_status: "FORCE_RESET_PASSWORD",
+        siret: "31497933700081",
+        erp: "YMAG",
+        organisation: "ERP",
+      }
+    );
+    await userAfterCreate({ user: userErp, pending: false, notify: false });
+    logger.info(`User erp created`);
+  }
 };

--- a/server/src/jobs/seed/start/index.js
+++ b/server/src/jobs/seed/start/index.js
@@ -6,7 +6,7 @@ import {
   addContributeurOrganisme,
   createOrganisme,
   findOrganismeByUai,
-} from "../../../common/actions/organismes.actions.js";
+} from "../../../common/actions/organismes/organismes.actions.js";
 import { userAfterCreate } from "../../../common/actions/users.afterCreate.actions.js";
 
 export const seedRoles = async () => {

--- a/server/tests/integration/common/actions/organismes.actions.test.js
+++ b/server/tests/integration/common/actions/organismes.actions.test.js
@@ -6,7 +6,7 @@ import {
   createOrganisme,
   findOrganismeById,
   updateOrganisme,
-} from "../../../../src/common/actions/organismes.actions.js";
+} from "../../../../src/common/actions/organismes/organismes.actions.js";
 import { buildTokenizedString } from "../../../../src/common/utils/buildTokenizedString.js";
 import { fiabilisationUaiSiretDb } from "../../../../src/common/model/collections.js";
 import { FIABILISATION_MAPPINGS } from "../../../../src/jobs/fiabilisation/uai-siret/create-fiabilisation-uai-siret-mapping/mapping.js";

--- a/server/tests/integration/db/indexes/organismes.indexes.test.js
+++ b/server/tests/integration/db/indexes/organismes.indexes.test.js
@@ -1,5 +1,5 @@
 import { strict as assert } from "assert";
-import { createOrganisme } from "../../../../src/common/actions/organismes.actions.js";
+import { createOrganisme } from "../../../../src/common/actions/organismes/organismes.actions.js";
 import { createIndexes, dropIndexes } from "../../../../src/common/model/indexes/index.js";
 import { getDbCollectionIndexes } from "../../../../src/common/mongodb.js";
 import cfasModelDescriptor from "./../../../../src/common/model/previous.models/toRemove.models/cfas.model.js";

--- a/server/tests/integration/http/dossiersApprenants.route.legacy.test.js
+++ b/server/tests/integration/http/dossiersApprenants.route.legacy.test.js
@@ -11,7 +11,7 @@ import {
 import { cfdRegex } from "../../../src/common/utils/validationsUtils/cfd.js";
 import { dossiersApprenantsMigrationDb, usersDb } from "../../../src/common/model/collections.js";
 import { createUserLegacy } from "../../../src/common/actions/legacy/users.legacy.actions.js";
-import { createOrganisme, findOrganismeById } from "../../../src/common/actions/organismes.actions.js";
+import { createOrganisme, findOrganismeById } from "../../../src/common/actions/organismes/organismes.actions.js";
 import { pick } from "lodash-es";
 import { buildTokenizedString } from "../../../src/common/utils/buildTokenizedString.js";
 import { insertDossierApprenant } from "../../../src/common/actions/dossiersApprenants.actions.js";

--- a/server/tests/integration/http/effectifs.route.test.js
+++ b/server/tests/integration/http/effectifs.route.test.js
@@ -14,7 +14,7 @@ import { startServer } from "../../utils/testUtils.js";
 import { seedRoles } from "../../../src/jobs/seed/start/index.js";
 import { createUser } from "../../../src/common/actions/users.actions.js";
 import { userAfterCreate } from "../../../src/common/actions/users.afterCreate.actions.js";
-import { createOrganisme } from "../../../src/common/actions/organismes.actions.js";
+import { createOrganisme } from "../../../src/common/actions/organismes/organismes.actions.js";
 
 // const createRandomDossierApprenantWithHistorique = async (props) => {
 //   const { _id } = await dossiersApprenants().createDossierApprenant(createRandomDossierApprenant());


### PR DESCRIPTION
- Création d'un dossier organismes dans actions, avec ajout d'un organismes.formations.actions.js
- Construction de l'arbre des formations liés à un organisme au moment de la création de l'organisme.
- Temporairement le code est en doublon dans le job d'hydrate et la méthode createOrganisme uniquement pour pouvoir logger en détail dans le job si besoin d'analyse.
- Fix de doublons identifiés sur le formation_id
- Update du seed:sample pour éviter de throw si un user existe déja