### PR TITLE
fix(server): handle organismes without siret in post

### DIFF
--- a/server/src/common/actions/dossiersApprenants.actions.js
+++ b/server/src/common/actions/dossiersApprenants.actions.js
@@ -6,6 +6,7 @@ import {
   validateDossiersApprenantsMigration,
 } from "../model/next.toKeep.models/dossiersApprenantsMigration.model.js";
 import { escapeRegExp } from "../utils/regexUtils.js";
+import { findOrganismeById } from "./organismes/organismes.actions.js";
 
 /**
  * Méthode qui ajoute un dossierApprenant en base
@@ -21,7 +22,7 @@ export const insertDossierApprenant = async (data) => {
  * Méthode qui construit un dossierApprenant et toutes les données liées
  * @param {*} param0
  */
-export const structureDossierApprenant = ({
+export const structureDossierApprenant = async ({
   organisme_id,
   nom_apprenant,
   prenom_apprenant,
@@ -41,6 +42,12 @@ export const structureDossierApprenant = ({
   //     date_reception: new Date(),
   //   },
   // ],
+
+  // Si on nous fourni un organisme_id existant on récupère le siret pour la structure
+  if (organisme_id) {
+    const organismeExistant = await findOrganismeById(organisme_id);
+    siret_etablissement = organismeExistant?.siret;
+  }
 
   return {
     ...defaultValuesDossiersApprenantsMigration(),

--- a/server/src/common/actions/engine/engine.organismes.utils.js
+++ b/server/src/common/actions/engine/engine.organismes.utils.js
@@ -6,7 +6,7 @@ import { fiabilisationUaiSiretDb } from "../../model/collections.js";
  * @param {*} {param0}
  * @returns
  */
-export const mapFiabilizedOrganismeUaiSiretCouple = async ({ uai, siret }) => {
+export const mapFiabilizedOrganismeUaiSiretCouple = async ({ uai, siret = null }) => {
   // Construction d'un tableau de mapping à partir de la collection et du tableau mapping
   const fiabilisationUaiSiretFromCollection = await fiabilisationUaiSiretDb().find().toArray();
   const fiabilisationMappings = [...fiabilisationUaiSiretFromCollection, ...FIABILISATION_MAPPINGS];

--- a/server/src/common/actions/organismes/organismes.actions.js
+++ b/server/src/common/actions/organismes/organismes.actions.js
@@ -175,13 +175,15 @@ export const insertOrganisme = async (data) => {
 export const structureOrganismeFromDossierApprenant = async (dossierApprenant) => {
   const { uai_etablissement, siret_etablissement, nom_etablissement } = dossierApprenant;
 
-  const adresseForOrganisme = await buildAdresseForOrganisme({ uai: uai_etablissement, sirets: [siret_etablissement] });
+  const adresseForOrganisme = siret_etablissement
+    ? await buildAdresseForOrganisme({ uai: uai_etablissement, sirets: [siret_etablissement] })
+    : {};
 
   return {
     ...defaultValuesOrganisme(),
     uai: uai_etablissement,
     siret: siret_etablissement,
-    sirets: [siret_etablissement],
+    sirets: siret_etablissement ? [siret_etablissement] : [],
     ...adresseForOrganisme,
     ...(nom_etablissement
       ? { nom: nom_etablissement.trim(), nom_tokenized: buildTokenizedString(nom_etablissement.trim(), 4) }

--- a/server/src/http/routes/specific.routes/dossiers-apprenants.routes.js
+++ b/server/src/http/routes/specific.routes/dossiers-apprenants.routes.js
@@ -160,7 +160,7 @@ export default () => {
             // TODO à supprimer une fois que la collection DossierApprenantMigration sera useless
             // TODO Store userEvents
             if (organisme.createdId || organisme.foundId) {
-              const structuredDossierApprenant = structureDossierApprenant({
+              const structuredDossierApprenant = await structureDossierApprenant({
                 ...dossierApprenantItem,
                 organisme_id: organisme.createdId || organisme.foundId, // Update sur l'organisme ajouté ou maj,
               });


### PR DESCRIPTION
Correctif d'un cas bloquant lorsqu'on a une transmission d'un organisme qui ne fournit pas de siret : 

- Lors du structureDossierApprenant je récupère le siret de l'organisme si il a été fourni
- J'ajoute la gestion des siret null dans la fonction de search dans le mapping de fiabilisation
- Je gère les sirets non fournis dans le structureOrganismeFromDossierApprenant 


TODO : Update les tests unitaires pour tester : 

- [ ] L'envoi d'un dossier avec un siret_etablissement non fourni, pour un uai_etablissement existant dans la table de fiabilisation -> on doit s'attendre à ce que la donnée passe bien et l'organisme soit créé avec le siret de la fiab.
- [ ] L'envoi d'un dossier avec un siret_etablissement non fourni, pour un uai_etablissement existant dans la table de fiabilisation et l'organisme déja existant -> on doit s'attendre à ce que la donnée passe bien et l'organisme soit retrouvé.
- [ ] L'envoi d'un dossier avec un siret_etablissement non fourni, pour un uai_etablissement non existant dans la table de fiabilisation -> on doit s'attendre à une erreur.

Une PR va venir s'ammender à ça pour gérer le 3e test unitaire et au lieu de throw une erreur, stocker dans la collection de fiabilisation ces cas particuliers pour analyse coté métier.
