### PR TITLE
chore: ajout de la date de dernière transmission des organismes

### DIFF
--- a/server/src/common/actions/engine/engine.actions.js
+++ b/server/src/common/actions/engine/engine.actions.js
@@ -19,7 +19,7 @@ import {
   findOrganismeBySiret,
   findOrganismeByUai,
   findOrganismeByUaiAndSiret,
-  setOrganismeFirstDateTransmissionIfNeeded,
+  setOrganismeTransmissionDates,
 } from "../organismes/organismes.actions.js";
 import { mapFiabilizedOrganismeUaiSiretCouple } from "./engine.organismes.utils.js";
 
@@ -324,9 +324,8 @@ export const runEngine = async ({ effectifData, lockEffectif = true }, organisme
       // Pas besoin d'update l'organisme
       organismeFoundId = organismeFound?._id;
 
-      // Si l'organisme provient de la fiabilisation et qu'il n'est pas flaggé comme transmettant,
-      // on ajoute la date de première transmission
-      await setOrganismeFirstDateTransmissionIfNeeded(organismeFoundId);
+      // On ajoute mets à jour les dates de transmission si organisme déja existant
+      await setOrganismeTransmissionDates(organismeFoundId);
 
       effectifData.organisme_id = organismeFound?._id.toString();
     }

--- a/server/src/common/actions/engine/engine.actions.js
+++ b/server/src/common/actions/engine/engine.actions.js
@@ -324,7 +324,7 @@ export const runEngine = async ({ effectifData, lockEffectif = true }, organisme
       // Pas besoin d'update l'organisme
       organismeFoundId = organismeFound?._id;
 
-      // On ajoute mets à jour les dates de transmission si organisme déja existant
+      // On ajoute ou mets à jour les dates de transmission si l'organisme est déja existant
       await setOrganismeTransmissionDates(organismeFoundId);
 
       effectifData.organisme_id = organismeFound?._id.toString();

--- a/server/src/common/model/organismes.model.js
+++ b/server/src/common/model/organismes.model.js
@@ -104,6 +104,7 @@ export const schema = object(
 
     metiers: arrayOf(string(), { description: "Les domaines métiers rattachés à l'établissement" }),
     first_transmission_date: date({ description: "Date de la première transmission de données" }),
+    last_transmission_date: date({ description: "Date de la dernière transmission de données" }),
     date_derniere_transmission: date({ description: "Date de la dernière transmission de données" }),
     est_dans_le_referentiel: boolean({ description: "Est dans le referentiel onisep des organismes" }),
     ferme: boolean({ description: "Le siret est fermé" }),

--- a/server/src/http/routes/specific.routes/espace.routes.js
+++ b/server/src/http/routes/specific.routes/espace.routes.js
@@ -24,6 +24,7 @@ export default () => {
         siret: 1,
         uai: 1,
         first_transmission_date: 1,
+        last_transmission_date: 1,
         fiabilisation_statut: 1,
       });
 

--- a/server/src/http/routes/specific.routes/serp.routes/upload.routes.js
+++ b/server/src/http/routes/specific.routes/serp.routes/upload.routes.js
@@ -32,7 +32,7 @@ import {
   getFormationWithRNCP,
   findFormationById,
 } from "../../../../common/actions/formations.actions.js";
-import { setOrganismeFirstDateTransmissionIfNeeded } from "../../../../common/actions/organismes/organismes.actions.js";
+import { setOrganismeTransmissionDates } from "../../../../common/actions/organismes/organismes.actions.js";
 import { sendServerEventsForUser } from "../server-events.routes.js";
 
 const mappingModel = {
@@ -947,7 +947,7 @@ export default ({ clamav }) => {
         confirm: true,
       });
 
-      if (uploads.last_snapshot_effectifs.length > 0) await setOrganismeFirstDateTransmissionIfNeeded(organisme_id);
+      if (uploads.last_snapshot_effectifs.length > 0) await setOrganismeTransmissionDates(organisme_id);
 
       return res.json({});
     })

--- a/server/src/jobs/cli.js
+++ b/server/src/jobs/cli.js
@@ -16,6 +16,7 @@ import { updateUsersApiSeeders } from "./users/update-apiSeeders.js";
 import { hydrateOrganismesReferentiel } from "./hydrate/organismes/hydrate-organismes-referentiel.js";
 import { updateOrganismesWithApis } from "./hydrate/organismes/update-organismes-with-apis.js";
 import { removeOrganismesSansSiretSansEffectifs } from "./patches/remove-organismes-sansSiret-sansEffectifs/index.js";
+import { updateLastTransmissionDateForOrganismes } from "./patches/update-lastTransmissionDates/index.js";
 
 /**
  * Job (temporaire) de suppression des organismes sans siret & sans effectifs
@@ -27,6 +28,18 @@ cli
     runScript(async () => {
       return removeOrganismesSansSiretSansEffectifs();
     }, "remove-organismes-sansSiret-sansEffectifs");
+  });
+
+/**
+ * Job (temporaire) de MAJ des date de dernières transmission des effectifs
+ */
+cli
+  .command("patches:update-lastTransmissionDate-organismes")
+  .description("Suppression des organismes sans siret & sans effectifs")
+  .action(async () => {
+    runScript(async () => {
+      return updateLastTransmissionDateForOrganismes();
+    }, "update-lastTransmissionDate-organismes");
   });
 
 /**

--- a/server/src/jobs/patches/update-lastTransmissionDates/index.js
+++ b/server/src/jobs/patches/update-lastTransmissionDates/index.js
@@ -1,0 +1,43 @@
+import { PromisePool } from "@supercharge/promise-pool/dist/promise-pool.js";
+import logger from "../../../common/logger.js";
+import { effectifsDb, organismesDb } from "../../../common/model/collections.js";
+
+let nbOrganismesUpdated = 0;
+
+/**
+ * Fonction de MAJ de la last_transmission_date des organismes avec effectifs
+ */
+export const updateLastTransmissionDateForOrganismes = async () => {
+  logger.info("MAJ de la last_transmission_date des organismes liés a des effectifs ... ");
+
+  // Récupération de la liste des organismes id ayant des effectifs liés
+  const organismesIdWithEffectifs = await effectifsDb().distinct("organisme_id");
+
+  // Pour chaque organisme id ayant des effectifs on set la last_transmission_date
+  // en récupérant la date de MAJ des effectifs (updated_at) la plus récente
+  await PromisePool.for(organismesIdWithEffectifs).process(setLastTransmissionDateForOrganisme);
+
+  logger.info(`${nbOrganismesUpdated} organismes mis à jour ...`);
+};
+
+/**
+ * Fonction de set de la last_transmission_date en récupérant la date de MAJ des effectifs (updated_at) la plus récente
+ * @param {*} organisme_id
+ */
+const setLastTransmissionDateForOrganisme = async (organisme_id) => {
+  const maxUpdatedDateForEffectifsForOrganisme = await effectifsDb()
+    .find({ organisme_id })
+    .sort({ updated_at: -1 })
+    .limit(1)
+    .toArray();
+
+  const maxUpdatedDate = maxUpdatedDateForEffectifsForOrganisme[0]?.updated_at;
+
+  if (maxUpdatedDate) {
+    await organismesDb().findOneAndUpdate(
+      { _id: organisme_id },
+      { $set: { last_transmission_date: maxUpdatedDate, updated_at: new Date() } }
+    );
+    nbOrganismesUpdated++;
+  }
+};

--- a/ui/common/constants/fiabilisation.js
+++ b/ui/common/constants/fiabilisation.js
@@ -1,7 +1,7 @@
 export const FIABILISATION_LABEL = {
-  A_FIABILISER: "à fiabiliser",
-  FIABILISE: "fiabilisé",
-  DEJA_FIABLE: "déja fiable",
-  NON_FIABILISABLE: "non fiabilisable",
-  INCONNU: "inconnu",
+  FIABLE: "Fiable",
+  FIABILISE: "Fiabilisé",
+  NON_FIABILISABLE_UAI_NON_VALIDEE: "Non fiabilisable (uai non validée)",
+  NON_FIABILISABLE_MAPPING: "Non fiabilisable (mapping)",
+  INCONNU: "Inconnu",
 };

--- a/ui/pages/mon-espace/mes-organismes.jsx
+++ b/ui/pages/mon-espace/mes-organismes.jsx
@@ -13,6 +13,7 @@ import { useEspace } from "@/hooks/useEspace";
 import Link from "@/components/Links/Link";
 import Table from "@/components/Table/Table";
 import withAuth from "@/components/withAuth";
+import { formatDateDayMonthYear } from "@/common/utils/dateUtils.js";
 
 function useEspaceOrganismes() {
   const {
@@ -174,12 +175,12 @@ function MesOrganismes() {
                   transmission: {
                     size: 120,
                     header: () => {
-                      return <Box textAlign="left">Transmission au tableau de bord</Box>;
+                      return <Box textAlign="left">Dernière transmission au tdb</Box>;
                     },
                     cell: ({ row }) => {
-                      const { first_transmission_date } = organismes[row.id];
-                      return first_transmission_date ? (
-                        <Text color="green">Transmet</Text>
+                      const { last_transmission_date } = organismes[row.id];
+                      return last_transmission_date ? (
+                        <Text color="green">Le {formatDateDayMonthYear(last_transmission_date)}</Text>
                       ) : (
                         <Text color="tomato">Ne transmet pas</Text>
                       );


### PR DESCRIPTION
Ajout d'un nouveau champ "date de dernière transmission" sur les organismes : 

- Ajout du champ au model 👉🏼 https://github.com/mission-apprentissage/flux-retour-cfas/pull/2634/commits/85b45cc0cd195602c5e0e951ea653034b84a062f
- Mise à jour de ce champ via API / Upload & Engine + tests 👉🏼 https://github.com/mission-apprentissage/flux-retour-cfas/pull/2634/commits/8b657386e5e5c56ae69f0dd1ceacca357a88243d
- Création d'un script pour initialiser les organismes existants 👉🏼 https://github.com/mission-apprentissage/flux-retour-cfas/pull/2634/commits/bc0ac590f22a75bb6b8a28363c24bdc25ee080d9
- MAJ du front (correction de constantes de fiab iso coté serveur + ajout date dernière transmission) 👉🏼 https://github.com/mission-apprentissage/flux-retour-cfas/pull/2634/commits/4f817bb76b2d26d0808a59351cacd18d0ae46a6e

Une fois déployé il faudra lancer : 

`yarn cli patches:update-lastTransmissionDate-organismes`