### PR TITLE
fix(server): changement de la méthode de calcul du nb d'organismes transmettant au tdb

### DIFF
--- a/server/src/common/actions/dossiersApprenants.actions.js
+++ b/server/src/common/actions/dossiersApprenants.actions.js
@@ -249,14 +249,14 @@ export const buildNewHistoriqueStatutApprenant = (
 };
 
 /**
- * Récupération du nb distinct d'organismes via leurs UAI
- // TODO voir si on garde ici ou dans un utils ?
+ * Récupération du nb distinct d'organismes
+ * On récupère le nombre distinct d'organismes id dans la collection dossiersApprenantsMigrationDb
  * @param {*} filters
  * @returns
  */
-export const getNbDistinctOrganismesByUai = async (filters = {}) => {
-  const distinctCfas = await dossiersApprenantsMigrationDb().distinct("uai_etablissement", filters);
-  return distinctCfas ? distinctCfas.length : 0;
+export const getNbDistinctOrganismes = async (filters = {}) => {
+  const distinctOrganismes = await dossiersApprenantsMigrationDb().distinct("organisme_id", filters);
+  return distinctOrganismes ? distinctOrganismes.length : 0;
 };
 
 /**

--- a/server/src/http/routes/specific.routes/indicateurs-national.routes.js
+++ b/server/src/http/routes/specific.routes/indicateurs-national.routes.js
@@ -4,7 +4,7 @@ import Joi from "joi";
 import tryCatch from "../../middlewares/tryCatchMiddleware.js";
 import { getAnneesScolaireListFromDate } from "../../../common/utils/anneeScolaireUtils.js";
 import { getCacheKeyForRoute } from "../../../common/utils/cacheUtils.js";
-import { getNbDistinctOrganismesByUai } from "../../../common/actions/dossiersApprenants.actions.js";
+import { getNbDistinctOrganismes } from "../../../common/actions/dossiersApprenants.actions.js";
 
 export default ({ effectifs, cache }) => {
   const router = express.Router();
@@ -27,7 +27,7 @@ export default ({ effectifs, cache }) => {
 
       const response = {
         date,
-        totalOrganismes: await getNbDistinctOrganismesByUai(filters),
+        totalOrganismes: await getNbDistinctOrganismes(filters),
         apprentis: await effectifs.apprentis.getCountAtDate(date, filters),
         rupturants: await effectifs.rupturants.getCountAtDate(date, filters),
         inscritsSansContrat: await effectifs.inscritsSansContrats.getCountAtDate(date, filters),

--- a/server/src/http/routes/specific.routes/indicateurs.routes.js
+++ b/server/src/http/routes/specific.routes/indicateurs.routes.js
@@ -2,8 +2,8 @@ import express from "express";
 import Joi from "joi";
 import tryCatch from "../../middlewares/tryCatchMiddleware.js";
 import { getAnneesScolaireListFromDate } from "../../../common/utils/anneeScolaireUtils.js";
-import { getNbDistinctOrganismesByUai } from "../../../common/actions/dossiersApprenants.actions.js";
 import { ObjectId } from "mongodb";
+import { getNbDistinctOrganismes } from "../../../common/actions/dossiersApprenants.actions.js";
 
 const commonEffectifsFilters = {
   organisme_id: Joi.string().allow(null, ""),
@@ -31,7 +31,7 @@ export default ({ effectifs }) => {
         annee_scolaire: { $in: getAnneesScolaireListFromDate(date) },
       };
 
-      const nbOrganismes = await getNbDistinctOrganismesByUai(filters);
+      const nbOrganismes = await getNbDistinctOrganismes(filters);
 
       return res.json({
         nbOrganismes,


### PR DESCRIPTION
MAJ de la fonction de décompte des organismes transmettant leurs données au TDB.

Désormais un décompte sur les organismes id distinct sans prendre en compte la notion d'uai (car ils peuvent etre null)