### PR TITLE
chore(server): ajoute route pour indicateurs dossiersApprenants ancien modèle

### DIFF
--- a/server/src/common/components/components.js
+++ b/server/src/common/components/components.js
@@ -1,15 +1,18 @@
 import createDossierApprenant from "./dossiersApprenants.js";
 import createEffectifs from "./effectifs.js";
 import createEffectifsFromDossiers from "./effectifs.dossiers.js";
+import createEffectifsFromDossiersOld from "./effectifs.dossiers.old.js";
 
 export default async (options = {}) => {
   const dossiersApprenants = options.dossiersApprenants || createDossierApprenant();
   const effectifs = options.effectifs || createEffectifs();
   const effectifsFromDossiers = options.effectifsFromDossiers || createEffectifsFromDossiers();
+  const effectifsFromDossiersOld = options.effectifsFromDossiersOld || createEffectifsFromDossiersOld();
 
   return {
     dossiersApprenants,
     effectifs,
     effectifsFromDossiers,
+    effectifsFromDossiersOld,
   };
 };

--- a/server/src/common/components/effectifs-dossiers-old/abandons.dossiers.js
+++ b/server/src/common/components/effectifs-dossiers-old/abandons.dossiers.js
@@ -1,0 +1,40 @@
+import { CODES_STATUT_APPRENANT, getStatutApprenantNameFromCode } from "../../constants/dossierApprenantConstants.js";
+import { IndicatorFromDossiersOld } from "./indicator.dossiers.js";
+
+export class EffectifsAbandonsFromDossiersOld extends IndicatorFromDossiersOld {
+  /**
+   * Pipeline de récupération des abandons à une date donnée
+   * @param {*} searchDate
+   * @param {*} filters
+   * @param {*} options
+   * @returns
+   */
+  getAtDateAggregationPipeline(searchDate, filters = {}, options = {}) {
+    return [
+      { $match: { ...filters, "historique_statut_apprenant.valeur_statut": CODES_STATUT_APPRENANT.abandon } },
+      ...this.getEffectifsWithStatutAtDateAggregationPipeline(searchDate, options.projection),
+      { $match: { "statut_apprenant_at_date.valeur_statut": CODES_STATUT_APPRENANT.abandon } },
+    ];
+  }
+
+  /**
+   * Function de récupération de la liste des abandons formatée pour un export à une date donnée
+   * @param {*} searchDate
+   * @param {*} filters
+   * @returns
+   */
+  async getExportFormattedListAtDate(searchDate, filters = {}) {
+    const projection = this.exportProjection;
+    return (await this.getListAtDate(searchDate, filters, { projection })).map((item) => ({
+      ...item,
+      statut: getStatutApprenantNameFromCode(item.statut_apprenant_at_date.valeur_statut),
+      date_abandon: item.statut_apprenant_at_date.date_statut,
+      historique_statut_apprenant: JSON.stringify(
+        item.historique_statut_apprenant.map((item) => ({
+          date: item.date_statut,
+          statut: getStatutApprenantNameFromCode(item.valeur_statut),
+        }))
+      ),
+    }));
+  }
+}

--- a/server/src/common/components/effectifs-dossiers-old/apprentis.dossiers.js
+++ b/server/src/common/components/effectifs-dossiers-old/apprentis.dossiers.js
@@ -1,0 +1,39 @@
+import { CODES_STATUT_APPRENANT, getStatutApprenantNameFromCode } from "../../constants/dossierApprenantConstants.js";
+import { IndicatorFromDossiersOld } from "./indicator.dossiers.js";
+
+export class EffectifsApprentisFromDossiersOld extends IndicatorFromDossiersOld {
+  /**
+   * Pipeline de récupération des apprentis à une date donnée
+   * @param {*} searchDate
+   * @param {*} filters
+   * @param {*} options
+   * @returns
+   */
+  getAtDateAggregationPipeline(searchDate, filters = {}, options = {}) {
+    return [
+      { $match: { ...filters, "historique_statut_apprenant.valeur_statut": CODES_STATUT_APPRENANT.apprenti } },
+      ...this.getEffectifsWithStatutAtDateAggregationPipeline(searchDate, options.projection),
+      { $match: { "statut_apprenant_at_date.valeur_statut": CODES_STATUT_APPRENANT.apprenti } },
+    ];
+  }
+
+  /**
+   * Function de récupération de la liste des apprentis formatée pour un export à une date donnée
+   * @param {*} searchDate
+   * @param {*} filters
+   * @returns
+   */
+  async getExportFormattedListAtDate(searchDate, filters = {}) {
+    const projection = this.exportProjection;
+    return (await this.getListAtDate(searchDate, filters, { projection })).map((item) => ({
+      ...item,
+      statut: getStatutApprenantNameFromCode(item.statut_apprenant_at_date.valeur_statut),
+      historique_statut_apprenant: JSON.stringify(
+        item.historique_statut_apprenant.map((item) => ({
+          date: item.date_statut,
+          statut: getStatutApprenantNameFromCode(item.valeur_statut),
+        }))
+      ),
+    }));
+  }
+}

--- a/server/src/common/components/effectifs-dossiers-old/indicator.dossiers.js
+++ b/server/src/common/components/effectifs-dossiers-old/indicator.dossiers.js
@@ -1,0 +1,132 @@
+import { dossiersApprenantsDb } from "../../model/collections.js";
+
+export class IndicatorFromDossiersOld {
+  /**
+   * Constructeur avec définition d'une projection d'export par défaut
+   */
+  constructor() {
+    this.exportProjection = {
+      uai_etablissement: 1,
+      siret_etablissement: 1,
+      etablissement_nom_departement: 1,
+      etablissement_nom_region: 1,
+      etablissement_reseaux: 1,
+      nom_etablissement: 1,
+      nom_apprenant: 1,
+      prenom_apprenant: 1,
+      date_de_naissance_apprenant: 1,
+      formation_cfd: 1,
+      formation_rncp: 1,
+      libelle_long_formation: 1,
+      annee_formation: 1,
+      periode_formation: 1,
+      annee_scolaire: 1,
+      contrat_date_debut: 1,
+      contrat_date_fin: 1,
+      contrat_date_rupture: 1,
+      historique_statut_apprenant: 1,
+      statut_apprenant_at_date: 1,
+    };
+  }
+
+  /**
+   * Décompte du nombre de jeunes correspondant à cet indicateur à la date donnée
+   * @param {*} searchDate Date de recherche
+   * @param {*} filters Filtres optionnels
+   * @param {*} options Options de regroupement / projection optionnelles
+   * @returns
+   */
+  async getCountAtDate(searchDate, filters = {}, options = {}) {
+    const groupedBy = options.groupedBy ?? { _id: null, count: { $sum: 1 } };
+    const aggregationPipeline = this.getAtDateAggregationPipeline(searchDate, filters, options);
+    const groupedAggregationPipeline = [...aggregationPipeline, { $group: groupedBy }];
+    const result = await dossiersApprenantsDb().aggregate(groupedAggregationPipeline).toArray();
+
+    if (!options.groupedBy) {
+      return result.length === 1 ? result[0].count : 0;
+    }
+    return result;
+  }
+
+  /**
+   * Liste tous les DossierApprenant correspondants à cet indicateur à la date donnée
+   * @param {*} searchDate Date de recherche
+   * @param {*} filters Filtres optionnels
+   * @param {*} options Options de regroupement / projection optionnelles
+   * @returns
+   */
+  async getListAtDate(searchDate, filters = {}, options = {}) {
+    const aggregationPipeline = await this.getAtDateAggregationPipeline(searchDate, filters, options);
+    const result = await dossiersApprenantsDb().aggregate(aggregationPipeline).toArray();
+    return result ?? [];
+  }
+
+  /**
+   * Pipeline de récupération des effectifs avec un statut donné à une date donnée - Principe :
+   * 1. On filtre dans l'historique sur les éléments ayant une date <= date recherchée
+   * 2. On construit dans l'historique des statuts un champ diff_date_search = différence entre la date du statut de l'historique et la date recherchée
+   * 3. On crée un champ statut_apprenant_at_date = statut dans l'historique avec le plus petit diff_date_search
+   */
+  getEffectifsWithStatutAtDateAggregationPipeline(date, projection = {}) {
+    return [
+      // Filtrage sur les élements avec date antérieure à la date recherchée
+      {
+        $project: {
+          ...projection,
+          historique_statut_apprenant: {
+            $filter: {
+              input: "$historique_statut_apprenant",
+              as: "result",
+              // Filtre dans l'historique sur les valeurs ayant une date antérieure à la date de recherche
+              cond: {
+                $lte: ["$$result.date_statut", date],
+              },
+            },
+          },
+        },
+      },
+      // on élimine les historique vides (un dossier sur lequel on aurait un seul élément à une date ultérieure à celle donnée)
+      {
+        $match: { historique_statut_apprenant: { $not: { $size: 0 } } },
+      },
+      // on trie les historique par date_statut puis par date_reception si date_statut identiques (cas régulier)
+      {
+        $project: {
+          ...projection,
+          historique_statut_apprenant: {
+            $sortArray: {
+              input: "$historique_statut_apprenant",
+              sortBy: { date_statut: 1, date_reception: 1 },
+            },
+          },
+        },
+      },
+      // on récupère le dernier élément, considéré comme le statut à la date donnée
+      {
+        $addFields: {
+          statut_apprenant_at_date: {
+            $last: "$historique_statut_apprenant",
+          },
+        },
+      },
+    ];
+  }
+
+  /**
+   * Fonction de récupération de la liste des apprentis anonymisée et formatée pour un export à une date donnée
+   * @param {*} searchDate
+   * @param {*} filters
+   * @returns
+   */
+  async getFullExportFormattedListAtDate(searchDate, filters = {}, indicateur, namedDataMode = false) {
+    return (await this.getExportFormattedListAtDate(searchDate, filters, indicateur)).map((item) => ({
+      ...item,
+      indicateur,
+      nom_apprenant: namedDataMode === true ? item.nom_apprenant : undefined,
+      prenom_apprenant: namedDataMode === true ? item.prenom_apprenant : undefined,
+      date_de_naissance_apprenant: namedDataMode === true ? item.date_de_naissance_apprenant : undefined,
+      date_debut_formation: item.periode_formation ? item.periode_formation[0] : null,
+      date_fin_formation: item.periode_formation ? item.periode_formation[1] : null,
+    }));
+  }
+}

--- a/server/src/common/components/effectifs-dossiers-old/inscrits-sans-contrats.dossiers.js
+++ b/server/src/common/components/effectifs-dossiers-old/inscrits-sans-contrats.dossiers.js
@@ -1,0 +1,52 @@
+import { CODES_STATUT_APPRENANT, getStatutApprenantNameFromCode } from "../../constants/dossierApprenantConstants.js";
+import { SEUIL_ALERTE_NB_MOIS_INSCRITS_SANS_CONTRATS } from "../../utils/validationsUtils/effectif.js";
+import { addMonths } from "date-fns";
+import { IndicatorFromDossiersOld } from "./indicator.dossiers.js";
+
+export class EffectifsInscritsSansContratsFromDossiersOld extends IndicatorFromDossiersOld {
+  /**
+   * Pipeline de récupération des inscrits sans contrats à une date donnée
+   * @param {*} searchDate
+   * @param {*} filters
+   * @param {*} options
+   * @returns
+   */
+  getAtDateAggregationPipeline(searchDate, filters = {}, options = {}) {
+    return [
+      { $match: { ...filters, "historique_statut_apprenant.valeur_statut": CODES_STATUT_APPRENANT.inscrit } },
+      ...this.getEffectifsWithStatutAtDateAggregationPipeline(searchDate, options.projection),
+      {
+        $match: {
+          "statut_apprenant_at_date.valeur_statut": CODES_STATUT_APPRENANT.inscrit,
+          "historique_statut_apprenant.valeur_statut": { $ne: CODES_STATUT_APPRENANT.apprenti },
+        },
+      },
+    ];
+  }
+
+  /**
+   * Function de récupération de la liste des inscrits sans contrats formatée pour un export à une date donnée
+   * @param {*} searchDate
+   * @param {*} filters
+   * @returns
+   */
+  async getExportFormattedListAtDate(searchDate, filters = {}) {
+    const projection = this.exportProjection;
+    return (await this.getListAtDate(searchDate, filters, { projection })).map((item) => ({
+      ...item,
+      statut: getStatutApprenantNameFromCode(item.statut_apprenant_at_date.valeur_statut),
+      date_inscription: item.statut_apprenant_at_date.date_statut, // Specific for inscrits sans contrats indicateur
+      historique_statut_apprenant: JSON.stringify(
+        item.historique_statut_apprenant.map((item) => ({
+          date: item.date_statut,
+          statut: getStatutApprenantNameFromCode(item.valeur_statut),
+        }))
+      ),
+      dans_le_statut_depuis:
+        addMonths(new Date(item.statut_apprenant_at_date.date_statut), SEUIL_ALERTE_NB_MOIS_INSCRITS_SANS_CONTRATS) >
+        Date.now()
+          ? `Moins de ${SEUIL_ALERTE_NB_MOIS_INSCRITS_SANS_CONTRATS} mois`
+          : `Plus de ${SEUIL_ALERTE_NB_MOIS_INSCRITS_SANS_CONTRATS} mois`,
+    }));
+  }
+}

--- a/server/src/common/components/effectifs-dossiers-old/rupturants.dossiers.js
+++ b/server/src/common/components/effectifs-dossiers-old/rupturants.dossiers.js
@@ -1,0 +1,61 @@
+import { CODES_STATUT_APPRENANT, getStatutApprenantNameFromCode } from "../../constants/dossierApprenantConstants.js";
+import { SEUIL_ALERTE_NB_MOIS_RUPTURANTS } from "../../utils/validationsUtils/effectif.js";
+import { addMonths } from "date-fns";
+import { IndicatorFromDossiersOld } from "./indicator.dossiers.js";
+
+export class EffectifsRupturantsFromDossiersOld extends IndicatorFromDossiersOld {
+  /**
+   * Pipeline de récupération des rupturants à une date donnée
+   * @param {*} searchDate
+   * @param {*} filters
+   * @param {*} options
+   * @returns
+   */
+  getAtDateAggregationPipeline(searchDate, filters = {}, options = {}) {
+    return [
+      // Filtrage sur les filtres passés en paramètres
+      {
+        $match: {
+          ...filters,
+          "historique_statut_apprenant.valeur_statut": CODES_STATUT_APPRENANT.inscrit,
+          "historique_statut_apprenant.1": { $exists: true },
+        },
+      },
+      ...this.getEffectifsWithStatutAtDateAggregationPipeline(searchDate, options.projection),
+      { $match: { "statut_apprenant_at_date.valeur_statut": CODES_STATUT_APPRENANT.inscrit } },
+      // set previousStatutAtDate to be the element in historique_statut_apprenant juste before statut_apprenant_at_date
+      {
+        $addFields: {
+          previousStatutAtDate: {
+            $arrayElemAt: ["$historique_statut_apprenant", -2],
+          },
+        },
+      },
+      { $match: { "previousStatutAtDate.valeur_statut": CODES_STATUT_APPRENANT.apprenti } },
+    ];
+  }
+
+  /**
+   * Function de récupération de la liste des rupturants formatée pour un export à une date donnée
+   * @param {*} searchDate
+   * @param {*} filters
+   * @returns
+   */
+  async getExportFormattedListAtDate(searchDate, filters = {}) {
+    const projection = this.exportProjection;
+    return (await this.getListAtDate(searchDate, filters, { projection })).map((item) => ({
+      ...item,
+      statut: getStatutApprenantNameFromCode(item.statut_apprenant_at_date.valeur_statut),
+      historique_statut_apprenant: JSON.stringify(
+        item.historique_statut_apprenant.map((item) => ({
+          date: item.date_statut,
+          statut: getStatutApprenantNameFromCode(item.valeur_statut),
+        }))
+      ),
+      dans_le_statut_depuis:
+        addMonths(new Date(item.statut_apprenant_at_date.date_statut), SEUIL_ALERTE_NB_MOIS_RUPTURANTS) > Date.now()
+          ? `Moins de ${SEUIL_ALERTE_NB_MOIS_RUPTURANTS} mois`
+          : `Plus de ${SEUIL_ALERTE_NB_MOIS_RUPTURANTS} mois`,
+    }));
+  }
+}

--- a/server/src/common/components/effectifs.dossiers.old.js
+++ b/server/src/common/components/effectifs.dossiers.old.js
@@ -1,20 +1,21 @@
 import { mergeObjectsBy } from "../utils/mergeObjectsBy.js";
 import { asyncForEach } from "../utils/asyncUtils.js";
 import { EFFECTIF_INDICATOR_NAMES } from "../constants/dossierApprenantConstants.js";
-import { EffectifsApprentisFromDossiers } from "./effectifs-dossiers/apprentis.dossiers.js";
-import { EffectifsAbandonsFromDossiers } from "./effectifs-dossiers/abandons.dossiers.js";
-import { EffectifsInscritsSansContratsFromDossiers } from "./effectifs-dossiers/inscrits-sans-contrats.dossiers.js";
-import { EffectifsRupturantsFromDossiers } from "./effectifs-dossiers/rupturants.dossiers.js";
+import { EffectifsApprentisFromDossiersOld } from "./effectifs-dossiers-old/apprentis.dossiers.js";
+import { EffectifsAbandonsFromDossiersOld } from "./effectifs-dossiers-old/abandons.dossiers.js";
+import { EffectifsInscritsSansContratsFromDossiersOld } from "./effectifs-dossiers-old/inscrits-sans-contrats.dossiers.js";
+import { EffectifsRupturantsFromDossiersOld } from "./effectifs-dossiers-old/rupturants.dossiers.js";
 
 /**
  * TODO : A Supprimer une fois passé sur le modèle effectifs
- * Gestion des effectifs depuis les dossiersApprenantsMigration
+ * Permets de faire la comparaison avant migration
+ * Gestion des effectifs depuis les dossiersApprenants
  */
 export default () => {
-  const apprentis = new EffectifsApprentisFromDossiers();
-  const abandons = new EffectifsAbandonsFromDossiers();
-  const inscritsSansContrats = new EffectifsInscritsSansContratsFromDossiers();
-  const rupturants = new EffectifsRupturantsFromDossiers();
+  const apprentis = new EffectifsApprentisFromDossiersOld();
+  const abandons = new EffectifsAbandonsFromDossiersOld();
+  const inscritsSansContrats = new EffectifsInscritsSansContratsFromDossiersOld();
+  const rupturants = new EffectifsRupturantsFromDossiersOld();
 
   /**
    * Récupération des effectifs pour tous les indicateurs du TdB
@@ -23,7 +24,7 @@ export default () => {
    * @param {*} param2
    * @returns
    */
-  const getEffectifsCountAtDateFromDossiers = async (searchDate, filters = {}, { groupedBy, projection }) => {
+  const getEffectifsCountAtDateFromDossiersOld = async (searchDate, filters = {}, { groupedBy, projection }) => {
     // compute number of apprentis, abandons, inscrits sans contrat and rupturants
     const apprentisCountByCfa = await apprentis.getCountAtDate(searchDate, filters, {
       groupedBy: { ...groupedBy, apprentis: { $sum: 1 } },
@@ -64,11 +65,11 @@ export default () => {
    *  }
    * }]
    */
-  const getEffectifsCountByNiveauFormationAtDateFromDossiers = async (searchDate, filters = {}) => {
+  const getEffectifsCountByNiveauFormationAtDateFromDossiersOld = async (searchDate, filters = {}) => {
     const projection = { niveau_formation: 1, niveau_formation_libelle: 1 };
     const groupedBy = { _id: "$niveau_formation", niveau_libelle: { $first: "$niveau_formation_libelle" } };
     // compute number of apprentis, abandons, inscrits sans contrat and rupturants
-    const effectifsByNiveauFormation = await getEffectifsCountAtDateFromDossiers(
+    const effectifsByNiveauFormation = await getEffectifsCountAtDateFromDossiersOld(
       searchDate,
       // compute effectifs with a niveau_formation
       { ...filters, niveau_formation: { $ne: null } },
@@ -104,14 +105,14 @@ export default () => {
    *  }
    * }]
    */
-  const getEffectifsCountByFormationAtDateFromDossiers = async (searchDate, filters = {}) => {
+  const getEffectifsCountByFormationAtDateFromDossiersOld = async (searchDate, filters = {}) => {
     const projection = { formation_cfd: 1, libelle_long_formation: 1 };
     const groupedBy = {
       _id: "$formation_cfd",
       // we will send libelle_long_formation along with the grouped effectifs so we need to project it
       libelle_long_formation: { $first: "$libelle_long_formation" },
     };
-    const effectifsByFormation = await getEffectifsCountAtDateFromDossiers(searchDate, filters, {
+    const effectifsByFormation = await getEffectifsCountAtDateFromDossiersOld(searchDate, filters, {
       groupedBy,
       projection,
     });
@@ -146,7 +147,7 @@ export default () => {
    *  }
    * }]
    */
-  const getEffectifsCountByFormationAndDepartementAtDateFromDossiers = async (searchDate, filters = {}) => {
+  const getEffectifsCountByFormationAndDepartementAtDateFromDossiersOld = async (searchDate, filters = {}) => {
     const projection = {
       formation_cfd: 1,
       etablissement_num_departement: 1,
@@ -157,7 +158,7 @@ export default () => {
       // we will send libelle_long_formation along with the grouped effectifs so we need to project it
       libelle_long_formation: { $first: "$libelle_long_formation" },
     };
-    const effectifsByFormationAndDepartement = await getEffectifsCountAtDateFromDossiers(searchDate, filters, {
+    const effectifsByFormationAndDepartement = await getEffectifsCountAtDateFromDossiersOld(searchDate, filters, {
       groupedBy,
       projection,
     });
@@ -191,10 +192,10 @@ export default () => {
    *  }
    * }]
    */
-  const getEffectifsCountByAnneeFormationAtDateFromDossiers = async (searchDate, filters = {}) => {
+  const getEffectifsCountByAnneeFormationAtDateFromDossiersOld = async (searchDate, filters = {}) => {
     const projection = { annee_formation: 1 };
     const groupedBy = { _id: "$annee_formation" };
-    const effectifsByAnneeFormation = await getEffectifsCountAtDateFromDossiers(searchDate, filters, {
+    const effectifsByAnneeFormation = await getEffectifsCountAtDateFromDossiersOld(searchDate, filters, {
       groupedBy,
       projection,
     });
@@ -227,7 +228,7 @@ export default () => {
    *  }
    * }]
    */
-  const getEffectifsCountByCfaAtDateFromDossiers = async (searchDate, filters = {}) => {
+  const getEffectifsCountByCfaAtDateFromDossiersOld = async (searchDate, filters = {}) => {
     // we need to project these fields to give information about the CFAs
     const projection = {
       uai_etablissement: 1,
@@ -240,7 +241,7 @@ export default () => {
       nom_etablissement: { $first: "$nom_etablissement" },
       siret_etablissement: { $addToSet: "$siret_etablissement" },
     };
-    const effectifsCountByCfa = await getEffectifsCountAtDateFromDossiers(searchDate, filters, {
+    const effectifsCountByCfa = await getEffectifsCountAtDateFromDossiersOld(searchDate, filters, {
       groupedBy,
       projection,
     });
@@ -282,7 +283,7 @@ export default () => {
    *  }
    * }]
    */
-  const getEffectifsCountBySiretAtDateFromDossiers = async (searchDate, filters = {}) => {
+  const getEffectifsCountBySiretAtDateFromDossiersOld = async (searchDate, filters = {}) => {
     // we need to project these fields to give information about the CFAs
     const projection = {
       siret_etablissement: 1,
@@ -293,7 +294,7 @@ export default () => {
       // we will send information about the organisme along with the grouped effectifs so we project it
       nom_etablissement: { $first: "$nom_etablissement" },
     };
-    const effectifsCountByCfa = await getEffectifsCountAtDateFromDossiers(
+    const effectifsCountByCfa = await getEffectifsCountAtDateFromDossiersOld(
       searchDate,
       // compute effectifs with a siret_etablissement
       { ...filters, siret_etablissement: { $ne: null } },
@@ -330,7 +331,7 @@ export default () => {
    *  }
    * }]
    */
-  const getEffectifsCountByDepartementAtDateFromDossiers = async (searchDate, filters = {}) => {
+  const getEffectifsCountByDepartementAtDateFromDossiersOld = async (searchDate, filters = {}) => {
     // we need to project these fields to give information about the departement
     const projection = {
       etablissement_nom_departement: 1,
@@ -340,7 +341,7 @@ export default () => {
       _id: "$etablissement_num_departement",
       etablissement_nom_departement: { $first: "$etablissement_nom_departement" },
     };
-    const effectifsCountByDepartement = await getEffectifsCountAtDateFromDossiers(searchDate, filters, {
+    const effectifsCountByDepartement = await getEffectifsCountAtDateFromDossiersOld(searchDate, filters, {
       groupedBy,
       projection,
     });
@@ -366,7 +367,7 @@ export default () => {
    * @param {*} filters
    * @returns
    */
-  const getDataListEffectifsAtDateFromDossiers = async (searchDate, filters = {}, namedDataMode = false) => {
+  const getDataListEffectifsAtDateFromDossiersOld = async (searchDate, filters = {}, namedDataMode = false) => {
     const apprentisAnonymous = await apprentis.getFullExportFormattedListAtDate(
       searchDate,
       filters,
@@ -400,13 +401,13 @@ export default () => {
     abandons,
     inscritsSansContrats,
     rupturants,
-    getEffectifsCountByCfaAtDateFromDossiers,
-    getEffectifsCountByNiveauFormationAtDateFromDossiers,
-    getEffectifsCountByFormationAtDateFromDossiers,
-    getEffectifsCountByAnneeFormationAtDateFromDossiers,
-    getEffectifsCountByDepartementAtDateFromDossiers,
-    getEffectifsCountByFormationAndDepartementAtDateFromDossiers,
-    getEffectifsCountBySiretAtDateFromDossiers,
-    getDataListEffectifsAtDateFromDossiers,
+    getEffectifsCountByCfaAtDateFromDossiersOld,
+    getEffectifsCountByNiveauFormationAtDateFromDossiersOld,
+    getEffectifsCountByFormationAtDateFromDossiersOld,
+    getEffectifsCountByAnneeFormationAtDateFromDossiersOld,
+    getEffectifsCountByDepartementAtDateFromDossiersOld,
+    getEffectifsCountByFormationAndDepartementAtDateFromDossiersOld,
+    getEffectifsCountBySiretAtDateFromDossiersOld,
+    getDataListEffectifsAtDateFromDossiersOld,
   };
 };

--- a/server/src/http/routes/specific.routes/old/indicateurs-national.dossiers.old.route.js
+++ b/server/src/http/routes/specific.routes/old/indicateurs-national.dossiers.old.route.js
@@ -1,0 +1,42 @@
+import express from "express";
+import { format } from "date-fns";
+import Joi from "joi";
+import tryCatch from "../../../middlewares/tryCatchMiddleware.js";
+import { getAnneesScolaireListFromDate } from "../../../../common/utils/anneeScolaireUtils.js";
+import { getCacheKeyForRoute } from "../../../../common/utils/cacheUtils.js";
+import { getNbDistinctOrganismesByUai } from "../../../../common/actions/dossiersApprenants.actions.js";
+
+export default ({ effectifsFromDossiersOld, cache }) => {
+  const router = express.Router();
+  router.get(
+    "/",
+    tryCatch(async (req, res) => {
+      const { date: dateFromQuery } = await Joi.object({
+        date: Joi.date().required(),
+      }).validateAsync(req.query, { abortEarly: false });
+
+      const date = new Date(dateFromQuery);
+      const filters = { annee_scolaire: { $in: getAnneesScolaireListFromDate(date) } };
+      const cacheKey = getCacheKeyForRoute(`${req.baseUrl}${req.path}`, {
+        date: format(date, "yyyy-MM-dd"),
+        filters,
+      });
+      const fromCache = await cache.get(cacheKey);
+
+      if (fromCache) return res.json(JSON.parse(fromCache));
+
+      const response = {
+        date,
+        totalOrganismes: await getNbDistinctOrganismesByUai(filters),
+        apprentis: await effectifsFromDossiersOld.apprentis.getCountAtDate(date, filters),
+        rupturants: await effectifsFromDossiersOld.rupturants.getCountAtDate(date, filters),
+        inscritsSansContrat: await effectifsFromDossiersOld.inscritsSansContrats.getCountAtDate(date, filters),
+        abandons: await effectifsFromDossiersOld.abandons.getCountAtDate(date, filters),
+      };
+
+      await cache.set(cacheKey, JSON.stringify(response));
+      return res.json(response);
+    })
+  );
+  return router;
+};

--- a/server/src/http/routes/specific.routes/old/indicateurs.dossiers.old.route.js
+++ b/server/src/http/routes/specific.routes/old/indicateurs.dossiers.old.route.js
@@ -1,0 +1,336 @@
+import express from "express";
+import { format } from "date-fns";
+import Joi from "joi";
+import tryCatch from "../../../middlewares/tryCatchMiddleware.js";
+import { getAnneesScolaireListFromDate } from "../../../../common/utils/anneeScolaireUtils.js";
+import { getCacheKeyForRoute } from "../../../../common/utils/cacheUtils.js";
+import { getNbDistinctOrganismesByUai } from "../../../../common/actions/dossiersApprenants.actions.js";
+
+const commonEffectifsFilters = {
+  organisme_id: Joi.string().required(),
+  etablissement_num_region: Joi.string().allow(null, ""),
+  etablissement_num_departement: Joi.string().allow(null, ""),
+  formation_cfd: Joi.string().allow(null, ""),
+  uai_etablissement: Joi.string().allow(null, ""),
+  siret_etablissement: Joi.string().allow(null, ""),
+  etablissement_reseaux: Joi.string().allow(null, ""),
+};
+
+export default ({ effectifsFromDossiersOld, cache }) => {
+  const router = express.Router();
+
+  /**
+   * Gets nb organismes formation
+   */
+  router.get(
+    "/total-organismes",
+    tryCatch(async (req, res) => {
+      const { date: dateFromQuery, ...filtersFromBody } = await Joi.object({
+        date: Joi.date().required(),
+        ...commonEffectifsFilters,
+      }).validateAsync(req.query, { abortEarly: false });
+
+      const date = new Date(dateFromQuery);
+      const filters = {
+        ...filtersFromBody,
+        annee_scolaire: { $in: getAnneesScolaireListFromDate(date) },
+      };
+
+      const nbOrganismes = await getNbDistinctOrganismesByUai(filters);
+
+      return res.json({
+        nbOrganismes,
+      });
+    })
+  );
+
+  /**
+   * Gets the effectifs count for input period & query
+   */
+  router.get(
+    "/",
+    tryCatch(async (req, res) => {
+      const {
+        date: dateFromParams,
+        // eslint-disable-next-line no-unused-vars
+        organisme_id,
+        ...filtersFromBody
+      } = await Joi.object({
+        date: Joi.date().required(),
+        ...commonEffectifsFilters,
+      }).validateAsync(req.query, { abortEarly: false });
+
+      const date = new Date(dateFromParams);
+      const filters = {
+        ...filtersFromBody,
+        annee_scolaire: { $in: getAnneesScolaireListFromDate(date) },
+      };
+
+      // try to retrieve from cache
+      const cacheKey = getCacheKeyForRoute(`${req.baseUrl}${req.path}`, {
+        date: format(date, "yyyy-MM-dd"),
+        filters,
+      });
+      const fromCache = await cache.get(cacheKey);
+
+      if (fromCache) {
+        return res.json(JSON.parse(fromCache));
+      } else {
+        const response = {
+          date,
+          apprentis: await effectifsFromDossiersOld.apprentis.getCountAtDate(date, filters),
+          rupturants: await effectifsFromDossiersOld.rupturants.getCountAtDate(date, filters),
+          inscritsSansContrat: await effectifsFromDossiersOld.inscritsSansContrats.getCountAtDate(date, filters),
+          abandons: await effectifsFromDossiersOld.abandons.getCountAtDate(date, filters),
+        };
+        // cache the result
+        await cache.set(cacheKey, JSON.stringify(response));
+        return res.json(response);
+      }
+    })
+  );
+
+  /**
+   * Get effectifs details by niveau_formation
+   */
+  router.get(
+    "/niveau-formation",
+    tryCatch(async (req, res) => {
+      const {
+        date: dateFromParams, // eslint-disable-next-line no-unused-vars
+        organisme_id,
+        ...filtersFromBody
+      } = await Joi.object({
+        date: Joi.date().required(),
+        ...commonEffectifsFilters,
+      }).validateAsync(req.query, { abortEarly: false });
+
+      const date = new Date(dateFromParams);
+      const filters = {
+        ...filtersFromBody,
+        annee_scolaire: { $in: getAnneesScolaireListFromDate(date) },
+      };
+
+      // try to retrieve from cache
+      const cacheKey = getCacheKeyForRoute(`${req.baseUrl}${req.path}`, {
+        date: format(date, "yyyy-MM-dd"),
+        filters,
+      });
+      const fromCache = await cache.get(cacheKey);
+
+      if (fromCache) {
+        return res.json(JSON.parse(fromCache));
+      } else {
+        const effectifsParNiveauFormation = await effectifsFromDossiersOld.getEffectifsCountByNiveauFormationAtDate(
+          date,
+          filters
+        );
+        await cache.set(cacheKey, JSON.stringify(effectifsParNiveauFormation));
+        return res.json(effectifsParNiveauFormation);
+      }
+    })
+  );
+
+  /**
+   * Get effectifs details by formation_cfd
+   */
+  router.get(
+    "/formation",
+    tryCatch(async (req, res) => {
+      const {
+        date: dateFromParams, // eslint-disable-next-line no-unused-vars
+        organisme_id,
+        ...filtersFromBody
+      } = await Joi.object({
+        date: Joi.date().required(),
+        niveau_formation: Joi.string().allow(null, ""),
+        ...commonEffectifsFilters,
+      }).validateAsync(req.query, { abortEarly: false });
+
+      const date = new Date(dateFromParams);
+      const filters = {
+        ...filtersFromBody,
+        annee_scolaire: { $in: getAnneesScolaireListFromDate(date) },
+      };
+
+      // try to retrieve from cache
+      const cacheKey = getCacheKeyForRoute(`${req.baseUrl}${req.path}`, {
+        date: format(date, "yyyy-MM-dd"),
+        filters,
+      });
+      const fromCache = await cache.get(cacheKey);
+
+      if (fromCache) {
+        return res.json(JSON.parse(fromCache));
+      } else {
+        const effectifsParFormation = await effectifsFromDossiersOld.getEffectifsCountByFormationAtDate(date, filters);
+        await cache.set(cacheKey, JSON.stringify(effectifsParFormation));
+        return res.json(effectifsParFormation);
+      }
+    })
+  );
+
+  /**
+   * Get effectifs details by annee_formation
+   */
+  router.get(
+    "/annee-formation",
+    tryCatch(async (req, res) => {
+      const {
+        date: dateFromParams, // eslint-disable-next-line no-unused-vars
+        organisme_id,
+        ...filtersFromBody
+      } = await Joi.object({
+        date: Joi.date().required(),
+        niveau_formation: Joi.string().allow(null, ""),
+        ...commonEffectifsFilters,
+      }).validateAsync(req.query, { abortEarly: false });
+
+      const date = new Date(dateFromParams);
+      const filters = {
+        ...filtersFromBody,
+        annee_scolaire: { $in: getAnneesScolaireListFromDate(date) },
+      };
+
+      // try to retrieve from cache
+      const cacheKey = getCacheKeyForRoute(`${req.baseUrl}${req.path}`, {
+        date: format(date, "yyyy-MM-dd"),
+        filters,
+      });
+      const fromCache = await cache.get(cacheKey);
+
+      if (fromCache) {
+        return res.json(JSON.parse(fromCache));
+      } else {
+        const effectifsParAnneeFormation = await effectifsFromDossiersOld.getEffectifsCountByAnneeFormationAtDate(
+          date,
+          filters
+        );
+        await cache.set(cacheKey, JSON.stringify(effectifsParAnneeFormation));
+
+        return res.json(effectifsParAnneeFormation);
+      }
+    })
+  );
+
+  /**
+   * Get effectifs details by cfa
+   */
+  router.get(
+    "/cfa",
+    tryCatch(async (req, res) => {
+      const {
+        date: dateFromQuery, // eslint-disable-next-line no-unused-vars
+        organisme_id,
+        ...filtersFromBody
+      } = await Joi.object({
+        date: Joi.date().required(),
+        ...commonEffectifsFilters,
+      }).validateAsync(req.query, { abortEarly: false });
+
+      const date = new Date(dateFromQuery);
+      const filters = {
+        ...filtersFromBody,
+        annee_scolaire: { $in: getAnneesScolaireListFromDate(date) },
+      };
+
+      // try to retrieve from cache
+      const cacheKey = getCacheKeyForRoute(`${req.baseUrl}${req.path}`, {
+        date: format(date, "yyyy-MM-dd"),
+        filters,
+      });
+      const fromCache = await cache.get(cacheKey);
+
+      if (fromCache) {
+        return res.json(JSON.parse(fromCache));
+      } else {
+        const effectifsByCfaAtDate = await effectifsFromDossiersOld.getEffectifsCountByCfaAtDate(date, filters);
+        await cache.set(cacheKey, JSON.stringify(effectifsByCfaAtDate));
+
+        return res.json(effectifsByCfaAtDate);
+      }
+    })
+  );
+
+  /**
+   * Get effectifs details by siret
+   */
+  router.get(
+    "/siret",
+    tryCatch(async (req, res) => {
+      const {
+        date: dateFromQuery, // eslint-disable-next-line no-unused-vars
+        organisme_id,
+        ...filtersFromBody
+      } = await Joi.object({
+        date: Joi.date().required(),
+        ...commonEffectifsFilters,
+      }).validateAsync(req.query, { abortEarly: false });
+
+      const date = new Date(dateFromQuery);
+      const filters = {
+        ...filtersFromBody,
+        annee_scolaire: { $in: getAnneesScolaireListFromDate(date) },
+      };
+
+      // try to retrieve from cache
+      const cacheKey = getCacheKeyForRoute(`${req.baseUrl}${req.path}`, {
+        date: format(date, "yyyy-MM-dd"),
+        filters,
+      });
+      const fromCache = await cache.get(cacheKey);
+
+      if (fromCache) {
+        return res.json(JSON.parse(fromCache));
+      } else {
+        const effectifsBySiretAtDate = await effectifsFromDossiersOld.getEffectifsCountBySiretAtDate(date, filters);
+        await cache.set(cacheKey, JSON.stringify(effectifsBySiretAtDate));
+
+        return res.json(effectifsBySiretAtDate);
+      }
+    })
+  );
+
+  /**
+   * Get effectifs details by departement
+   */
+  router.get(
+    "/departement",
+    tryCatch(async (req, res) => {
+      const {
+        date: dateFromQuery, // eslint-disable-next-line no-unused-vars
+        organisme_id,
+        ...filtersFromBody
+      } = await Joi.object({
+        date: Joi.date().required(),
+        ...commonEffectifsFilters,
+      }).validateAsync(req.query, { abortEarly: false });
+
+      const date = new Date(dateFromQuery);
+      const filters = {
+        ...filtersFromBody,
+        annee_scolaire: { $in: getAnneesScolaireListFromDate(date) },
+      };
+
+      // try to retrieve from cache
+      const cacheKey = getCacheKeyForRoute(`${req.baseUrl}${req.path}`, {
+        date: format(date, "yyyy-MM-dd"),
+        filters,
+      });
+      const fromCache = await cache.get(cacheKey);
+
+      if (fromCache) {
+        return res.json(JSON.parse(fromCache));
+      } else {
+        const effectifsByDepartementAtDate = await effectifsFromDossiersOld.getEffectifsCountByDepartementAtDate(
+          date,
+          filters
+        );
+        await cache.set(cacheKey, JSON.stringify(effectifsByDepartementAtDate));
+        return res.json(effectifsByDepartementAtDate);
+      }
+    })
+  );
+
+  return router;
+};

--- a/server/src/http/server.js
+++ b/server/src/http/server.js
@@ -24,8 +24,11 @@ import cfasRouter from "./routes/specific.routes/old/cfas.route.js";
 import formationRouter from "./routes/specific.routes/old/formations.route.js";
 import indicateursNationalRouter from "./routes/specific.routes/indicateurs-national.routes.js";
 import indicateursNationalDossiersRouter from "./routes/specific.routes/old/indicateurs-national.dossiers.route.js";
+import indicateursNationalDossiersOldRouter from "./routes/specific.routes/old/indicateurs-national.dossiers.old.route.js";
+
 import indicateursRouter from "./routes/specific.routes/indicateurs.routes.js";
 import indicateursDossiersRouter from "./routes/specific.routes/old/indicateurs.dossiers.route.js";
+import indicateursDossiersOldRouter from "./routes/specific.routes/old/indicateurs.dossiers.old.route.js";
 
 import emails from "./routes/emails.routes.js";
 import session from "./routes/session.routes.js";
@@ -141,6 +144,14 @@ export default async (services) => {
     checkJwtToken,
     permissionsOrganismeMiddleware(["organisme/tableau_de_bord"]),
     indicateursDossiersRouter(services)
+  );
+  app.use("/api/indicateurs-national-dossiers-old", indicateursNationalDossiersOldRouter(services)); // FRONT
+  app.use(
+    // FRONT
+    ["/api/indicateurs-dossiers-old"],
+    checkJwtToken,
+    permissionsOrganismeMiddleware(["organisme/tableau_de_bord"]),
+    indicateursDossiersOldRouter(services)
   );
 
   // TODO : Route à corriger / transformer pour le filtre par formations


### PR DESCRIPTION
Petite PR d'ajout de routes temporaires pour voir les indicateurs en se basant sur l'ancien modèle DossiersApprenants.

Un peu dirty car copier / coller de composant mais c'est du temporaire pour la recette / comparaison des données.

Utilisable en appelant : `/api/indicateurs-national-dossiers-old` et `/api/indicateurs-dossiers-old`