### PR TITLE
feat: affichage des régions dans l'email de validation de l'admin

### DIFF
--- a/server/src/common/services/mailer/emails/templates.js
+++ b/server/src/common/services/mailer/emails/templates.js
@@ -8,6 +8,21 @@ function getTemplateFile(name) {
   return path.join(__dirname(import.meta.url), `${name}.mjml.ejs`);
 }
 
+function getRegionAsString(code) {
+  const region = REGIONS_BY_ID[code];
+  return region ? `${region.nom} (${region.code})` : code;
+}
+
+function getDepartementAsString(code) {
+  const dep = DEPARTEMENTS_BY_ID[code];
+  return dep ? `${dep.nom} (${dep.code})` : code;
+}
+
+function getAcademyAsString(code) {
+  const academie = ACADEMIES_BY_ID[code];
+  return academie ? `${academie.nom} (${academie.code})` : code;
+}
+
 export function activation_user({ payload }, token, options = {}) {
   const prefix = options.resend ? "[Rappel] " : "";
   return {
@@ -29,12 +44,19 @@ export function activation_user({ payload }, token, options = {}) {
 
 export function validation_first_organisme_user_by_tdb_team({ payload }, token, options = {}) {
   const prefix = options.resend ? "[Rappel] " : "";
+  const region_as_string = getRegionAsString(payload.organisme.adresse.region);
+  const departement_as_string = getDepartementAsString(payload.organisme.adresse.departement);
+  const academie_as_string = getAcademyAsString(payload.organisme.adresse.academie);
+
   return {
     subject: `${prefix} [ADMIN] Demande d'accès à l'organisme ${payload.organisme.nom}`,
     templateFile: getTemplateFile("validation_first_organisme_user_by_tdb_team"),
     data: {
       user: payload.user,
       organisme: payload.organisme,
+      region_as_string,
+      academie_as_string,
+      departement_as_string,
       type: payload.type,
       token,
     },
@@ -43,26 +65,9 @@ export function validation_first_organisme_user_by_tdb_team({ payload }, token, 
 
 export function validation_user_by_tdb_team({ payload }, token, options = {}) {
   const prefix = options.resend ? "[Rappel] " : "";
-  const regions_as_string = payload.user.codes_region
-    .map((code) => {
-      const region = REGIONS_BY_ID[code];
-      return region ? `${region.nom} (${region.code})` : code;
-    })
-    .join(", ");
-
-  const departements_as_string = payload.user.codes_departement
-    .map((code) => {
-      const dep = DEPARTEMENTS_BY_ID[code];
-      return dep ? `${dep.nom} (${dep.code})` : code;
-    })
-    .join(", ");
-
-  const academies_as_string = payload.user.codes_academie
-    .map((code) => {
-      const academie = ACADEMIES_BY_ID[code];
-      return academie ? `${academie.nom} (${academie.code})` : code;
-    })
-    .join(", ");
+  const regions_as_string = payload.user.codes_region.map(getRegionAsString).join(", ");
+  const departements_as_string = payload.user.codes_departement.map(getDepartementAsString).join(", ");
+  const academies_as_string = payload.user.codes_academie.map(getAcademyAsString).join(", ");
 
   return {
     subject: `${prefix} [ADMIN] Demande d'accès`,
@@ -80,12 +85,19 @@ export function validation_user_by_tdb_team({ payload }, token, options = {}) {
 
 export function validation_user_by_orga_admin({ payload }, token, options = {}) {
   const prefix = options.resend ? "[Rappel] " : "";
+  const region_as_string = getRegionAsString(payload.organisme.adresse.region);
+  const departement_as_string = getDepartementAsString(payload.organisme.adresse.departement);
+  const academie_as_string = getAcademyAsString(payload.organisme.adresse.academie);
+
   return {
     subject: `${prefix} Demande d'accès à votre organisme ${payload.organisme.nom}`,
     templateFile: getTemplateFile("validation_user_by_orga_admin"),
     data: {
       user: payload.user,
       organisme: payload.organisme,
+      region_as_string,
+      academie_as_string,
+      departement_as_string,
       type: payload.type,
       token,
     },

--- a/server/src/common/services/mailer/emails/validation_first_organisme_user_by_tdb_team.mjml.ejs
+++ b/server/src/common/services/mailer/emails/validation_first_organisme_user_by_tdb_team.mjml.ejs
@@ -35,19 +35,21 @@
                   <li>
                     Adresse :
                     <ul>
-                      <li>code_postal : <%= data.organisme.adresse.code_postal %>
+                      <li>Code postal : <%= data.organisme.adresse.code_postal %>
                       </li>
-                      <li>code_insee : <%= data.organisme.adresse.code_insee %>
+                      <li>Code insee : <%= data.organisme.adresse.code_insee %>
                       </li>
-                      <li>commune: <%= data.organisme.adresse.commune %>
+                      <li>Commune : <%= data.organisme.adresse.commune %>
                       </li>
-                      <li>departement: <%= data.organisme.adresse.departement %>
+                      <li>Commune : <%= data.organisme.adresse.commune %>
                       </li>
-                      <li>region: <%= data.organisme.adresse.region %>
+                      <li>Departement : <%= data.departement_as_string %>
                       </li>
-                      <li>academie: <%= data.organisme.adresse.academie %>
+                      <li>Region : <%= data.region_as_string %>
                       </li>
-                      <li>complete: <%= data.organisme.adresse.complete %>
+                      <li>Academie : <%= data.academie_as_string %>
+                      </li>
+                      <li>Complete : <%= data.organisme.adresse.complete %>
                       </li>
                     </ul>
                   </li>

--- a/server/src/common/services/mailer/emails/validation_user_by_orga_admin.mjml.ejs
+++ b/server/src/common/services/mailer/emails/validation_user_by_orga_admin.mjml.ejs
@@ -29,25 +29,25 @@
                   </li>
                   <li>Reseaux :<%= data.organisme.reseaux.join(',') %>
                   </li>
-                  <li>Erps: <%= data.organisme.erps.join(',') %>
+                  <li>Erps : <%= data.organisme.erps.join(',') %>
                   </li>
 
                   <li>
                     Adresse :
                     <ul>
-                      <li>code_postal : <%= data.organisme.adresse.code_postal %>
+                      <li>Code postal : <%= data.organisme.adresse.code_postal %>
                       </li>
-                      <li>code_insee : <%= data.organisme.adresse.code_insee %>
+                      <li>Code insee : <%= data.organisme.adresse.code_insee %>
                       </li>
-                      <li>commune: <%= data.organisme.adresse.commune %>
+                      <li>Commune : <%= data.organisme.adresse.commune %>
                       </li>
-                      <li>departement: <%= data.organisme.adresse.departement %>
+                      <li>Departement : <%= data.departement_as_string %>
                       </li>
-                      <li>region: <%= data.organisme.adresse.region %>
+                      <li>Region : <%= data.region_as_string %>
                       </li>
-                      <li>academie: <%= data.organisme.adresse.academie %>
+                      <li>Academie : <%= data.academie_as_string %>
                       </li>
-                      <li>complete: <%= data.organisme.adresse.complete %>
+                      <li>Complete : <%= data.organisme.adresse.complete %>
                       </li>
                     </ul>
                   </li>

--- a/server/src/http/routes/user.routes/register.routes.js
+++ b/server/src/http/routes/user.routes/register.routes.js
@@ -264,7 +264,7 @@ export default ({ mailer }) => {
         throw Boom.conflict("Unable to retrieve user");
       }
 
-      if (userDb.account_status !== "FORCE_COMPLETE_PROFILE_STEP1") {
+      if (!["FORCE_COMPLETE_PROFILE_STEP1", "FORCE_COMPLETE_PROFILE_STEP2"].includes(userDb.account_status)) {
         logger.error(
           `User ${userDb.email} is not in the right status to ask for access (status : ${userDb.account_status})`
         );


### PR DESCRIPTION
Une PR qui fait suite a la PR https://github.com/mission-apprentissage/flux-retour-cfas/pull/2575, mais cette fois pour afficher les régions / academies / departement pour l'admin d'un organisme.

Related issue: https://github.com/mission-apprentissage/flux-retour-cfas/issues/2430

screenshot:
<img width="527" alt="Screenshot 2023-02-15 at 16 23 05" src="https://user-images.githubusercontent.com/966303/219071816-1be2de25-f5db-4477-98bc-807e9232c338.png">

