### PR TITLE
feat: deploiement automatique recette

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -1,0 +1,53 @@
+name: Deployment subworkflow
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: The environment to deploy to
+        type: string
+        required: true
+      server_ip:
+        description: The targeted server
+        type: string
+        required: true
+      user:
+        description: The server user to connect
+        type: string
+        required: true
+    secrets:
+      SSH_PRIVATE_KEY:
+        description: SSH private key
+        required: true
+      SSH_KNOWN_HOSTS:
+        description: SSH known hosts list
+        required: true
+    outputs:
+      status:
+        description: Whether deployment succeeded or not
+        value: ${{ jobs.deploy.outputs.status }}
+jobs:
+  deploy:
+    name: Deploy on ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          name: github_actions
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+          config: |
+            Host ${{inputs.server_ip}}
+              HostName ${{inputs.server_ip}}
+              User ${{inputs.user}}
+              IdentityFile ~/.ssh/github_actions
+
+      - name: Run playbook
+        run: |
+          bash .infra/scripts/deploy-app.sh ${{ inputs.environment }}

--- a/.github/workflows/release-recette.yml
+++ b/.github/workflows/release-recette.yml
@@ -1,7 +1,7 @@
 name: Deploy on recette
 on:
   push:
-    branches: [master, sgt/feat/deploy-recette]
+    branches: [master]
 
 jobs:
   tests:

--- a/.github/workflows/release-recette.yml
+++ b/.github/workflows/release-recette.yml
@@ -1,0 +1,23 @@
+name: Deploy on recette
+on:
+  push:
+    branches: [master, sgt/feat/deploy-recette]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - run: make ci
+
+  deploy:
+    needs: ["tests"]
+    uses: "./.github/workflows/_deploy.yml"
+    with:
+      environment: recette
+      server_ip: 146.59.226.69
+      user: sven
+    secrets:
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}


### PR DESCRIPTION
cette PR déploie automatiquement sur recette quand un nouveau commit est pushé dans master. La clé SSH utilisé est pour l'instant la mienne, mais on peut imaginer la mettre à jour plus tard pour utiliser un compte dédié.

Et voici un exemple de workflow run: https://github.com/mission-apprentissage/flux-retour-cfas/actions/runs/4135164772/jobs/7147352096

je ferais une PR dédiée pour mettre a jour le workflow de deploiement en prod
