### PR TITLE
fix(server): mapFiabilizedOrganismeUaiSiretCouple & setFirstTransmissionDate

### DIFF
--- a/server/src/common/actions/engine/engine.actions.js
+++ b/server/src/common/actions/engine/engine.actions.js
@@ -18,6 +18,7 @@ import {
   findOrganismeByUai,
   findOrganismeByUaiAndSiret,
   insertOrganisme,
+  setOrganismeFirstDateTransmissionIfNeeded,
 } from "../organismes/organismes.actions.js";
 import { mapFiabilizedOrganismeUaiSiretCouple } from "./engine.organismes.utils.js";
 
@@ -314,6 +315,11 @@ export const runEngine = async ({ effectifData, lockEffectif = true }, organisme
       // Ajout organisme id a l'effectifData
       // Pas besoin d'update l'organisme
       organismeFoundId = organismeFound?._id;
+
+      // Si l'organisme provient de la fiabilisation et qu'il n'est pas flaggé comme transmettant,
+      // on ajoute la date de première transmission
+      await setOrganismeFirstDateTransmissionIfNeeded(organismeFoundId);
+
       effectifData.organisme_id = organismeFound?._id.toString();
     }
   }

--- a/server/src/common/actions/engine/engine.organismes.utils.js
+++ b/server/src/common/actions/engine/engine.organismes.utils.js
@@ -12,7 +12,7 @@ export const mapFiabilizedOrganismeUaiSiretCouple = async ({ uai, siret }) => {
   const fiabilisationMappings = [...fiabilisationUaiSiretFromCollection, ...FIABILISATION_MAPPINGS];
 
   const foundCouple = fiabilisationMappings
-    .filter((item) => (item.uai && item.uai === uai) || (item.siret && item.siret === siret))
+    .filter((item) => item.uai === uai && item.siret === siret)
     .map(({ uai_fiable, siret_fiable }) => ({ cleanUai: uai_fiable, cleanSiret: siret_fiable }));
 
   return foundCouple[0] || { cleanUai: uai, cleanSiret: siret }; // Take only first match


### PR DESCRIPTION
Fix de la fiabilisation, on ne settait pas la firstDate et la fonction de mapping des couples n'était pas bonne.

Avec ce fix, les données transmises sur un couple fiabilisé seront bien rattachées et l'organisme sera bien flaggé comme transmettant coté UI.

Une autre PR arrive pour le clean des organismes non fiables à supprimer (et effectifs / contributeurs liés à switcher)