### PR TITLE
chore(infra): desactivate cron jobs (temporary)

### DIFF
--- a/.infra/ansible/roles/setup/files/app/tools/cron-data-jobs/run-analyse-fiabilite-donnees-recues-job.sh
+++ b/.infra/ansible/roles/setup/files/app/tools/cron-data-jobs/run-analyse-fiabilite-donnees-recues-job.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 readonly LOG_FILEPATH="/var/log/data-jobs/run_analyse_fiabilite_donnees_recues_job_$(date +'%Y-%m-%d_%H%M%S').log"
 
 call_analyse_fiabilite_job_with_logs(){
-  docker exec flux_retour_cfas_server bash -c "yarn cli:fiabilisation analyse:dossiersApprenants-recus" || true
+  # TODO - Voir si on le réactive ?
+  # docker exec flux_retour_cfas_server bash -c "yarn cli:fiabilisation analyse:dossiersApprenants-recus" || true
 } 
 
 call_analyse_fiabilite_job_with_logs >> ${LOG_FILEPATH}

--- a/.infra/ansible/roles/setup/files/app/tools/cron-data-jobs/run-daily-jobs.sh
+++ b/.infra/ansible/roles/setup/files/app/tools/cron-data-jobs/run-daily-jobs.sh
@@ -8,20 +8,21 @@ set -euo pipefail
 readonly LOG_FILEPATH="/var/log/data-jobs/run_daily_jobs_$(date +'%Y-%m-%d_%H%M%S').log"
 
 call_daily_jobs_with_logs(){
-  # Remplissage des organismes et des formations liées
-  docker exec flux_retour_cfas_server bash -c "yarn cli hydrate:organismes-and-formations" || true
+
+  # TODO : a lancer en manuel ? - Remplissage des organismes et des formations liées
+  # docker exec flux_retour_cfas_server bash -c "yarn cli hydrate:organismes-and-formations" || true
   
-  # Remplissage des réseaux depuis csv fournis
-  docker exec flux_retour_cfas_server bash -c "yarn cli hydrate:reseaux-newFormat" || true
+  # TODO : a lancer en manuel ? - Remplissage des réseaux depuis csv fournis
+  # docker exec flux_retour_cfas_server bash -c "yarn cli hydrate:reseaux-newFormat" || true
 
-  # Remplissage de la collection EffectifsApprenants
-  docker exec flux_retour_cfas_server bash -c "yarn cli hydrate:effectifsApprenants" || true
+  # TODO : a réactiver - Remplissage de la collection EffectifsApprenants
+  # docker exec flux_retour_cfas_server bash -c "yarn cli hydrate:effectifsApprenants" || true
 
-  # Purge des données inutiles
-  docker exec flux_retour_cfas_server bash -c "yarn cli purge:events" || true
+  # TODO : a réactiver - Purge des données inutiles
+  # docker exec flux_retour_cfas_server bash -c "yarn cli purge:events" || true
 
-  # Warm-up cache avec calculs effectifs coûteux
-  docker exec flux_retour_cfas_server bash -c "yarn cli cache:warmup" || true 
+  # TODO : job à fixer - Warm-up cache avec calculs effectifs coûteux
+  # docker exec flux_retour_cfas_server bash -c "yarn cli cache:warmup" || true 
 } 
 
 call_daily_jobs_with_logs >> ${LOG_FILEPATH}


### PR DESCRIPTION
Désactivation (temporaire) des jobs CRON

Le temps qu'on lance les scripts de migration pour éviter les conflits je propose de désactiver (commentés) ces lancements de jobs. Voir ensemble ce qu'on gardera après.