### PR TITLE
fix(server): update siret & sirets in hydrate-organismes-and-formations

### DIFF
--- a/server/src/jobs/hydrate/organismes/hydrate-organismes-and-formations.js
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes-and-formations.js
@@ -121,6 +121,8 @@ export const hydrateOrganismesAndFormations = async () => {
           organisme.sirets.length === 1 && organisme.sirets[0] === organismeReferentiel.siret;
         const updatedOrganisme = {
           ...organisme,
+          ...(siret ? { siret } : {}),
+          ...(siret ? { sirets: [siret] } : {}),
           nature: organismeReferentiel.nature,
           natureValidityWarning: !perfectUaiSiretMatch,
           est_dans_le_referentiel: true,


### PR DESCRIPTION
Fix d'une anomalie dans l'hydrate des organismes / formations (thx to @Anne-Camille ) d'update non fait du siret de l'organisme lorsqu'il est remonté depuis le référentiel.