### PR TITLE
feat: ajout info progression upload

### DIFF
--- a/server/src/http/routes/specific.routes/server-events.routes.js
+++ b/server/src/http/routes/specific.routes/server-events.routes.js
@@ -1,0 +1,39 @@
+import express from "express";
+import { v4 as uuidv4 } from "uuid";
+
+let clients = [];
+
+export function sendServerEventsForUser(userId, message) {
+  clients
+    .filter((client) => client.userId.toString() === userId.toString())
+    .map((client) => {
+      client.response.write(`data: ${JSON.stringify(message)}\n\n`);
+    });
+}
+
+export default () => {
+  const router = express.Router();
+  router.get("/", function eventsHandler(req, res) {
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      Connection: "keep-alive",
+      "Cache-Control": "no-cache",
+    });
+    req.id = uuidv4();
+
+    const userId = req.user._id;
+
+    clients.push({
+      userId: userId,
+      requestId: req.id,
+      response: res,
+    });
+
+    req.on("close", () => {
+      console.log(`${userId} Connection closed`);
+      clients = clients.filter((client) => client.requestId !== req.id);
+    });
+  });
+
+  return router;
+};

--- a/server/src/http/server.js
+++ b/server/src/http/server.js
@@ -25,6 +25,7 @@ import organismesRouter from "./routes/specific.routes/organismes.routes.js";
 import formationRouter from "./routes/specific.routes/old/formations.route.js";
 import indicateursNationalRouter from "./routes/specific.routes/indicateurs-national.routes.js";
 import indicateursRouter from "./routes/specific.routes/indicateurs.routes.js";
+import serverEvents from "./routes/specific.routes/server-events.routes.js";
 
 import emails from "./routes/emails.routes.js";
 import session from "./routes/session.routes.js";
@@ -94,6 +95,7 @@ export default async (services) => {
   app.use("/api/v1/organisme", checkJwtToken, organisme(services));
   app.use("/api/v1/effectif", checkJwtToken, effectif());
   app.use("/api/v1/upload", checkJwtToken, upload(services));
+  app.use("/api/v1/server-events", checkJwtToken, serverEvents());
 
   // private admin access
   app.use(

--- a/ui/hooks/useServerEvents.js
+++ b/ui/hooks/useServerEvents.js
@@ -1,23 +1,19 @@
 import { useEffect, useState } from "react";
 
-export default function useServerEvent() {
-  const [messages, setMessages] = useState([]);
-  const [listening, setListening] = useState(false);
+export default function useServerEvents() {
+  const [data, setData] = useState(null);
 
   useEffect(() => {
-    if (!listening) {
-      setListening(true);
-      const events = new EventSource(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/server-events`);
-      events.onmessage = (event) => {
-        const parsedData = JSON.parse(event.data);
-        setMessages((messages) => messages.concat(parsedData));
-      };
-    }
-  }, [listening, messages]);
+    const eventSource = new EventSource(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/server-events`);
+    eventSource.onmessage = (event) => {
+      const parsedData = JSON.parse(event.data);
+      setData(parsedData);
+    };
 
-  return {
-    messages,
-    lastMessage: messages[messages.length - 1],
-    reset: () => setMessages([]),
-  };
+    return () => {
+      eventSource.close();
+    };
+  }, []);
+
+  return [data, setData];
 }

--- a/ui/hooks/useServerEvents.js
+++ b/ui/hooks/useServerEvents.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+export default function useServerEvent() {
+  const [messages, setMessages] = useState([]);
+  const [listening, setListening] = useState(false);
+
+  useEffect(() => {
+    if (!listening) {
+      setListening(true);
+      const events = new EventSource(`${process.env.NEXT_PUBLIC_BASE_URL}/api/v1/server-events`);
+      events.onmessage = (event) => {
+        const parsedData = JSON.parse(event.data);
+        setMessages((messages) => messages.concat(parsedData));
+      };
+    }
+  }, [listening, messages]);
+
+  return {
+    messages,
+    lastMessage: messages[messages.length - 1],
+    reset: () => setMessages([]),
+  };
+}

--- a/ui/modules/mon-espace/effectifs/Televersements.jsx
+++ b/ui/modules/mon-espace/effectifs/Televersements.jsx
@@ -39,7 +39,7 @@ const Televersements = () => {
   const setCurrentEffectifsState = useSetRecoilState(effectifsStateAtom);
   const [mapping, setMapping] = useState(null);
   const router = useRouter();
-  const { lastMessage, reset: resetServerEvent } = useServerEvents();
+  const [lastMessage, resetServerEvent] = useServerEvents();
 
   const [availableKeys, setAvailableKeys] = useState({
     in: [{ label: "", value: "" }],

--- a/ui/modules/mon-espace/effectifs/engine/TransmissionFichier/components/UploadFiles.js
+++ b/ui/modules/mon-espace/effectifs/engine/TransmissionFichier/components/UploadFiles.js
@@ -2,13 +2,15 @@ import React, { useCallback, useMemo, useState } from "react";
 import { Box, HStack, Button, Heading, Input, ListItem, Text, List, useToast, Spinner, Link } from "@chakra-ui/react";
 import { useDropzone } from "react-dropzone";
 import { useRecoilValue } from "recoil";
-
 import queryString from "query-string";
+
+import { _delete, _postFile } from "@/common/httpClient";
+import { hasContextAccessTo } from "@/common/utils/rolesUtils";
+import { Bin, DownloadLine, File } from "@/theme/components/icons";
+import { organismeAtom } from "@/hooks/organismeAtoms";
+import useServerEvents from "@/hooks/useServerEvents";
+
 import { useDocuments } from "../hooks/useDocuments";
-import { _delete, _postFile } from "../../../../../../common/httpClient";
-import { hasContextAccessTo } from "../../../../../../common/utils/rolesUtils";
-import { Bin, DownloadLine, File } from "../../../../../../theme/components/icons";
-import { organismeAtom } from "../../../../../../hooks/organismeAtoms";
 
 const endpoint = `${process.env.NEXT_PUBLIC_BASE_URL}/api`;
 
@@ -47,6 +49,7 @@ const UploadFiles = ({ title }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [uploadError, setUploadError] = useState(null);
   const { documents, onDocumentsChanged } = useDocuments();
+  const { lastMessage, reset: resetServerEvent } = useServerEvents();
 
   const maxFiles = 1;
 
@@ -94,6 +97,7 @@ const UploadFiles = ({ title }) => {
   );
 
   const onDeleteClicked = async (file) => {
+    resetServerEvent();
     if (hasContextAccessTo(organisme, "organisme/page_effectifs/supprimer_un_document")) {
       // eslint-disable-next-line no-restricted-globals
       const remove = confirm("Voulez-vous vraiment supprimer ce document ?");
@@ -146,7 +150,10 @@ const UploadFiles = ({ title }) => {
           {uploadError && <Text color="error">{uploadError}</Text>}
           <>
             {isSubmitting ? (
-              <Spinner />
+              <Box textAlign="center" flex="1" flexDirection="column">
+                <Spinner />
+                <Text mt={2}>{lastMessage}</Text>{" "}
+              </Box>
             ) : (
               <List>
                 {documents?.unconfirmed?.map((file) => {
@@ -175,7 +182,10 @@ const UploadFiles = ({ title }) => {
       ) : (
         <Box {...getRootProps({ style })} mb={8} minH="200px">
           {isSubmitting ? (
-            <Spinner />
+            <Box textAlign="center" flex="1" flexDirection="column">
+              <Spinner />
+              <Text mt={2}>{lastMessage}</Text>
+            </Box>
           ) : (
             <>
               <Input {...getInputProps()} />

--- a/ui/modules/mon-espace/effectifs/engine/TransmissionFichier/components/UploadFiles.js
+++ b/ui/modules/mon-espace/effectifs/engine/TransmissionFichier/components/UploadFiles.js
@@ -49,7 +49,7 @@ const UploadFiles = ({ title }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [uploadError, setUploadError] = useState(null);
   const { documents, onDocumentsChanged } = useDocuments();
-  const { lastMessage, reset: resetServerEvent } = useServerEvents();
+  const [lastMessage, resetServerEvent] = useServerEvents();
 
   const maxFiles = 1;
 


### PR DESCRIPTION
Cette PR ajoute un peu l'information de progression sur l'upload d'un fichier, avec le nombre de d'enregistrements traités, vs le nombre total. L'info transite sous forme de server events. On peut réutiliser ce canal pour une autre partie de l'app si besoin.

video: https://youtu.be/C0Hdc7R5j30