### PR TITLE
Revert "chore(infra): gestion de l'url du référentiel en recette / prod (#2605)"

### DIFF
--- a/.infra/ansible/roles/setup/files/app/.overrides/common/docker-compose.common.yml
+++ b/.infra/ansible/roles/setup/files/app/.overrides/common/docker-compose.common.yml
@@ -14,6 +14,7 @@ services:
 
   server:
     environment:
+      - FLUX_RETOUR_CFAS_MNA_REFERENTIEL_ENDPOINT_URL=https://referentiel.apprentissage.onisep.fr/api/v1
       - FLUX_RETOUR_CFAS_CLAMAV_URI=clamav:3310
     volumes:
       - /opt/flux-retour-cfas/data/server:/data

--- a/.infra/ansible/roles/setup/files/app/.overrides/dev/docker-compose.env.yml
+++ b/.infra/ansible/roles/setup/files/app/.overrides/dev/docker-compose.env.yml
@@ -15,7 +15,6 @@ services:
       # MongoDb
       - FLUX_RETOUR_CFAS_MONGODB_URI={{ vault[env_type].FLUX_RETOUR_CFAS_MONGODB_URI }}
       # APIs
-      - FLUX_RETOUR_CFAS_MNA_REFERENTIEL_ENDPOINT_URL=https://referentiel-recette.apprentissage.beta.gouv.fr/api/v1
       - FLUX_RETOUR_CFAS_TABLES_CORRESPONDANCES_ENDPOINT_URL=https://tables-correspondances-recette.apprentissage.beta.gouv.fr/api
       - FLUX_RETOUR_CFAS_MNA_CATALOG_ENDPOINT_URL=https://catalogue-recette.apprentissage.beta.gouv.fr/api
       - FLUX_RETOUR_CFAS_LBA_ENDPOINT_URL=http://labonnealternance-recette.apprentissage.beta.gouv.fr/api

--- a/.infra/ansible/roles/setup/files/app/.overrides/production/docker-compose.env.yml
+++ b/.infra/ansible/roles/setup/files/app/.overrides/production/docker-compose.env.yml
@@ -16,7 +16,6 @@ services:
       # MongoDb
       - FLUX_RETOUR_CFAS_MONGODB_URI={{ vault[env_type].FLUX_RETOUR_CFAS_MONGODB_URI }}
       # APIs
-      - FLUX_RETOUR_CFAS_MNA_REFERENTIEL_ENDPOINT_URL=https://referentiel.apprentissage.onisep.fr/api/v1
       - FLUX_RETOUR_CFAS_TABLES_CORRESPONDANCES_ENDPOINT_URL=https://tables-correspondances.apprentissage.beta.gouv.fr/api
       - FLUX_RETOUR_CFAS_MNA_CATALOG_ENDPOINT_URL=https://catalogue.apprentissage.beta.gouv.fr/api
       - FLUX_RETOUR_CFAS_LBA_ENDPOINT_URL=http://labonnealternance.apprentissage.beta.gouv.fr/api

--- a/.infra/ansible/roles/setup/files/app/.overrides/recette/docker-compose.env.yml
+++ b/.infra/ansible/roles/setup/files/app/.overrides/recette/docker-compose.env.yml
@@ -15,7 +15,6 @@ services:
       # MongoDb
       - FLUX_RETOUR_CFAS_MONGODB_URI={{ vault[env_type].FLUX_RETOUR_CFAS_MONGODB_URI }}
       # APIs
-      - FLUX_RETOUR_CFAS_MNA_REFERENTIEL_ENDPOINT_URL=https://referentiel-recette.apprentissage.beta.gouv.fr/api/v1
       - FLUX_RETOUR_CFAS_TABLES_CORRESPONDANCES_ENDPOINT_URL=https://tables-correspondances-recette.apprentissage.beta.gouv.fr/api
       - FLUX_RETOUR_CFAS_MNA_CATALOG_ENDPOINT_URL=https://catalogue-recette.apprentissage.beta.gouv.fr/api
       - FLUX_RETOUR_CFAS_LBA_ENDPOINT_URL=http://labonnealternance-recette.apprentissage.beta.gouv.fr/api


### PR DESCRIPTION
Ceci n'est pas un troll, finalement il s'avère que l'environnement de recette du référentiel est "pourri" donc on reste branché sur la prod.

This reverts commit 1f998742e820d90732082c96068c24823f406079.
