### PR TITLE
chore(infra): gestion de l'url du référentiel en recette / prod

### DIFF
--- a/.infra/ansible/roles/setup/files/app/.overrides/common/docker-compose.common.yml
+++ b/.infra/ansible/roles/setup/files/app/.overrides/common/docker-compose.common.yml
@@ -14,7 +14,6 @@ services:
 
   server:
     environment:
-      - FLUX_RETOUR_CFAS_MNA_REFERENTIEL_ENDPOINT_URL=https://referentiel.apprentissage.onisep.fr/api/v1
       - FLUX_RETOUR_CFAS_CLAMAV_URI=clamav:3310
     volumes:
       - /opt/flux-retour-cfas/data/server:/data

--- a/.infra/ansible/roles/setup/files/app/.overrides/dev/docker-compose.env.yml
+++ b/.infra/ansible/roles/setup/files/app/.overrides/dev/docker-compose.env.yml
@@ -15,6 +15,7 @@ services:
       # MongoDb
       - FLUX_RETOUR_CFAS_MONGODB_URI={{ vault[env_type].FLUX_RETOUR_CFAS_MONGODB_URI }}
       # APIs
+      - FLUX_RETOUR_CFAS_MNA_REFERENTIEL_ENDPOINT_URL=https://referentiel-recette.apprentissage.beta.gouv.fr/api/v1
       - FLUX_RETOUR_CFAS_TABLES_CORRESPONDANCES_ENDPOINT_URL=https://tables-correspondances-recette.apprentissage.beta.gouv.fr/api
       - FLUX_RETOUR_CFAS_MNA_CATALOG_ENDPOINT_URL=https://catalogue-recette.apprentissage.beta.gouv.fr/api
       - FLUX_RETOUR_CFAS_LBA_ENDPOINT_URL=http://labonnealternance-recette.apprentissage.beta.gouv.fr/api

--- a/.infra/ansible/roles/setup/files/app/.overrides/production/docker-compose.env.yml
+++ b/.infra/ansible/roles/setup/files/app/.overrides/production/docker-compose.env.yml
@@ -16,6 +16,7 @@ services:
       # MongoDb
       - FLUX_RETOUR_CFAS_MONGODB_URI={{ vault[env_type].FLUX_RETOUR_CFAS_MONGODB_URI }}
       # APIs
+      - FLUX_RETOUR_CFAS_MNA_REFERENTIEL_ENDPOINT_URL=https://referentiel.apprentissage.onisep.fr/api/v1
       - FLUX_RETOUR_CFAS_TABLES_CORRESPONDANCES_ENDPOINT_URL=https://tables-correspondances.apprentissage.beta.gouv.fr/api
       - FLUX_RETOUR_CFAS_MNA_CATALOG_ENDPOINT_URL=https://catalogue.apprentissage.beta.gouv.fr/api
       - FLUX_RETOUR_CFAS_LBA_ENDPOINT_URL=http://labonnealternance.apprentissage.beta.gouv.fr/api

--- a/.infra/ansible/roles/setup/files/app/.overrides/recette/docker-compose.env.yml
+++ b/.infra/ansible/roles/setup/files/app/.overrides/recette/docker-compose.env.yml
@@ -15,6 +15,7 @@ services:
       # MongoDb
       - FLUX_RETOUR_CFAS_MONGODB_URI={{ vault[env_type].FLUX_RETOUR_CFAS_MONGODB_URI }}
       # APIs
+      - FLUX_RETOUR_CFAS_MNA_REFERENTIEL_ENDPOINT_URL=https://referentiel-recette.apprentissage.beta.gouv.fr/api/v1
       - FLUX_RETOUR_CFAS_TABLES_CORRESPONDANCES_ENDPOINT_URL=https://tables-correspondances-recette.apprentissage.beta.gouv.fr/api
       - FLUX_RETOUR_CFAS_MNA_CATALOG_ENDPOINT_URL=https://catalogue-recette.apprentissage.beta.gouv.fr/api
       - FLUX_RETOUR_CFAS_LBA_ENDPOINT_URL=http://labonnealternance-recette.apprentissage.beta.gouv.fr/api


### PR DESCRIPTION
Petite modification pour taper dans l'API de recette du référentiel si on est sur l'env de dev / recette.

Je supprime du common du coup et adapte la variable sur les 3 env