### PR TITLE
fix(server): clear fiabilisationUaiSiret before build

### DIFF
--- a/server/src/jobs/fiabilisation/uai-siret/build-fiabilisation/index.js
+++ b/server/src/jobs/fiabilisation/uai-siret/build-fiabilisation/index.js
@@ -34,7 +34,9 @@ const insertInFiabilisationIfNotExist = async (fiabilisation) => {
  * TODO : optims upsert
  */
 export const buildFiabilisationUaiSiret = async () => {
-  await clearFiabilisationUaiSiret();
+  logger.info("Clear de la table fiabilisation Uai Siret...");
+  await fiabilisationUaiSiretDb().deleteMany({});
+
   const organismesFromReferentiel = await organismesReferentielDb().find().toArray();
 
   // on récupère tous les couples UAI/SIRET depuis les dossiers apprenants (migration)
@@ -229,12 +231,4 @@ const insertManualMappingsFromFile = async () => {
   });
 
   return nbInserted;
-};
-
-/**
- * Suppression des éléments de la table fiabilisation uai siret
- */
-const clearFiabilisationUaiSiret = async () => {
-  logger.info("Clear de la table fiabilisation Uai Siret...");
-  await fiabilisationUaiSiretDb().deleteMany({});
 };

--- a/server/src/jobs/fiabilisation/uai-siret/build-fiabilisation/index.js
+++ b/server/src/jobs/fiabilisation/uai-siret/build-fiabilisation/index.js
@@ -34,6 +34,7 @@ const insertInFiabilisationIfNotExist = async (fiabilisation) => {
  * TODO : optims upsert
  */
 export const buildFiabilisationUaiSiret = async () => {
+  await clearFiabilisationUaiSiret();
   const organismesFromReferentiel = await organismesReferentielDb().find().toArray();
 
   // on récupère tous les couples UAI/SIRET depuis les dossiers apprenants (migration)
@@ -228,4 +229,12 @@ const insertManualMappingsFromFile = async () => {
   });
 
   return nbInserted;
+};
+
+/**
+ * Suppression des éléments de la table fiabilisation uai siret
+ */
+const clearFiabilisationUaiSiret = async () => {
+  logger.info("Clear de la table fiabilisation Uai Siret...");
+  await fiabilisationUaiSiretDb().deleteMany({});
 };


### PR DESCRIPTION
Reset de la table de fiabilisation avant le lancement du script.
On avait qqs reliquats de couples qui n'ont plus lieu d'être dans la table, le clear avant exécution devrait corriger ces soucis.