### PR TITLE
refacfor(server): normalisation des calls a runScript

### DIFF
--- a/server/src/common/actions/jobEvents.actions.js
+++ b/server/src/common/actions/jobEvents.actions.js
@@ -1,19 +1,28 @@
 import { jobEventsDb } from "../model/collections.js";
 
 /**
- * Création d'un user event
- * @param {*} param0
+ * Création d'un job event
+ * @param {*} data
  * @returns
  */
 export const createJobEvent = async ({ jobname, action, data, date = new Date() }) => {
-  await jobEventsDb().insertOne({
+  const { insertedId } = await jobEventsDb().insertOne({
     jobname,
     action,
     ...(data ? { data } : {}),
     date,
   });
+  return insertedId;
+};
 
-  return;
+/**
+ * Mise à jour d'un job event
+ * @param {*} _id
+ * @param {Object} data
+ * @returns
+ */
+export const updateJobEvent = async (_id, data) => {
+  return jobEventsDb().updateOne({ _id }, { $set: data });
 };
 
 /**

--- a/server/src/common/constants/jobsConstants.js
+++ b/server/src/common/constants/jobsConstants.js
@@ -5,4 +5,5 @@ export const jobEventStatuts = {
   started: "started",
   executed: "executed",
   ended: "ended",
+  error: "error",
 };

--- a/server/src/jobs/cli.fiabilisation.js
+++ b/server/src/jobs/cli.fiabilisation.js
@@ -11,13 +11,13 @@ import { applyFiabilisationUaiSiret } from "./fiabilisation/uai-siret/apply-fiab
 cli
   .command("build:fiabilisation-uai-siret")
   .description("Création de la collection pour fiabilisation des UAI SIRET")
-  .action(() => {
+  .action((_, options) =>
     runScript(async () => {
       // On lance séquentiellement 2 fois la construction de la table de fiabilisation - nécessaire pour prendre en compte tous les cas
       await buildFiabilisationUaiSiret();
       await buildFiabilisationUaiSiret();
-    }, "build-fiabilisation-uai-siret");
-  });
+    }, options._name)
+  );
 
 /**
  * Job d'application de la fiabilisation UAI SIRET
@@ -25,11 +25,11 @@ cli
 cli
   .command("apply:fiabilisation-uai-siret")
   .description("Application du mapping de fiabilisation des UAI SIRET")
-  .action(() => {
+  .action((_, options) =>
     runScript(async () => {
       return applyFiabilisationUaiSiret();
-    }, "apply-fiabilisation-uai-siret");
-  });
+    }, options._name)
+  );
 
 /**
  * Job d'analyse de la fiabilité des dossiersApprenants reçus
@@ -37,10 +37,10 @@ cli
 cli
   .command("analyse:dossiersApprenants-recus")
   .description("Analyse de la fiabilité des dossiersApprenants reçus")
-  .action(() => {
+  .action((_, options) =>
     runScript(async () => {
       return analyseFiabiliteDossierApprenantsRecus();
-    }, "analyse-dossiersApprenants-recus");
-  });
+    }, options._name)
+  );
 
 cli.parse(process.argv);

--- a/server/src/jobs/cli.js
+++ b/server/src/jobs/cli.js
@@ -1,5 +1,6 @@
 import "dotenv/config.js";
 import { Option, program as cli } from "commander";
+
 import { runScript } from "./scriptWrapper.js";
 import { seedSample, seedAdmin, seedRoles } from "./seed/start/index.js";
 import { clear, clearRoles, clearUsers } from "./clear/clear-all.js";
@@ -24,11 +25,11 @@ import { updateLastTransmissionDateForOrganismes } from "./patches/update-lastTr
 cli
   .command("patches:remove-organismes-sansSiret-sansEffectifs")
   .description("Suppression des organismes sans siret & sans effectifs")
-  .action(async () => {
+  .action(async (_, options) =>
     runScript(async () => {
       return removeOrganismesSansSiretSansEffectifs();
-    }, "remove-organismes-sansSiret-sansEffectifs");
-  });
+    }, options._name)
+  );
 
 /**
  * Job (temporaire) de MAJ des date de dernières transmission des effectifs
@@ -36,11 +37,11 @@ cli
 cli
   .command("patches:update-lastTransmissionDate-organismes")
   .description("Suppression des organismes sans siret & sans effectifs")
-  .action(async () => {
+  .action(async (_, options) =>
     runScript(async () => {
       return updateLastTransmissionDateForOrganismes();
-    }, "update-lastTransmissionDate-organismes");
-  });
+    }, options._name)
+  );
 
 /**
  * Job d'initialisation de données de test
@@ -49,12 +50,12 @@ cli
   .command("seed")
   .description("Seed global data")
   .option("-e, --email <string>", "Email de l'utilisateur Admin")
-  .action(async ({ email }) => {
+  .action(async ({ email }, options) =>
     runScript(async () => {
       await seedRoles();
       return seedAdmin({ adminEmail: email?.toLowerCase() });
-    }, "Seed-admin");
-  });
+    }, options._name)
+  );
 
 /**
  * Job d'initialisation de données de test
@@ -62,11 +63,11 @@ cli
 cli
   .command("seed:sample")
   .description("Seed sample data")
-  .action(async () => {
+  .action(async (_, options) =>
     runScript(async () => {
       return seedSample();
-    }, "Seed sample");
-  });
+    }, options._name)
+  );
 
 /**
  * Job d'initialisation des roles
@@ -75,11 +76,11 @@ cli
 cli
   .command("seed:roles")
   .description("Seed roles")
-  .action(async () => {
+  .action(async (_, options) =>
     runScript(async () => {
       return seedRoles();
-    }, "Seed-roles");
-  });
+    }, options._name)
+  );
 
 /**
  * Job d'initialisation d'un user admin
@@ -89,11 +90,11 @@ cli
   .command("seed:admin")
   .description("Seed user admin")
   .option("-e, --email <string>", "Email de l'utilisateur Admin")
-  .action(async ({ email }) => {
+  .action(async ({ email }, options) =>
     runScript(async () => {
       return seedAdmin({ adminEmail: email?.toLowerCase() });
-    }, "Seed-admin");
-  });
+    }, options._name)
+  );
 
 /**
  * Job de nettoyage de db
@@ -102,29 +103,29 @@ cli
   .command("clear")
   .description("Clear projet")
   .option("-a, --all", "Tout supprimer")
-  .action(({ all }) => {
+  .action(({ all }, options) =>
     runScript(async () => {
       return clear({ clearAll: all });
-    }, "Clear");
-  });
+    }, options._name)
+  );
 
 cli
   .command("clear:users")
   .description("Clear users")
-  .action(() => {
+  .action((_, options) =>
     runScript(async () => {
       return clearUsers();
-    }, "Clear");
-  });
+    }, options._name)
+  );
 
 cli
   .command("clear:roles")
   .description("Clear roles")
-  .action(() => {
+  .action((_, options) =>
     runScript(async () => {
       return clearRoles();
-    }, "Clear");
-  });
+    }, options._name)
+  );
 
 /**
  * Job de remplissage des organismes du référentiel
@@ -132,11 +133,11 @@ cli
 cli
   .command("hydrate:organismes-referentiel")
   .description("Remplissage des organismes du référentiel")
-  .action(async () => {
+  .action(async (_, options) =>
     runScript(async () => {
       return hydrateOrganismesReferentiel();
-    }, "hydrate-organismes-referentiel");
-  });
+    }, options._name)
+  );
 
 /**
  * Job de remplissage des organismes en allant ajouter / maj aux organismes existants (issus de la transmission)
@@ -145,11 +146,11 @@ cli
 cli
   .command("hydrate:organismes")
   .description("Remplissage des organismes via le référentiel")
-  .action(async () => {
+  .action(async (_, options) =>
     runScript(async () => {
       return hydrateOrganismesFromReferentiel();
-    }, "hydrate-organismes");
-  });
+    }, options._name)
+  );
 
 /**
  * Job de mise à jour des organismes en allant appeler des API externes pour remplir
@@ -160,11 +161,11 @@ cli
 cli
   .command("update:organismes-with-apis")
   .description("Mise à jour des organismes via API externes")
-  .action(async () => {
+  .action(async (_, options) =>
     runScript(async () => {
       return updateOrganismesWithApis();
-    }, "update-organismes-with-apis");
-  });
+    }, options._name)
+  );
 
 /**
  * Job de remplissage & maj des d'organismes / dossiersApprenants pour les réseaux avec le nouveau format
@@ -172,11 +173,11 @@ cli
 cli
   .command("hydrate:reseaux")
   .description("Remplissage des réseaux pour les organismes et dossiersApprenants")
-  .action(async () => {
+  .action(async (_, options) =>
     runScript(async () => {
       return hydrateReseaux();
-    }, "hydrate-reseaux");
-  });
+    }, options._name)
+  );
 
 /**
  * Job d'archivage des dossiers apprenants et des effectifs
@@ -185,11 +186,11 @@ cli
   .command("archive:dossiersApprenantsEffectifs")
   .description("Archivage des dossiers apprenants")
   .option("--limit <int>", "Année limite d'archivage")
-  .action(async ({ limit }) => {
+  .action(async ({ limit }, options) =>
     runScript(async () => {
       return hydrateArchivesDossiersApprenantsAndEffectifs(limit);
-    }, "hydrate-archive-dossiersApprenants-effectifs");
-  });
+    }, options._name)
+  );
 
 /**
  * Job de purge des events
@@ -198,11 +199,11 @@ cli
   .command("purge:events")
   .description("Purge des logs inutiles")
   .option("--nbDaysToKeep <int>", "Nombre de jours à conserver")
-  .action(async ({ nbDaysToKeep }) => {
+  .action(async ({ nbDaysToKeep }, options) =>
     runScript(async () => {
       return purgeEvents(nbDaysToKeep);
-    }, "purge-events");
-  });
+    }, options._name)
+  );
 
 /**
  * Job de création d'un utilisateur
@@ -215,7 +216,7 @@ cli
   .option("--nom <string>", "Nom de l'utilisateur")
   .option("--isAdmin <bool>", "Indique s'il est administrateur")
   .option("--isCrossOrganismes <bool>", "Indique s'il est cross organismes")
-  .action(async ({ email, prenom, nom, isAdmin, isCrossOrganismes }) => {
+  .action(async ({ email, prenom, nom, isAdmin, isCrossOrganismes }, options) =>
     runScript(async () => {
       return createUserAccount({
         email,
@@ -223,8 +224,8 @@ cli
         nom,
         permissions: { is_admin: isAdmin, is_cross_organismes: isCrossOrganismes },
       });
-    }, "create-user");
-  });
+    }, options._name)
+  );
 
 /**
  * Job de génération d'un token de MAJ de mot de passe pour un utilisateur
@@ -233,11 +234,11 @@ cli
   .command("generate:password-update-token")
   .description("Génération d'un token de MAJ de mot de passe pour un utilisateur")
   .requiredOption("--email <string>", "Email de l'utilisateur")
-  .action(async ({ email }) => {
+  .action(async ({ email }, options) =>
     runScript(async () => {
       return generatePasswordUpdateTokenForUser(email);
-    }, "generate-password-update-token");
-  });
+    }, options._name)
+  );
 
 /**
  * Job de génération d'un token de MAJ de mot de passe pour un utilisateur legacy (ancien modèle)
@@ -246,11 +247,11 @@ cli
   .command("generate-legacy:password-update-token")
   .description("Génération d'un token de MAJ de mot de passe pour un utilisateur legacy")
   .requiredOption("--username <string>", "username de l'utilisateur")
-  .action(async ({ username }) => {
+  .action(async ({ username }, options) =>
     runScript(async () => {
       return generatePasswordUpdateTokenForUserLegacy(username);
-    }, "generate-password-update-token-legacy");
-  });
+    }, options._name)
+  );
 
 /**
  * TEMPORAIRE
@@ -261,11 +262,11 @@ cli
   .command("users:update-apiSeeders")
   .description("Modification des utilisateurs fournisseurs de données")
   .addOption(new Option("--mode <mode>", "Mode de mise à jour").choices(["active", "inactive"]).makeOptionMandatory())
-  .action(async ({ mode }) => {
+  .action(async ({ mode }, options) =>
     runScript(async () => {
       return updateUsersApiSeeders(mode);
-    }, "users:update-apiSeeders");
-  });
+    }, options._name)
+  );
 
 cli;
 

--- a/server/src/jobs/fiabilisation/uai-siret/apply-fiabilisation/index.js
+++ b/server/src/jobs/fiabilisation/uai-siret/apply-fiabilisation/index.js
@@ -1,5 +1,5 @@
 import { PromisePool } from "@supercharge/promise-pool/dist/promise-pool.js";
-import { createJobEvent } from "../../../../common/actions/jobEvents.actions.js";
+
 import {
   STATUT_FIABILISATION_COUPLES_UAI_SIRET,
   STATUT_FIABILISATION_ORGANISME,
@@ -10,8 +10,6 @@ import {
   fiabilisationUaiSiretDb,
   organismesDb,
 } from "../../../../common/model/collections.js";
-
-const JOB_NAME = "apply-fiabilisation-uai-siret";
 
 const filters = {
   annee_scolaire: { $in: ["2022-2022", "2022-2023", "2023-2023"] },
@@ -31,12 +29,6 @@ let nbOrganismesNonFiabilisablesUaiNonValidees = 0;
  *
  */
 export const applyFiabilisationUaiSiret = async () => {
-  await createJobEvent({
-    jobname: JOB_NAME,
-    date: new Date(),
-    action: "beginning",
-  });
-
   // Reset des statuts de fiabilisation des organismes
   await resetStatutFiabilisation();
 
@@ -58,18 +50,13 @@ export const applyFiabilisationUaiSiret = async () => {
     "organismes mis à jour en tant que non fiabilisables (uai non validée dans le référentiel)"
   );
 
-  await createJobEvent({
-    jobname: JOB_NAME,
-    date: new Date(),
-    action: "finishing",
-    data: {
-      nbOrganismesFiables,
-      nbDossiersApprenantsFiabilises,
-      nbOrganismesFiabilises,
-      nbOrganismesNonFiabilisablesMapping,
-      nbOrganismesNonFiabilisablesUaiNonValidees,
-    },
-  });
+  return {
+    nbOrganismesFiables,
+    nbDossiersApprenantsFiabilises,
+    nbOrganismesFiabilises,
+    nbOrganismesNonFiabilisablesMapping,
+    nbOrganismesNonFiabilisablesUaiNonValidees,
+  };
 };
 
 /**

--- a/server/src/jobs/hydrate/organismes/hydrate-organismes-referentiel.js
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes-referentiel.js
@@ -12,7 +12,7 @@ let nbOrganismeNotCreated = 0;
  * Script qui initialise les organismes du référentiel dans la collection organismesReferentiel
  */
 export const hydrateOrganismesReferentiel = async () => {
-  logger.info(`Clear des organismes du référentiel...`);
+  logger.info("Clear des organismes du référentiel...");
   await organismesReferentielDb().deleteMany({});
 
   // On récupère l'intégralité des organismes depuis le référentiel
@@ -26,15 +26,10 @@ export const hydrateOrganismesReferentiel = async () => {
   logger.info(`--> ${nbOrganismeCreated} organismesReferentiel créés depuis le référentiel`);
   logger.info(`--> ${nbOrganismeNotCreated} organismesReferentiel non créés depuis le référentiel (erreur)`);
 
-  await createJobEvent({
-    jobname: JOB_NAME,
-    date: new Date(),
-    action: "finishing",
-    data: {
-      nbOrganismesCrees: nbOrganismeCreated,
-      nbOrganismesNonCreesErreur: nbOrganismeNotCreated,
-    },
-  });
+  return {
+    nbOrganismesCrees: nbOrganismeCreated,
+    nbOrganismesNonCreesErreur: nbOrganismeNotCreated,
+  };
 };
 
 /**

--- a/server/src/jobs/hydrate/organismes/hydrate-organismes.js
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes.js
@@ -40,17 +40,12 @@ export const hydrateOrganismesFromReferentiel = async () => {
   logger.info(`---> ${nbOrganismeUpdated} organismes mis à jour`);
   logger.info(`---> ${nbOrganismeNotUpdated} organismes non mis à jour depuis le référentiel (erreur)`);
 
-  await createJobEvent({
-    jobname: JOB_NAME,
-    date: new Date(),
-    action: "finishing",
-    data: {
-      nbOrganismesCrees: nbOrganismeCreated,
-      nbOrganismesNonCreesErreur: nbOrganismeNotCreated,
-      nbOrganismesMaj: nbOrganismeUpdated,
-      nbOrganismesNonMajErreur: nbOrganismeNotUpdated,
-    },
-  });
+  return {
+    nbOrganismesCrees: nbOrganismeCreated,
+    nbOrganismesNonCreesErreur: nbOrganismeNotCreated,
+    nbOrganismesMaj: nbOrganismeUpdated,
+    nbOrganismesNonMajErreur: nbOrganismeNotUpdated,
+  };
 };
 
 /**

--- a/server/src/jobs/hydrate/organismes/update-organismes-with-apis.js
+++ b/server/src/jobs/hydrate/organismes/update-organismes-with-apis.js
@@ -38,15 +38,10 @@ export const updateOrganismesWithApis = async () => {
   logger.info(`---> ${nbOrganismeUpdated} organismes mis à jour`);
   logger.info(`---> ${nbOrganismeNotUpdated} organismes non mis à jour (erreur)`);
 
-  await createJobEvent({
-    jobname: JOB_NAME,
-    date: new Date(),
-    action: "finishing",
-    data: {
-      nbOrganismesMaj: nbOrganismeUpdated,
-      nbOrganismesNonMajErreur: nbOrganismeNotUpdated,
-    },
-  });
+  return {
+    nbOrganismesMaj: nbOrganismeUpdated,
+    nbOrganismesNonMajErreur: nbOrganismeNotUpdated,
+  };
 };
 
 /**

--- a/server/src/jobs/users/create-user.js
+++ b/server/src/jobs/users/create-user.js
@@ -1,4 +1,3 @@
-import { createJobEvent } from "../../common/actions/jobEvents.actions.js";
 import { createUser } from "../../common/actions/users.actions.js";
 import { USER_ACCOUNT_STATUS } from "../../common/constants/usersConstants.js";
 import logger from "../../common/logger.js";
@@ -20,13 +19,7 @@ export const createUserAccount = async ({ email, nom, prenom, permissions = {} }
       account_status: USER_ACCOUNT_STATUS.FIRST_FORCE_RESET_PASSWORD,
     }
   );
-
-  await createJobEvent({
-    jobname: "create-user",
-    date: new Date(),
-    action: "create-user",
-    data: { email },
-  });
-
   logger.info(`User ${email} successfully created`);
+
+  return { email };
 };


### PR DESCRIPTION
une PR pour revoir un peu le fonctionnement des scripts:
- utilisation du nom de la cmd pour le jobName pour éviter les erreurs de copier / coller (ex: la cmd "seed" utilisait Seed-admin)
- un seul jobEvent par run (sauf sur certains cas particuliers)
- log de l'exception rencontré dans runScript
- log systematique des datas renvoyé par l'action