### PR TITLE
chore(server): ajout du job de clean organismes non fiables

### DIFF
--- a/server/src/jobs/cli.fiabilisation.js
+++ b/server/src/jobs/cli.fiabilisation.js
@@ -9,6 +9,7 @@ import { removeDossierApprenantsDuplicates } from "./fiabilisation/duplicates/do
 import { analyseFiabiliteDossierApprenantsRecus } from "./fiabilisation/dossiersApprenants/analyse-fiabilite-dossiers-apprenants-recus.js";
 import { createFiabilisationUaiSiretMapping } from "./fiabilisation/uai-siret/create-fiabilisation-uai-siret-mapping/index.js";
 import { updateDossiersApprenantWithFiabilisationUaiSiret } from "./fiabilisation/uai-siret/update-dossiers-apprenants-with-fiabilisation-uai-siret/index.js";
+import { cleanOrganismesNonFiables } from "./fiabilisation/uai-siret/clean-organismes-non-fiables/index.js";
 
 /**
  * Job d'identification des doublons dans les fichiers CSV de réseaux
@@ -108,6 +109,18 @@ cli
     runScript(async () => {
       return updateDossiersApprenantWithFiabilisationUaiSiret();
     }, "apply-fiabilisation-uai-siret");
+  });
+
+/**
+ * Job de suppression des organismes non fiables et déplacement des contributeurs & effectifs liés
+ */
+cli
+  .command("clean:organismes-non-fiables")
+  .description("Suppression des organismes non fiables et déplacement des contributeurs & effectifs liés")
+  .action(() => {
+    runScript(async () => {
+      return cleanOrganismesNonFiables();
+    }, "fiabilisation-clean-organismes-non-fiables");
   });
 
 cli.parse(process.argv);

--- a/server/src/jobs/fiabilisation/uai-siret/clean-organismes-non-fiables/index.js
+++ b/server/src/jobs/fiabilisation/uai-siret/clean-organismes-non-fiables/index.js
@@ -1,0 +1,178 @@
+import logger from "../../../../common/logger.js";
+import cliProgress from "cli-progress";
+import { effectifsDb, fiabilisationUaiSiretDb, organismesDb } from "../../../../common/model/collections.js";
+import { asyncForEach } from "../../../../common/utils/asyncUtils.js";
+import { findOrganismeByQuery } from "../../../../common/actions/organismes/organismes.actions.js";
+import { createJobEvent } from "../../../../common/actions/jobEvents.actions.js";
+
+const loadingBar = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
+const JOB_NAME = "fiabilisation-clean-organismes-non-fiables";
+
+/**
+ * Fonction de nettoyage des organismes non fiables du TdB
+ * Se base sur la collection fiabilisationUaiSiretDb contenant la liste des couples UAI - SIRET à fiabiliser
+ * Déplacement des contributeurs & effectifs liés puis suppression des organismes
+ */
+export const cleanOrganismesNonFiables = async () => {
+  logger.info("Nettoyage des organismes non fiables");
+
+  let nbOrganismesNonFiablesDansLeTdb = 0;
+  let nbOrganismesFiablesLieDansLeTdb = 0;
+  let nbEffectifsSwitches = 0;
+  let nbContributeursAjoutes = 0;
+
+  let nbOrganismesSupprimes = 0;
+
+  const allFiabilisationCouples = await fiabilisationUaiSiretDb().find().toArray();
+
+  logger.info(`Traitement de ${allFiabilisationCouples.length} couples dans la collection fiabilisation ...`);
+  loadingBar.start(allFiabilisationCouples.length, 0);
+
+  await asyncForEach(allFiabilisationCouples, async ({ uai, siret, uai_fiable, siret_fiable }) => {
+    try {
+      // On cherche dans le tdb la présence de l'organisme non fiable pour le couple uai-siret
+      const organismeNonFiable = await findOrganismeByQuery({ uai, siret });
+
+      if (organismeNonFiable) {
+        nbOrganismesNonFiablesDansLeTdb++;
+
+        // On cherche dans le tdb la présence de l'organisme fiable rattaché via pour le couple uai_fiable-siret_fiable
+        const organismeFiable = await findOrganismeByQuery({ uai: uai_fiable, siret: siret_fiable });
+
+        await createJobEvent({
+          jobname: JOB_NAME,
+          date: new Date(),
+          action: "organisme-non-fiable-found",
+          data: { organismeNonFiable, organismeFiable },
+        });
+
+        // Si un organisme fiable rattaché est trouvé on switch les effectifs et append les contributeurs
+        if (organismeFiable) {
+          nbOrganismesFiablesLieDansLeTdb++;
+          const modifiedEffectifsCount = await switchEffectifsBetweenOrganismes(
+            organismeNonFiable._id,
+            organismeFiable._id
+          );
+          nbEffectifsSwitches += modifiedEffectifsCount;
+
+          await createJobEvent({
+            jobname: JOB_NAME,
+            date: new Date(),
+            action: "organisme-fiable-switch-effectifs",
+            data: { organismeFiable, nbEffectifsMaj: modifiedEffectifsCount },
+          });
+
+          const modifiedContributeursCount = await appendContributeurFromOrganisme(
+            organismeFiable._id,
+            organismeNonFiable.contributeurs
+          );
+          nbContributeursAjoutes += modifiedContributeursCount;
+
+          await createJobEvent({
+            jobname: JOB_NAME,
+            date: new Date(),
+            action: "organisme-fiable-append-contributeurs",
+            data: { organismeFiable, nbContributeursAjoutes: modifiedContributeursCount },
+          });
+        }
+
+        // Suppression de l'organisme non fiable
+        await organismesDb().deleteOne({ _id: organismeNonFiable._id });
+        await createJobEvent({
+          jobname: JOB_NAME,
+          date: new Date(),
+          action: "organisme-non-fiable-supprime",
+          data: { organismeNonFiable },
+        });
+        nbOrganismesSupprimes++;
+      }
+
+      loadingBar.increment();
+    } catch (error) {
+      await createJobEvent({
+        jobname: JOB_NAME,
+        date: new Date(),
+        action: "clean-error",
+        data: { error },
+      });
+    }
+  });
+
+  loadingBar.stop();
+
+  // Log & stats
+  logger.info(`-> ${nbOrganismesNonFiablesDansLeTdb} organismes non fiables dans le TdB`);
+  logger.info(`-> ${nbOrganismesFiablesLieDansLeTdb} organismes fiables liés à un non fiable dans le TdB`);
+  logger.info(`-> ${nbEffectifsSwitches} effectifs switches entre organismes non fiables & fiables`);
+  logger.info(
+    `-> ${nbContributeursAjoutes} contributeurs ajoutes à un organisme fiable depuis un organisme non fiable`
+  );
+  logger.info(`-> ${nbOrganismesSupprimes} organismes non fiables supprimés du TdB`);
+
+  await createJobEvent({
+    jobname: JOB_NAME,
+    date: new Date(),
+    action: "finishing",
+    data: {
+      nbOrganismesNonFiablesDansLeTdb,
+      nbOrganismesFiablesLieDansLeTdb,
+      nbOrganismesSupprimes,
+    },
+  });
+};
+
+/**
+ * Méthode de MAJ de l'organismeId pour les effectifs d'un organismeId source
+ * Ne fait pas la MAJ pour un effectif déja existant sur la base de la clé d'unicité
+ * @param {*} organismeNonFiableId
+ * @param {*} organismeFiableId
+ * @returns
+ */
+const switchEffectifsBetweenOrganismes = async (organismeNonFiableId, organismeFiableId) => {
+  let updatedCount = 0;
+  const effectifsForOrganismeNonFiable = await effectifsDb().find({ organisme_id: organismeNonFiableId }).toArray();
+
+  await asyncForEach(effectifsForOrganismeNonFiable, async (currentEffectifNonFiable) => {
+    // Si l'effectif existe déja pour l'organisme fiable sur la base de la clé d'unicité on ne le transfère pas
+    const existantEffectif = await effectifsDb().count({
+      organisme_id: organismeFiableId,
+      annee_scolaire: currentEffectifNonFiable.annee_scolaire,
+      id_erp_apprenant: currentEffectifNonFiable.id_erp_apprenant,
+      "apprenant.nom": currentEffectifNonFiable.apprenant.nom,
+      "apprenant.prenom": currentEffectifNonFiable.apprenant.prenom,
+      "formation.cfd": currentEffectifNonFiable.formation.cfd,
+    });
+
+    if (existantEffectif === 0) {
+      // S'il n'existe pas déja on le transfère vers l'organisme fiable
+      await effectifsDb().updateOne(
+        { _id: currentEffectifNonFiable._id },
+        { $set: { organisme_id: organismeFiableId } }
+      );
+      updatedCount++;
+    }
+  });
+
+  return updatedCount;
+};
+
+/**
+ * Méthode d'ajout d'une liste de contributeurs à un organisme
+ * @param {*} organismeToUpdateId
+ * @param {*} contributeursToAppend
+ * @returns
+ */
+const appendContributeurFromOrganisme = async (organismeToUpdateId, contributeursToAppend = []) => {
+  const updated = await organismesDb().updateOne(
+    { _id: organismeToUpdateId },
+    {
+      $addToSet: {
+        // https://www.mongodb.com/docs/manual/reference/operator/update/addToSet/#value-to-add-is-an-array
+        etablissement_reseaux: { $contributeurs: contributeursToAppend },
+      },
+    },
+    { returnDocument: "after" }
+  );
+
+  return updated.modifiedCount;
+};


### PR DESCRIPTION
Ajout du script de clean des organismes non fiables.

Pour chaque organisme non fiable, on switch ses effectifs sur l'organisme fiable rattaché, on append les contributeurs s'il y en a des nouveaux et enfin on le supprime.

Testé localement.
J'ai mis pas mal de logs pour bien identifier tout ce qui se passe.
