### PR TITLE
chore: remove nas backup for recette

### DIFF
--- a/.infra/ansible/env.ini
+++ b/.infra/ansible/env.ini
@@ -15,8 +15,6 @@ host_name=tableau-de-bord-recette
 update_sshd_config=true
 git_revision=develop
 env_type=recette
-backup_partition_name=fluxretourcfas
-backup_cron=true
 
 [production]
 146.59.226.70


### PR DESCRIPTION
Plus besoin de backups sur le NAS pour la recette, c'était juste pour les tests.

TODO : une fois la PR validée 

- [ ] refaire un setup VM de la recette
- [ ] supprimer l'ip de la recette autorisée sur le NAS