### PR TITLE
fix(server): hydrate new reseaux anomalie on update dossiers

### DIFF
--- a/server/src/common/actions/dossiersApprenants.actions.js
+++ b/server/src/common/actions/dossiersApprenants.actions.js
@@ -204,6 +204,8 @@ export const buildNewHistoriqueStatutApprenant = (
   updated_statut_apprenant,
   updated_date_metier_mise_a_jour_statut
 ) => {
+  if (!updated_statut_apprenant) return historique_statut_apprenant_existant;
+
   let newHistoriqueStatutApprenant = historique_statut_apprenant_existant;
 
   // Vérification si le nouveau statut existe déja dans l'historique actuel

--- a/server/src/jobs/hydrate/reseaux/hydrate-reseaux.actions.js
+++ b/server/src/jobs/hydrate/reseaux/hydrate-reseaux.actions.js
@@ -15,10 +15,20 @@ export const updateDossiersApprenantsNetworksIfNeeded = async (organisme, reseau
     .toArray();
 
   await asyncForEach(dossiersApprenantsForOrganismeWithoutThisNetwork, async (dossierToUpdate) => {
-    await updateDossierApprenant(dossierToUpdate._id, {
-      ...dossierToUpdate,
-      etablissement_reseaux: [...dossierToUpdate.etablissement_reseaux, reseau],
-    });
+    try {
+      await updateDossierApprenant(dossierToUpdate._id, {
+        ...dossierToUpdate,
+        etablissement_reseaux: [...dossierToUpdate.etablissement_reseaux, reseau],
+      });
+    } catch (err) {
+      // Log error
+      await createJobEvent({
+        jobname: JOBNAME,
+        date: new Date(),
+        action: "update-dossierApprenant-error",
+        data: { dossierToUpdate },
+      });
+    }
 
     // Log update
     await createJobEvent({


### PR DESCRIPTION
Correction d'une anomalie lors de l'update de dossiers depuis l'hydrate des réseaux. 

Depuis l'hydrate l'objet fourni pour l'update n'a pas de statut (pas nécessaire) et l'historique était construit avec un élément vide, je garde l'historique initial désormais si aucun statut n'est fourni.
