### PR TITLE
fix(server): update effectifs unique index using id_erp_apprenant

### DIFF
--- a/server/src/common/model/next.toKeep.models/effectifs.model/effectifs.model.js
+++ b/server/src/common/model/next.toKeep.models/effectifs.model/effectifs.model.js
@@ -13,7 +13,19 @@ import {
 export const collectionName = "effectifs";
 
 export const indexes = () => {
-  return [[{ organisme_id: 1, annee_scolaire: 1, id_erp_apprenant: 1 }, { unique: true }]];
+  return [
+    [
+      {
+        organisme_id: 1,
+        annee_scolaire: 1,
+        id_erp_apprenant: 1,
+        "apprenant.nom": 1,
+        "apprenant.prenom": 1,
+        "formation.cfd": 1,
+      },
+      { unique: true },
+    ],
+  ];
 };
 
 export const schema = object(

--- a/server/src/common/model/next.toKeep.models/effectifs.model/effectifs.model.js
+++ b/server/src/common/model/next.toKeep.models/effectifs.model/effectifs.model.js
@@ -13,14 +13,8 @@ import {
 export const collectionName = "effectifs";
 
 export const indexes = () => {
-  return [
-    [
-      { organisme_id: 1, annee_scolaire: 1, "apprenant.nom": 1, "apprenant.prenom": 1, "formation.cfd": 1 },
-      { unique: true },
-    ],
-  ];
+  return [[{ organisme_id: 1, annee_scolaire: 1, id_erp_apprenant: 1 }, { unique: true }]];
 };
-// "id_erp_apprenant"
 
 export const schema = object(
   {

--- a/server/src/http/routes/specific.routes/serp.routes/upload.routes.js
+++ b/server/src/http/routes/specific.routes/serp.routes/upload.routes.js
@@ -662,7 +662,7 @@ export default ({ clamav }) => {
         const { effectif: canNotBeImportEffectif } = await hydrateEffectif({
           organisme_id,
           source: document.document_id.toString(),
-          id_erp_apprenant: `${index}`,
+          id_erp_apprenant: new ObjectId().toString(),
           annee_scolaire,
           apprenant: { nom: data.apprenant?.nom ?? "", prenom: data.apprenant?.prenom ?? "" },
           formation: { cfd: data.formation?.cfd ?? "", rncp: data.formation?.rncp ?? "" },


### PR DESCRIPTION
Il y a des cas ou l'on ne peut ajouter un effectif car il existe déja un effectif identique mais avec un id_erp_apprenant différent.

En changeant l'index unique on devrait plus avoir le souci.
Voir avec @antoinebigard si lors de l'upload on rempli bien un id_erp_apprenant et si pas d'effets de bord