### PR TITLE
Fix/create admin user

### DIFF
--- a/server/migrations/20230209000000-fix-admin-permissions.js
+++ b/server/migrations/20230209000000-fix-admin-permissions.js
@@ -1,0 +1,57 @@
+export const up = async (db) => {
+  // also define is_cross_organismes to true when is_admin is true
+  await db.collection("usersMigration").updateMany(
+    {
+      is_admin: true,
+      is_cross_organismes: false,
+    },
+    {
+      $set: {
+        is_cross_organismes: true,
+      },
+    }
+  );
+
+  // add a permission entry for admin users without one
+  const usersWithoutPermissions = await db
+    .collection("usersMigration")
+    .aggregate([
+      {
+        $match: {
+          is_admin: true,
+        },
+      },
+      {
+        $lookup: {
+          from: "permissions",
+          localField: "email",
+          foreignField: "userEmail",
+          as: "permissions",
+        },
+      },
+      {
+        $match: {
+          "permissions.0": { $exists: false },
+        },
+      },
+    ])
+    .toArray();
+
+  const adminRole = await db.collection("roles").findOne({ name: "organisme.admin" });
+
+  if (usersWithoutPermissions.length > 0) {
+    await db.collection("permissions").insertMany(
+      usersWithoutPermissions.map((user) => ({
+        custom_acl: [],
+        created_at: new Date(),
+        updated_at: new Date(),
+        role: adminRole._id,
+        organisme_id: null,
+        userEmail: user.email,
+        pending: false,
+      }))
+    );
+  }
+};
+
+export const down = async () => {};

--- a/server/src/common/actions/roles.actions.js
+++ b/server/src/common/actions/roles.actions.js
@@ -73,3 +73,11 @@ export const hasAclsByRoleId = async (id, acl) => {
 
   return acl.every((page) => roleDb.acl.includes(page));
 };
+
+export const getRoleByName = async (name, projection = {}) => {
+  const role = await rolesDb().findOne({ name }, { projection });
+  if (!role) {
+    throw new Error(`Role ${name} doesn't exist`);
+  }
+  return role;
+};

--- a/server/src/common/actions/users.actions.js
+++ b/server/src/common/actions/users.actions.js
@@ -157,7 +157,7 @@ export const getUser = async (email) => {
  * @returns
  */
 export const getUserById = async (_id, projection = {}) => {
-  const user = await usersMigrationDb().findOne({ _id }, { projection });
+  const user = await usersMigrationDb().findOne({ _id: ObjectId(_id) }, { projection });
 
   if (!user) {
     throw new Error("Unable to find user");

--- a/server/src/common/actions/users.actions.js
+++ b/server/src/common/actions/users.actions.js
@@ -209,6 +209,7 @@ export const updateUser = async (_id, data) => {
     {
       $set: validateUser({
         email: user.email,
+        is_cross_organismes: user.is_cross_organismes,
         ...data,
       }),
     },

--- a/server/src/common/actions/users.afterCreate.actions.js
+++ b/server/src/common/actions/users.afterCreate.actions.js
@@ -12,6 +12,9 @@ import {
 import { updateMainOrganismeUser } from "./users.actions.js";
 import { NATURE_ORGANISME_DE_FORMATION } from "../utils/validationsUtils/organisme-de-formation/nature.js";
 import { uniq } from "lodash-es";
+import { permissionsDb } from "../model/collections.js";
+import { getRoleByName } from "./roles.actions.js";
+import { defaultValuesPermission, validatePermission } from "../model/permissions.model.js";
 
 /**
  * Méthode d'ajouts des permissions en fonction de l'utilisateur
@@ -172,5 +175,33 @@ export const userAfterCreate = async ({
         }
       }
     }
+  }
+};
+
+/**
+ * Met à jour la permission `organisme.admin` d'un utilisateur selon qu'il est admin ou non.
+ *
+ * @param {*} user
+ * @returns
+ */
+export const refreshUserPermissions = async (user) => {
+  const adminRole = await getRoleByName("organisme.admin");
+
+  if (user.is_admin) {
+    await permissionsDb().insertOne(
+      validatePermission({
+        ...defaultValuesPermission(),
+        organisme_id: null,
+        userEmail: user.email.toLowerCase(),
+        role: adminRole._id,
+        pending: false,
+      })
+    );
+  } else {
+    await permissionsDb().deleteOne({
+      organisme_id: null,
+      userEmail: user.email,
+      role: adminRole._id,
+    });
   }
 };

--- a/server/src/http/routes/admin.routes/users.routes.js
+++ b/server/src/http/routes/admin.routes/users.routes.js
@@ -150,10 +150,6 @@ export default ({ mailer }) => {
       const options = body.options;
 
       await updateUser(userid, {
-        is_cross_organismes:
-          options.permissions.is_cross_organismes !== undefined
-            ? !!options.permissions.is_cross_organismes
-            : !!options.permissions.is_admin,
         is_admin: options.permissions.is_admin,
         email: options.email,
         prenom: options.prenom,


### PR DESCRIPTION
~Encore basé sur #2505. Je refais un rebase après merge.~

Tentative pour corriger les permissions d'un administrateur nouvellement créé depuis l'UI.
Contrairement à un admin créé depuis la CLI, l'UI n'ajoute pas les permissions automatiquement.

Les changements :
- le champ `is_cross_organismes` est mis à true si `is_admin`, car non envoyé depuis l'UI (j'avais cru voir une checkbox côté UI mercredi donc soit elle a été supprimée, soit j'ai louché :stuck_out_tongue_closed_eyes: ) 
- le champ `account_status` passe à `FORCE_RESET_PASSWORD` pour ne pas obliger l'utilisateur à renseigner d'autres infos à la connexion. Infos sur son organisme (qu'il n'a pas) si j'ai bien compris.
- la fonctione `userAfterCreate()` est appelée pour créer des permissions. Ici une seule entrée dans la collection permissions.

Avec cette PR, un administrateur créé peut accéder à la partie administration, mais je n'ai pas fait d'autres tests.

Voici un petit état des lieux de l'appel des fonctions `createUser` et `userAfterCreate`.
En vert, l'appel qui a été ajouté.
Est-ce qu'il faudrait appeler `userAfterCreate` après chaque appel à `createUser` ?

![image](https://user-images.githubusercontent.com/8938024/216675008-ea6e3b45-3203-49f5-b487-e711bf5196d3.png)
