### PR TITLE
Feat/cli action duplicates identify siren

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -23,7 +23,8 @@ services:
         - NEXT_PUBLIC_METABASE_URL=https://localhost/metabase
         - NEXT_PUBLIC_METABASE_SECRET_KEY=
         - SKIP_PREFLIGHT_CHECK=true
-        - NEXT_PUBLIC_SENTRY_DSN=
+    environment:
+      - NEXT_PUBLIC_SENTRY_DSN=
 
   server:
     build:
@@ -44,6 +45,7 @@ services:
       - FLUX_RETOUR_CFAS_AUTH_ACTIVATION_JWT_SECRET=secret
       - FLUX_RETOUR_CFAS_AUTH_API_TOKEN_JWT_SECRET=secret
       - FLUX_RETOUR_CFAS_AUTH_PASSWORD_JWT_SECRET=secret
+      - FLUX_RETOUR_CFAS_SENTRY_DSN=
 
     depends_on:
       - smtp

--- a/server/src/jobs/cli.fiabilisation.js
+++ b/server/src/jobs/cli.fiabilisation.js
@@ -10,6 +10,7 @@ import { analyseFiabiliteDossierApprenantsRecus } from "./fiabilisation/dossiers
 import { updateFiabilisationUaiSiretAFiabiliser } from "./fiabilisation/uai-siret/update-fiabilisation-type/index.js";
 import { buildFiabilisationUaiSiret } from "./fiabilisation/uai-siret/build-fiabilisation/index.js";
 import { applyFiabilisationUaiSiret } from "./fiabilisation/uai-siret/apply-fiabilisation/index.js";
+import { identifySirenDuplicates } from "./fiabilisation/duplicates/dossiersApprenants-duplicates-siren/identify.js";
 
 // /**
 //  * Job de suppression des organismes non fiables et déplacement des contributeurs & effectifs liés
@@ -108,6 +109,18 @@ cli
     runScript(async ({ effectifs }) => {
       return identifyCfdDuplicates(effectifs);
     }, "duplicates-identify-cfd");
+  });
+
+/**
+ * Job d'identification des doublons par siren sur les dossiersApprenants
+ */
+cli
+  .command("duplicates:identify-siren")
+  .description("Identification des doublons par siren sur les dossiersApprenants")
+  .action(() => {
+    runScript(async ({ effectifs }) => {
+      return identifySirenDuplicates(effectifs);
+    }, "duplicates-identify-siren");
   });
 
 /**

--- a/server/src/jobs/fiabilisation/duplicates/dossiersApprenants-duplicates-siren/identify.js
+++ b/server/src/jobs/fiabilisation/duplicates/dossiersApprenants-duplicates-siren/identify.js
@@ -1,0 +1,22 @@
+import cliProgress from "cli-progress";
+import logger from "../../../../common/logger.js";
+import { DUPLICATE_TYPE_CODES, getDuplicatesList } from "../dossiersApprenants.duplicates.actions.js";
+
+const loadingBar = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
+
+/**
+ * Job d'identification des doublons de SIRENs
+ * Construit une collection dossiersApprenantsDoublonsSiren contenant les doublons
+ */
+export const identifySirenDuplicates = async () => {
+  logger.info("Run identification dossiersApprenants with duplicates siren...");
+
+  // Identify all duplicates
+  const duplicates = await getDuplicatesList(DUPLICATE_TYPE_CODES.siren.code, {}, { allowDiskUse: true });
+  loadingBar.start(duplicates.length, 0);
+
+  // FIXME non testé
+
+  loadingBar.stop();
+  logger.info("End identification DossierApprenant with duplicates siren !");
+};

--- a/server/src/jobs/fiabilisation/duplicates/dossiersApprenants.duplicates.actions.js
+++ b/server/src/jobs/fiabilisation/duplicates/dossiersApprenants.duplicates.actions.js
@@ -3,6 +3,7 @@ import { dossiersApprenantsMigrationDb } from "../../../common/model/collections
 export const DUPLICATE_COLLECTION_NAMES = {
   dossiersApprenantsDoublonsUais: "dossiersApprenantsDoublonsUais",
   dossiersApprenantsDoublonsCfd: "dossiersApprenantsDoublonsCfd",
+  dossiersApprenantsDoublonsSiren: "dossiersApprenantsDoublonsSiren",
   dossiersApprenantsDuplicatesRemoved: "dossiersApprenantsDuplicatesRemoved",
 };
 
@@ -29,6 +30,10 @@ export const DUPLICATE_TYPE_CODES = {
   uai_etablissement: {
     name: "Uai",
     code: "5",
+  },
+  siren: {
+    name: "Siren",
+    code: "6",
   },
 };
 
@@ -136,6 +141,24 @@ const findDossiersApprenantsDuplicates = async (
         etablissement_num_region: { $addToSet: "$etablissement_num_region" },
         // Ajout des différents nom_apprenant en doublon potentiel
         nom_apprenants: { $addToSet: "$nom_apprenant" },
+        // ajout des différents statut_apprenant
+        statut_apprenants: { $addToSet: "$historique_statut_apprenant.valeur_statut" },
+        count: { $sum: 1 },
+      };
+      break;
+
+    case DUPLICATE_TYPE_CODES.siren.code:
+      unicityQueryGroup = {
+        _id: {
+          nom_apprenant: "$nom_apprenant",
+          prenom_apprenant: "$prenom_apprenant",
+          date_de_naissance_apprenant: "$date_de_naissance_apprenant",
+          siren: { $substrCP: ["$siret_etablissement", 0, 9] },
+        },
+        // Ajout des ids unique de chaque doublons
+        duplicatesIds: { $addToSet: "$_id" },
+        // Ajout des différents siret en doublon potentiel
+        sirets: { $addToSet: "$siret_etablissement" },
         // ajout des différents statut_apprenant
         statut_apprenants: { $addToSet: "$historique_statut_apprenant.valeur_statut" },
         count: { $sum: 1 },


### PR DESCRIPTION
Suite à la requête de @sbenfares, voici 2 requêtes Mongo pour obtenir les doublons d'un apprenant sur la base d'un SIREN commun :
1. identifier les doublons nom / prénom / date de naissance de l'apprenant
1. identifier les doublons id_erp_apprenant

```js
// liste des doublons de siren par nom, prénom, date
[
  {
    "$group": {
      "_id": {
        "nom_apprenant": "$nom_apprenant",
        "prenom_apprenant": "$prenom_apprenant",
        "date_de_naissance_apprenant": "$date_de_naissance_apprenant",
        "siren": { "$substrCP": ["$siret_etablissement", 0, 9] }
      },
      "duplicateSirets": { $addToSet: "$siret_etablissement" },
      "duplicatesIds": { $addToSet: "$_id" },
    }
  },
  {
    $match: {
      "duplicateSirets.1": {$exists: true}
    }
  },
  {
    $project: {
      _id: 0,
      "nom_apprenant": "$_id.nom_apprenant",
      "prenom_apprenant": "$_id.prenom_apprenant",
      "date_de_naissance_apprenant": "$_id.date_de_naissance_apprenant",
      "siren": "$_id.siren",
      "duplicateSirets": "$duplicateSirets"
      "duplicatesIds": "$duplicatesIds",
    }
  }
]

// liste des doublons de siren par id_erp_apprenant
[
  {
    "$group": {
      "_id": {
        "id_erp_apprenant": "$id_erp_apprenant",
        "siren": { "$substrCP": ["$siret_etablissement", 0, 9] }
      },
      "duplicateSirets": { $addToSet: "$siret_etablissement" },
      "duplicatesIds": { $addToSet: "$_id" },
    }
  },
  {
    $match: {
      "duplicateSirets.1": {$exists: true}
    }
  },
  {
    $project: {
      _id: 0,
      "id_erp_apprenant": "$_id.id_erp_apprenant",
      "siren": "$_id.siren",
      "duplicateSirets": "$duplicateSirets"
      "duplicatesIds": "$duplicatesIds",
    }
  }
]
```

Pour chaque ligne, on va avoir l'apprenant (nom+prénom+date de naissance OU id erp), le siren, et les sirets et ids apprenant en doublon.
Est-ce bien ce que tu attendais @sbenfares ?

Quelques remarques :
- J'ai testé ces requêtes sur le metabase de recette et ça a l'air de fonctionner.
- Je n'ai pas pu tester en local car ma table *dossiersApprenantsMigration* est vide. Est-ce qu'on a des dumps anonymisés / données de test ?
- J'ai tenté de commencer à intégrer une commande dans le CLI fiabilisation car le fonctionnement paraît similaire au job *duplicates:identify-cfd* qui identifie des doublons. Mais ce dernier est s'occupe aussi de calculer plein d'indicateurs (nbApprentis, nbRupturants, etc) en plus d'enregistrer les résultats dans une autre collection. Donc je ne suis pas sûr de ce qu'il faut que je fasse.

J'ai mis cette PR en WIP. On reparle de tout ça la semaine prochaine. :)

PS: cette PR est basée sur #2505, mais il ne faut pas s'inquiéter. :grin: 