### PR TITLE
fix(server): hydrate organisme job & fiabilisation reseaux

### DIFF
--- a/.infra/ansible/roles/setup/files/app/tools/cron-data-jobs/run-daily-jobs.sh
+++ b/.infra/ansible/roles/setup/files/app/tools/cron-data-jobs/run-daily-jobs.sh
@@ -9,14 +9,14 @@ readonly LOG_FILEPATH="/var/log/data-jobs/run_daily_jobs_$(date +'%Y-%m-%d_%H%M%
 
 call_daily_jobs_with_logs(){
 
-  # TODO : TEMPORARY DESACTIVATED - Remplissage des organismes et des formations liées
-  # docker exec flux_retour_cfas_server bash -c "yarn cli hydrate:organismes-and-formations" || true
+  # Remplissage des organismes et des formations liées
+  docker exec flux_retour_cfas_server bash -c "yarn cli hydrate:organismes-and-formations" || true
   
-  # TODO : a lancer en manuel ou sur un timing différent (chaque semaine) ? - Remplissage des réseaux depuis csv fournis
-  # docker exec flux_retour_cfas_server bash -c "yarn cli hydrate:reseaux-newFormat" || true
+  # Remplissage des réseaux depuis csv fournis
+  docker exec flux_retour_cfas_server bash -c "yarn cli hydrate:reseaux-newFormat" || true
 
-  # TODO : TEMPORARY DESACTIVATED - Purge des données inutiles
-  # docker exec flux_retour_cfas_server bash -c "yarn cli purge:events" || true
+  # Purge des données inutiles
+  docker exec flux_retour_cfas_server bash -c "yarn cli purge:events" || true
 } 
 
 call_daily_jobs_with_logs >> ${LOG_FILEPATH}

--- a/server/src/common/actions/organismes/organismes.actions.js
+++ b/server/src/common/actions/organismes/organismes.actions.js
@@ -78,7 +78,6 @@ export const createOrganisme = async ({ uai, siret, nom: nomIn, adresse: adresse
     throw new Error(`Un organisme avec l'UAI ${uai} et le siret ${siret} existe déjà`);
   }
 
-  // TODO [metier] really used ?
   let metiers = [];
   try {
     metiers = (await getMetiersBySirets([siret]))?.metiers ?? [];
@@ -282,7 +281,6 @@ export const updateOrganisme = async (id, { nom, sirets, ...data }) => {
     throw new Error(`Unable to find organisme ${_id.toString()}`);
   }
 
-  // TODO [metier] really used ?
   let metiers = [];
   if (sirets && Array.isArray(sirets) && !sirets.every((newSiret) => organisme.sirets.includes(newSiret))) {
     try {

--- a/server/src/common/apis/apiReferentielMna.js
+++ b/server/src/common/apis/apiReferentielMna.js
@@ -7,7 +7,7 @@ import config from "../../config.js";
 const API_ENDPOINT = config.mnaReferentielApi.endpoint;
 
 export const fetchOrganismes = async (options = {}) => {
-  const { itemsPerPage = 100, champs } = options;
+  const { itemsPerPage = 10000, champs = DEFAULT_REFERENTIEL_FIELDS_TO_FETCH.join(",") } = options;
 
   const { data } = await axios({
     method: "GET",

--- a/server/src/common/model/organismes.model.js
+++ b/server/src/common/model/organismes.model.js
@@ -11,12 +11,14 @@ export const collectionName = "organismes";
 
 export const indexes = () => {
   return [
-    [{ uai: 1 }, { name: "uai", unique: true }],
+    [
+      { uai: 1, siret: 1 },
+      { name: "uai_siret", unique: true },
+    ],
     [
       { nom: "text", nom_tokenized: "text" },
       { name: "nom_tokenized_text", default_language: "french" },
     ],
-    [{ sirets: 1 }, { name: "sirets" }],
   ];
 };
 

--- a/server/src/jobs/hydrate/organismes/hydrate-organismes-and-formations.js
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes-and-formations.js
@@ -33,7 +33,7 @@ export const hydrateOrganismesAndFormations = async () => {
   let nbOrganismeNotCreated = 0;
   let nbFormationsCreated = 0;
   let nbFormationsNotCreated = 0;
-  let nbOrganismeWithoutUai = 0;
+  let nbOrganismeWithoutUaiOrSiret = 0;
   let nbOrganismeUpdated = 0;
   let nbOrganismeNotUpdated = 0;
 
@@ -46,7 +46,7 @@ export const hydrateOrganismesAndFormations = async () => {
     // Si aucun UAI ou siret on ne peut pas effectuer de traitement
     if (!uai || !siret) {
       // TODO voir coté métier comment gérer la récupération d'organismes sans uai ou siret dans le référentiel
-      nbOrganismeWithoutUai++;
+      nbOrganismeWithoutUaiOrSiret++;
       loadingBar.increment();
       continue;
     }
@@ -119,7 +119,9 @@ export const hydrateOrganismesAndFormations = async () => {
   loadingBar.stop();
 
   // Log & stats
-  logger.info(`-> ${nbOrganismeWithoutUai} organismes sans UAI / Siret dans le référentiel (pas de traitement)`);
+  logger.info(
+    `-> ${nbOrganismeWithoutUaiOrSiret} organismes sans UAI ou Siret dans le référentiel (pas de traitement)`
+  );
   logger.info(
     `--> ${nbOrganismeCreated} organismes créés depuis le référentiel (avec ajout de l'arbre des formations)`
   );
@@ -134,7 +136,7 @@ export const hydrateOrganismesAndFormations = async () => {
     date: new Date(),
     action: "finishing",
     data: {
-      nbOrganismesSansUai: nbOrganismeWithoutUai,
+      nbOrganismesSansUaiOuSiret: nbOrganismeWithoutUaiOrSiret,
       nbOrganismesCrees: nbOrganismeCreated,
       nbOrganismesNonCreesErreur: nbOrganismeNotCreated,
       nbOrganismesMaj: nbOrganismeUpdated,


### PR DESCRIPTION
Refacto & correction du job de récupération des organismes.
Plusieurs soucis identifiés qui impactent la fiabilisation des réseaux des organismes.
Une refacto & simplification du job.

Pour le moment pas d'optimisation de perf' mais à envisager par la suite.

- Refacto fonction de récupération d'infos depuis SIRET via API Entreprise 👉🏼 https://github.com/mission-apprentissage/flux-retour-cfas/pull/2584/commits/7e3472c01fd6355e35be297b6d3702d9867e21c1 (mutualisé car appelé depuis un job + depuis un composant)
- MAJ du modèle organisme pour couple UAI Siret unique via index 👉🏼 https://github.com/mission-apprentissage/flux-retour-cfas/pull/2584/commits/f3793e716169bd9f67c73a96a431af3bd75542f3
- Refacto fetchOrganismes avec options par défaut : 👉🏼 https://github.com/mission-apprentissage/flux-retour-cfas/pull/2584/commits/5b63a19613ed8e509032f81d5601da6db9689d17
- Refacto / correction / simplification du script de récupération des organismes 👉🏼 https://github.com/mission-apprentissage/flux-retour-cfas/pull/2584/commits/6d0d3db47685aeaccaa4c4cf4506e04e811a2769
- Modif de l'infra et du CRON pour lancement des scripts chaque matin 👉🏼 https://github.com/mission-apprentissage/flux-retour-cfas/pull/2584/commits/a20d4f13119338973f2c658b1d8522672390c0ff