### PR TITLE
feat(ui): add info réseau & adresse on organisme Info

### DIFF
--- a/ui/modules/mon-espace/landing/LandingOrganisme/components/OrganismeInfo.jsx
+++ b/ui/modules/mon-espace/landing/LandingOrganisme/components/OrganismeInfo.jsx
@@ -37,8 +37,20 @@ export default function OrganismeInfo() {
     );
   }
 
-  const { _id: organismeId, uai, nature, natureValidityWarning, sirets, ferme, enseigne, raison_sociale } = organisme;
+  const {
+    _id: organismeId,
+    uai,
+    nature,
+    natureValidityWarning,
+    sirets,
+    ferme,
+    enseigne,
+    raison_sociale,
+    reseaux,
+  } = organisme;
   const siretToDisplay = formatSiretSplitted(sirets[0]);
+  // eslint-disable-next-line no-undef
+  const uniqReseaux = [...new Set(reseaux)];
 
   return (
     <>
@@ -56,6 +68,7 @@ export default function OrganismeInfo() {
           <Heading color="grey.800" fontSize="1.6rem" as="h3" mb={2}>
             {enseigne || raison_sociale}
           </Heading>
+
           <HStack fontSize="epsilon" textColor="grey.800" spacing="2w">
             <HStack>
               <Text>UAI :</Text>
@@ -86,6 +99,21 @@ export default function OrganismeInfo() {
               {natureValidityWarning && <NatureOrganismeDeFormationWarning />}
             </HStack>
           </HStack>
+
+          {uniqReseaux?.length > 0 && (
+            <HStack fontSize="epsilon" textColor="grey.800" mt={4} spacing="2w">
+              <HStack>
+                <Text>
+                  Cet organisme fait partie
+                  <>
+                    {uniqReseaux?.length == 1
+                      ? ` du réseau ${(<b>uniqReseaux[0]</b>)}`
+                      : ` des réseaux </b>${uniqReseaux.join(", ")}</b>`}
+                  </>
+                </Text>
+              </HStack>
+            </HStack>
+          )}
 
           {ferme && (
             <Ribbons variant="alert" mt={10}>

--- a/ui/modules/mon-espace/landing/LandingOrganisme/components/OrganismeInfo.jsx
+++ b/ui/modules/mon-espace/landing/LandingOrganisme/components/OrganismeInfo.jsx
@@ -47,10 +47,35 @@ export default function OrganismeInfo() {
     enseigne,
     raison_sociale,
     reseaux,
+    adresse,
   } = organisme;
+
   const siretToDisplay = formatSiretSplitted(sirets[0]);
+
+  // TODO Fix coté back
   // eslint-disable-next-line no-undef
   const uniqReseaux = [...new Set(reseaux)];
+
+  const getOrganismeReseauxAndAdresseText = (reseaux, adresseComplete) => {
+    if (reseaux) {
+      return (
+        <>
+          Cet organisme fait partie du réseau <strong>{reseaux[0]}</strong>{" "}
+          {reseaux.slice(1, reseaux.length)?.map((item) => (
+            <>
+              et du réseau <strong>{item}</strong>
+            </>
+          ))}
+          . {adresseComplete ? `Sa domiciliation est ${adresseComplete}.` : ""}
+        </>
+      );
+    } else {
+      if (adresseComplete) {
+        return <>La domiciliation de cet organisme est {adresseComplete}</>;
+      }
+      return null;
+    }
+  };
 
   return (
     <>
@@ -103,14 +128,7 @@ export default function OrganismeInfo() {
           {uniqReseaux?.length > 0 && (
             <HStack fontSize="epsilon" textColor="grey.800" mt={4} spacing="2w">
               <HStack>
-                <Text>
-                  Cet organisme fait partie
-                  <>
-                    {uniqReseaux?.length == 1
-                      ? ` du réseau ${(<b>uniqReseaux[0]</b>)}`
-                      : ` des réseaux </b>${uniqReseaux.join(", ")}</b>`}
-                  </>
-                </Text>
+                <Text>{getOrganismeReseauxAndAdresseText(uniqReseaux, adresse?.complete)}</Text>
               </HStack>
             </HStack>
           )}


### PR DESCRIPTION
Rajout des l'info des réseaux d'un organisme pour la recette.

Anomalie constatée sur l'array des réseaux qui peut contenir des doublons, à fix : https://github.com/mission-apprentissage/flux-retour-cfas/issues/2477

