### PR TITLE
fix(server): correction des migrations en filtrant sur les organismes avec siret

### DIFF
--- a/server/migrations/20230210140629-remove-sirets-from-organismes.js
+++ b/server/migrations/20230210140629-remove-sirets-from-organismes.js
@@ -1,4 +1,4 @@
 export const up = async (db) => {
   const collection = db.collection("organismes");
-  await collection.updateMany({}, { $unset: { sirets: "" } });
+  await collection.updateMany({ siret: { $exists: true } }, { $unset: { sirets: "" } });
 };

--- a/server/migrations/20230210155720-set-default-fiabilisation-statut-organismes.js
+++ b/server/migrations/20230210155720-set-default-fiabilisation-statut-organismes.js
@@ -2,5 +2,8 @@ import { FIABILISATION_TYPES } from "../src/common/constants/fiabilisationConsta
 
 export const up = async (db) => {
   const collection = db.collection("organismes");
-  await collection.updateMany({}, { $set: { fiabilisation_statut: FIABILISATION_TYPES.INCONNU } });
+  await collection.updateMany(
+    { siret: { $exists: true } },
+    { $set: { fiabilisation_statut: FIABILISATION_TYPES.INCONNU } }
+  );
 };

--- a/server/migrations/20230210161055-set-default-fiabilisation-type-fiabilisationUaiSiret.js
+++ b/server/migrations/20230210161055-set-default-fiabilisation-type-fiabilisationUaiSiret.js
@@ -2,5 +2,8 @@ import { FIABILISATION_TYPES } from "../src/common/constants/fiabilisationConsta
 
 export const up = async (db) => {
   const collection = db.collection("fiabilisationUaiSiret");
-  await collection.updateMany({ type: { $exists: false } }, { $set: { type: FIABILISATION_TYPES.A_FIABILISER } });
+  await collection.updateMany(
+    { siret: { $exists: true }, type: { $exists: false } },
+    { $set: { type: FIABILISATION_TYPES.A_FIABILISER } }
+  );
 };


### PR DESCRIPTION
Correction des migrations pour update les organismes ayant un siret.

Désormais le siret est obligatoire dans la collection organismes, vu avec @felixat13 on va analyser et supprimer les organismes sans siret qui n'ont plus rien à faire dans les données.