### PR TITLE
fix: fix error on random sirets not following Luhn algorithm 

### DIFF
--- a/server/src/common/utils/validationUtils.js
+++ b/server/src/common/utils/validationUtils.js
@@ -20,10 +20,16 @@ export function siretSchema() {
   return Joi.string()
     .regex(/^[0-9]{14}$/)
     .creditCard()
-    .error(
-      (errors) =>
-        new Error(`Error: schema not valid : ValidationError: ${errors[0].local.key} must follow Luhn algorithm`)
-    );
+    .error((errors) => {
+      const error = errors[0].local;
+      return new Error(
+        error.code === "string.base"
+          ? `Error: schema not valid : ValidationError: ${error.key} must be a string`
+          : error.value
+          ? `Error: schema not valid : ValidationError: ${error.key} must follow Luhn algorithm`
+          : `Error: schema not valid : ValidationError: empty ${error.key}`
+      );
+    });
 }
 // const UAI_REGEX = /^[0-9_]{7}[a-zA-Z]{1}$/;
 export function uaiSchema() {

--- a/server/tests/data/randomizedSample.js
+++ b/server/tests/data/randomizedSample.js
@@ -11,7 +11,14 @@ const getRandomIne = () => new RandExp(/^[0-9]{9}[A-Z]{2}$/).gen().toUpperCase()
 export const getRandomFormationCfd = () => new RandExp(/^[0-9]{8}$/).gen().toUpperCase();
 const getRandomRncpFormation = () => `RNCP${new RandExp(/^[0-9]{5}$/).gen()}`;
 export const getRandomUaiEtablissement = () => new RandExp(/^[0-9]{7}[A-Z]{1}$/).gen().toUpperCase();
-export const getRandomSiretEtablissement = () => new RandExp(/^[0-9]{14}$/).gen().toUpperCase(); // TODO: this doesn't follow the luhn algorithm. To fix.
+export const getRandomSiretEtablissement = () =>
+  faker.helpers.arrayElement([
+    "41461021200014", // CENTR FORMATION TECHNICIENS AGRICOLES
+    "77568013501089", // etablissement fermé
+    "77568013501139", // ASSOCIATION POUR LA PROMOTION SOCIALE ET LA FORMATION PROFESSIONNELLE DANS LES TRANSPORTS ROUTIERS
+    "77937827200016", // ASSOC FAMIL GEST DU L.E.A.P. ST SORLIN
+    "78354361400029", // OGEC ST LUC CAMBRAI
+  ]);
 export const getSampleSiretEtablissement = () => "13002526500013";
 const getRandomStatutApprenant = () => faker.helpers.arrayElement(Object.values(CODES_STATUT_APPRENANT));
 const getRandomNature = () =>
@@ -39,9 +46,9 @@ const getRandomAnneeFormation = () => faker.helpers.arrayElement([0, 1, 2, 3]);
 export const getRandomAnneeScolaire = () => {
   const currentYear = new Date().getFullYear();
   const anneeScolaire = faker.helpers.arrayElement([
-    [currentYear - 1, currentYear], // [2020, 2021]
-    [currentYear, currentYear + 1], // [2021, 2022]
-    [currentYear + 1, currentYear + 2], // [2022, 2023]
+    [currentYear - 1, currentYear],
+    [currentYear, currentYear + 1],
+    [currentYear + 1, currentYear + 2],
   ]);
   return anneeScolaire.join("-");
 };


### PR DESCRIPTION
une petite PR pour fixer une erreur récurrente dans les tests concernant le format du SIRET + amélioration du message d'erreur affichée.
Les sirets utilisés sont les memes que dans le repertoire tests/data