### PR TITLE
fix: afficher les effectifs apres premiere transmission

### DIFF
--- a/ui/modules/mon-espace/effectifs/EffectifsPage.jsx
+++ b/ui/modules/mon-espace/effectifs/EffectifsPage.jsx
@@ -71,8 +71,6 @@ const EffectifsPage = ({ isMine }) => {
     } else if (organisme.mode_de_transmission === "API") {
       if (organisme.erps?.length === 0 && !organisme.first_transmission_date) {
         return <TransmissionAPI />;
-      } else if (!organisme.first_transmission_date) {
-        return <Televersements organisme={organisme} />;
       } else {
         return <Effectifs isMine={isMine} organismesEffectifs={organismesEffectifs} organisme={organisme} />;
       }

--- a/ui/modules/mon-espace/effectifs/EffectifsPage.jsx
+++ b/ui/modules/mon-espace/effectifs/EffectifsPage.jsx
@@ -71,7 +71,7 @@ const EffectifsPage = ({ isMine }) => {
     } else if (organisme.mode_de_transmission === "API") {
       if (organisme.erps?.length === 0 && !organisme.first_transmission_date) {
         return <TransmissionAPI />;
-      } else if (organisme.first_transmission_date) {
+      } else if (!organisme.first_transmission_date) {
         return <Televersements organisme={organisme} />;
       } else {
         return <Effectifs isMine={isMine} organismesEffectifs={organismesEffectifs} organisme={organisme} />;

--- a/ui/pages/mon-espace/organisme/[id]/effectifs/index.jsx
+++ b/ui/pages/mon-espace/organisme/[id]/effectifs/index.jsx
@@ -20,7 +20,6 @@ const PageEffectifsDeMonOrganisme = () => {
   const { organisme, isloaded } = useOrganisme(router.query.id);
   const { title } = PAGES.sesEffectifs(organisme?._id);
 
-  console.log("router.query.id", { id: router.query.id, organisme });
   return (
     <Page>
       <Head>


### PR DESCRIPTION
un tout petit bug qui empeche un organisme avec mode_de_transmission = "API" de voir ses effectids apres la premiere transmission 