### PR TITLE
fix: update certbot docker image

### DIFF
--- a/.infra/ansible/roles/setup/files/app/tools/ssl/certbot/Dockerfile
+++ b/.infra/ansible/roles/setup/files/app/tools/ssl/certbot/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.1-stretch
+FROM node:16-stretch
 
 RUN apt update && apt install -y certbot curl
 RUN yarn global add serve


### PR DESCRIPTION
Fix an issue with chalk requiring node ^12.17.0