### PR TITLE
fix(server): missing & empty historique_statut

### DIFF
--- a/server/src/common/actions/engine/engine.actions.js
+++ b/server/src/common/actions/engine/engine.actions.js
@@ -4,6 +4,7 @@ import { getCpInfo } from "../../apis/apiTablesCorrespondances.js";
 import { ACADEMIES, REGIONS, DEPARTEMENTS } from "../../constants/territoiresConstants.js";
 import { dateFormatter, dateStringToLuxon, jsDateToLuxon } from "../../utils/formatterUtils.js";
 import { telephoneConverter } from "../../utils/validationsUtils/frenchTelephoneNumber.js";
+import { buildNewHistoriqueStatutApprenant } from "../dossiersApprenants.actions.js";
 import {
   buildEffectif,
   findEffectifById,
@@ -347,6 +348,14 @@ export const runEngine = async ({ effectifData, lockEffectif = true }, organisme
     // Gestion des maj d'effectif
     if (found) {
       effectifUpdatedId = found._id;
+
+      // Update de historique
+      effectif.apprenant.historique_statut = buildNewHistoriqueStatutApprenant(
+        found.apprenant.historique_statut,
+        effectifData.apprenant?.historique_statut[0]?.valeur_statut,
+        effectifData.apprenant?.historique_statut[0]?.date_statut
+      );
+
       if (lockEffectif) {
         await updateEffectifAndLock(effectifUpdatedId, effectif);
       } else {

--- a/server/src/http/routes/specific.routes/dossiers-apprenants.routes.js
+++ b/server/src/http/routes/specific.routes/dossiers-apprenants.routes.js
@@ -140,9 +140,16 @@ export default () => {
                 ? currentDossierApprenant.periode_formation.split("-").map(Number)
                 : [],
               source: user.username,
+              historique_statut_apprenant: [
+                {
+                  valeur_statut: currentDossierApprenant.statut_apprenant,
+                  date_statut: new Date(currentDossierApprenant.date_metier_mise_a_jour_statut),
+                  date_reception: new Date(),
+                },
+              ],
             };
 
-            // Structure effectif & organisme from item
+            // Construction d'un historique à partir du statut et de la date_metier_mise_a_jour_statut
             const effectifData = structureEffectifFromDossierApprenant(dossierApprenantItem);
             const organismeData = await structureOrganismeFromDossierApprenant(dossierApprenantItem);
 


### PR DESCRIPTION
Fix des historiques des dossiersApprenantsMigration et effectifs qui sont vides quand provenant de l'API.

3 Cas identifiés : 

- Création d'un dossier + effectif simple : on set l'historique avec un élement dans le tableau
- Maj du couple statut / date métier d'un dossier : on fait la maj dans l'update du dossierApprenantMigration
- Maj du couple statut / date métier d'un effectif : on fait la maj dans l'engine

