### PR TITLE
chore: add type for MongoClient + lint

### DIFF
--- a/server/src/common/actions/dossiersApprenants.actions.js
+++ b/server/src/common/actions/dossiersApprenants.actions.js
@@ -208,7 +208,7 @@ export const buildNewHistoriqueStatutApprenant = (
 /**
  * Récupération du nb distinct d'organismes
  * On récupère le nombre distinct d'organismes id dans la collection dossiersApprenantsMigrationDb
- * @param {*} filters
+ * @param {import("mongodb").Filter<any>} filters
  * @returns
  */
 export const getNbDistinctOrganismes = async (filters = {}) => {

--- a/server/src/common/actions/emails.actions.js
+++ b/server/src/common/actions/emails.actions.js
@@ -6,6 +6,7 @@ function addEmail(userEmail, token, templateName, payload) {
   return usersMigrationDb().findOneAndUpdate(
     { email: userEmail },
     {
+      // @ts-ignore
       $push: {
         emails: {
           token,
@@ -56,6 +57,7 @@ function addEmailSendDate(token, templateName) {
       $set: {
         "emails.$.templateName": templateName,
       },
+      // @ts-ignore
       $push: {
         "emails.$.sendDates": new Date(),
       },
@@ -115,6 +117,7 @@ export async function unsubscribeUser(id) {
 }
 
 export async function renderEmail({ templates }, token) {
+  /** @type {any} */
   const user = await usersMigrationDb().findOne({ "emails.token": token });
   const { templateName, payload } = user.emails.find((e) => e.token === token);
   const template = templates[templateName]({ to: user.email, payload }, token);
@@ -150,6 +153,9 @@ export const createMailer = (mailerService) => {
     },
     async resendEmail(token, options = {}) {
       const user = await usersMigrationDb().findOne({ "emails.token": token });
+      if (!user) {
+        throw new Error("user not found");
+      }
       const previous = user.emails.find((e) => e.token === token);
 
       const nextTemplateName = options.newTemplateName || previous.templateName;

--- a/server/src/common/actions/engine/engine.actions.js
+++ b/server/src/common/actions/engine/engine.actions.js
@@ -351,6 +351,7 @@ export const runEngine = async ({ effectifData }, organismeData) => {
       await updateEffectifAndLock(effectifUpdatedId, effectif);
     } else {
       effectifCreatedId = await insertEffectif(effectif);
+      /** @type {import("mongodb").WithId<any>} */
       const effectifCreated = await findEffectifById(effectifCreatedId);
       await updateEffectifAndLock(effectifCreatedId, {
         apprenant: effectifCreated.apprenant,

--- a/server/src/common/actions/organismes/organismes.actions.js
+++ b/server/src/common/actions/organismes/organismes.actions.js
@@ -78,7 +78,9 @@ export const createOrganisme = async (
     })
   );
 
-  return await organismesDb().findOne({ _id: insertedId });
+  return {
+    _id: insertedId,
+  };
 };
 
 /**
@@ -418,7 +420,7 @@ export const setOrganismeTransmissionDates = async (id) => {
 /**
  * Returns sous-établissements by siret for an uai
  * @param {string} uai
- * @returns {Promise<Array<{siret_etablissement: string, nom_etablissement: string}>>}
+ * @returns {Promise<Array<any>>}
  */
 export const getSousEtablissementsForUai = async (uai) => {
   return await organismesDb()

--- a/server/src/common/actions/organismes/organismes.formations.actions.js
+++ b/server/src/common/actions/organismes/organismes.formations.actions.js
@@ -165,6 +165,9 @@ const getOrganismeNature = (defaultNature, formationCatalog, organismesLinkedToF
  */
 export const findOrganismeFormationByCfd = async (organisme_id, cfd) => {
   const organisme = await organismesDb().findOne({ _id: new ObjectId(organisme_id) });
+  if (!organisme) {
+    throw new Error("organisme not found");
+  }
   const formationFound = await getFormationWithCfd(cfd, { _id: 1 });
 
   if (!formationFound) return null;

--- a/server/src/common/actions/permissions.actions.js
+++ b/server/src/common/actions/permissions.actions.js
@@ -154,24 +154,26 @@ export const updatePermission = async ({ organisme_id, userEmail, roleName, cust
 
 /**
  * Méthode de mise à jour d'activation d'accès
- * @param {*} permissionProps
+ * @param {Object} options
+ * @param {string} options.userEmail
+ * @param {boolean} options.pending
+ * @param {string|undefined|ObjectId} options.organisme_id
  * @returns
  */
 export const updatePermissionsPending = async ({ userEmail, pending, organisme_id }) => {
   const permissions = await findPermissionsByUserEmail(organisme_id, userEmail, { _id: 1 });
-  if (!permissions && !permissions.length) {
+  if (!permissions || !permissions.length) {
     throw new Error(`Unable to find permissions for userEmail ${userEmail.toLowerCase()}`);
   }
 
-  return permissionsDb().updateMany(
+  await permissionsDb().updateMany(
     { _id: { $in: permissions.map(({ _id }) => _id) } },
     {
       $set: {
         pending,
         updated_at: new Date(),
       },
-    },
-    { returnDocument: "after" }
+    }
   );
 };
 
@@ -179,12 +181,12 @@ export const updatePermissionsPending = async ({ userEmail, pending, organisme_i
  * Méthode de suppression de permissions
  * @param {Object} options
  * @param {string} options.userEmail
- * @param {string|null|ObjectId} options.organisme_id
+ * @param {string|undefined|ObjectId} options.organisme_id
  * @returns
  */
 export const removePermissions = async ({ userEmail, organisme_id }) => {
   const permissions = await findPermissionsByUserEmail(organisme_id, userEmail, { _id: 1 });
-  if (!permissions && !permissions.length) {
+  if (!permissions || !permissions.length) {
     throw new Error(
       `Unable to find permissions for userEmail ${userEmail.toLowerCase()} and organisme ${organisme_id}`
     );

--- a/server/src/common/actions/roles.actions.js
+++ b/server/src/common/actions/roles.actions.js
@@ -66,7 +66,7 @@ export const findRoleById = async (id, projection = {}) => {
 };
 
 export const hasAclsByRoleId = async (id, acl) => {
-  const roleDb = await rolesDb().findOne({ _id: new ObjectId(id) }, { acl: 1 });
+  const roleDb = await rolesDb().findOne({ _id: new ObjectId(id) }, { projection: { acl: 1 } });
   if (!roleDb) {
     throw new Error("Role doesn't exist");
   }

--- a/server/src/common/actions/sifa.actions/sifa.actions.js
+++ b/server/src/common/actions/sifa.actions/sifa.actions.js
@@ -41,6 +41,9 @@ export const isEligibleSIFA = ({ historique_statut }) => {
  */
 export const generateSifa = async (organisme_id) => {
   const organisme = await findOrganismeById(organisme_id);
+  if (!organisme) {
+    throw new Error("organisme not found");
+  }
   const effectifsDb = await findEffectifs(organisme_id);
   let effectifs = [];
   for (const effectif of effectifsDb) {

--- a/server/src/common/actions/uploads.actions.js
+++ b/server/src/common/actions/uploads.actions.js
@@ -48,6 +48,7 @@ export const addDocument = async (
   organisme_id,
   { nom_fichier, chemin_fichier, taille_fichier, ext_fichier, hash_fichier, userEmail }
 ) => {
+  /** @type {any} */
   let found = null;
   try {
     found = await getUploadEntryByOrgaId(organisme_id);
@@ -95,6 +96,7 @@ export const addDocument = async (
 
 // TODO DIRTY update, to clean
 export const updateDocument = async (organisme_id, { nom_fichier, taille_fichier, ...data }) => {
+  /** @type {any} */
   let found = null;
   try {
     found = await getUploadEntryByOrgaId(organisme_id);
@@ -125,6 +127,9 @@ export const updateDocument = async (organisme_id, { nom_fichier, taille_fichier
   return updated.value;
 };
 
+/**
+ * @returns {Promise<any>}
+ */
 export const removeDocument = async (organismeId, { nom_fichier, chemin_fichier, taille_fichier }) => {
   const found = await getUploadEntryByOrgaId(organismeId);
 

--- a/server/src/common/actions/users.actions.js
+++ b/server/src/common/actions/users.actions.js
@@ -13,7 +13,7 @@ import { findActivePermissionsForUser, hasAtLeastOneContributeurNotPending } fro
 /**
  * Méthode de création d'un utilisateur
  * @param {*} userProps
- * @returns
+ * @returns {Promise<import("mongodb").WithId<any>>}
  */
 export const createUser = async ({ email, password }, options = {}) => {
   const passwordHash = options.hash || hashUtil(password);
@@ -127,7 +127,7 @@ export const authenticate = async (email, password) => {
   const current = user.password;
   if (compare(password, current)) {
     if (isTooWeak(current)) {
-      await rehashPassword(user, password);
+      await rehashPassword(user._id, password);
     }
     return user;
   }
@@ -251,6 +251,7 @@ export const updateMainOrganismeUser = async ({ organisme_id, userEmail }) => {
 };
 
 export const structureUser = async (user) => {
+  /** @type {import("mongodb").WithId<any>[]} */
   const rolesList = user.roles?.length
     ? await rolesDb()
         .find({ _id: { $in: user.roles } })
@@ -310,6 +311,7 @@ export const updateUserLastConnection = async (email) => {
       $set: {
         last_connection: new Date(),
       },
+      // @ts-ignore
       $push: { connection_history: new Date() },
     }
   );

--- a/server/src/common/mongodb.js
+++ b/server/src/common/mongodb.js
@@ -3,6 +3,7 @@ import omitDeep from "omit-deep";
 import logger from "./logger.js";
 import { asyncForEach } from "./utils/asyncUtils.js";
 
+/** @type {MongoClient} */
 let mongodbClient;
 
 const ensureInitialization = () => {
@@ -74,7 +75,7 @@ export const collectionExistInDb = (collectionsInDb, collectionName) =>
  */
 export const configureDbSchemaValidation = async (modelDescriptors) => {
   const db = getDatabase();
-  await ensureInitialization();
+  ensureInitialization();
   await asyncForEach(modelDescriptors, async ({ collectionName, schema }) => {
     await createCollectionIfDoesNotExist(collectionName);
 
@@ -104,15 +105,11 @@ export const clearAllCollections = async () => {
 
 /**
  * Clear d'une collection
- * @param {*} name
+ * @param {string} name
  * @returns
  */
-export function clearCollection(name) {
+export async function clearCollection(name) {
   logger.warn(`Suppression des données de la collection ${name}...`);
   ensureInitialization();
-  return mongodbClient
-    .db()
-    .collection(name)
-    .deleteMany({})
-    .then((res) => res.deletedCount);
+  await getDatabase().collection(name).deleteMany({});
 }

--- a/server/src/http/routes/admin.routes/users.routes.js
+++ b/server/src/http/routes/admin.routes/users.routes.js
@@ -31,7 +31,10 @@ export default ({ mailer }) => {
     "/users",
     tryCatch(async (req, res) => {
       let usersList = await getAllUsers();
-      let roleNamesById = (await getAllRoles()).reduce((acc, role) => ({ ...acc, [role._id]: role.name }), {});
+      let roleNamesById = (await getAllRoles()).reduce(
+        (acc, role) => ({ ...acc, [role._id.toString()]: role.name }),
+        {}
+      );
       let permissionsByEmail = (await getAllPermissions()).reduce(
         (acc, permission) => ({
           ...acc,
@@ -144,8 +147,7 @@ export default ({ mailer }) => {
     tryCatch(async ({ body, params }, res) => {
       const userid = params.userid;
 
-      let rolesId = await findRolesByNames(body.options.roles, { _id: 1 });
-      rolesId = rolesId.map(({ _id }) => _id);
+      const rolesId = (await findRolesByNames(body.options.roles, { _id: 1 })).map(({ _id }) => _id);
 
       const options = body.options;
 

--- a/server/src/http/routes/specific.routes/dossiers-apprenants.routes.js
+++ b/server/src/http/routes/specific.routes/dossiers-apprenants.routes.js
@@ -123,7 +123,7 @@ export default () => {
           if (dossierApprenantValidation.error) {
             const prettyValidationError = buildPrettyValidationError(dossierApprenantValidation.error);
             validationErrors.push(prettyValidationError);
-            await dossiersApprenantsApiErrorsDb().insert({
+            await dossiersApprenantsApiErrorsDb().insertOne({
               erp: user.username,
               created_at: new Date(),
               data: currentDossierApprenant,

--- a/server/src/http/routes/specific.routes/effectif.routes.js
+++ b/server/src/http/routes/specific.routes/effectif.routes.js
@@ -221,7 +221,7 @@ export default () => {
       // eslint-disable-next-line no-unused-vars
       const { inputNames, ...data } = body; // TODO JOI (inputNames used to track suer actions)
 
-      const effectifDb = await effectifsDb().findOne({ _id: new ObjectId(params.id) }, { _id: 0, __v: 0 });
+      const effectifDb = await effectifsDb().findOne({ _id: new ObjectId(params.id) });
       if (!effectifDb) {
         throw new Error(`Unable to find effectif ${params.id}`);
       }

--- a/server/src/http/routes/specific.routes/organismes.routes.js
+++ b/server/src/http/routes/specific.routes/organismes.routes.js
@@ -25,6 +25,7 @@ export default () => {
       const limit = Number(params.limit ?? 50);
       const skip = (page - 1) * limit;
 
+      /** @type {import("mongodb").Filter<any>} */
       const jsonQuery = JSON.parse(query);
       const allData = await organismesDb().find(jsonQuery).skip(skip).limit(limit).toArray();
       const count = await organismesDb().countDocuments(jsonQuery);

--- a/server/src/http/routes/specific.routes/serp.routes/upload.routes.js
+++ b/server/src/http/routes/specific.routes/serp.routes/upload.routes.js
@@ -664,8 +664,8 @@ export default ({ clamav }) => {
           `Vérification en cours: ${index + 1} sur ${convertedData.length} effectifs`
         );
         if (typeCodeDiplome === "RNCP" && data.formation?.rncp) {
-          const { cfd } = (await getFormationWithRNCP(data.formation?.rncp, { cfd: 1 })) || {};
-          data.formation.cfd = cfd ?? "Erreur";
+          const formation = await getFormationWithRNCP(data.formation?.rncp, { cfd: 1 });
+          data.formation.cfd = formation?.cfd ?? "Erreur";
         } else {
           const { rncps } = (await getFormationWithCfd(data.formation.cfd, { rncps: 1 })) || { rncps: [] };
           data.formation.rncp = rncps[0] ?? data.formation?.rncp;
@@ -709,8 +709,8 @@ export default ({ clamav }) => {
 
             const formationDb = await findFormationById(organismeFormation.formation_id);
             data.formation.formation_id = organismeFormation.formation_id;
-            data.formation.annee = formationDb.annee;
-            data.formation.libelle_long = formationDb.libelle;
+            data.formation.annee = formationDb?.annee;
+            data.formation.libelle_long = formationDb?.libelle;
             const { effectif: canBeImportEffectif, found: foundInDb } = await hydrateEffectif(
               {
                 organisme_id,

--- a/server/src/jobs/fiabilisation/dossiersApprenants/analyse-fiabilite-dossiers-apprenants-recus.js
+++ b/server/src/jobs/fiabilisation/dossiersApprenants/analyse-fiabilite-dossiers-apprenants-recus.js
@@ -36,7 +36,7 @@ export const analyseFiabiliteDossierApprenantsRecus = async () => {
   const latestReceivedDossiersApprenantsCursor = getReceivedDossiersApprenantsInLast24hCursor();
 
   // delete existing dossiers apprenant analysis results
-  await getDbCollection("dossiersApprenantsApiInputFiabilite").deleteMany();
+  await getDbCollection("dossiersApprenantsApiInputFiabilite").deleteMany({});
 
   // build map of non unique apprenants to mark them as such in fiabilité analysis
   logger.info("Building Map of unique apprenants received in the last 24h");
@@ -73,6 +73,7 @@ export const analyseFiabiliteDossierApprenantsRecus = async () => {
   // iterate over data and create an entry for each dossier apprenant sent with fiabilité metadata
   logger.info("Iterating over all dossiers apprenants received in the last 24h to analyse their data");
   while (await latestReceivedDossiersApprenantsCursor.hasNext()) {
+    /** @type {any} */
     const { data, username, date } = await latestReceivedDossiersApprenantsCursor.next();
     latestReceivedDossiersApprenantsCount++;
 

--- a/server/src/jobs/hydrate/archive-dossiers-apprenants/hydrate-archive-dossiersApprenants.js
+++ b/server/src/jobs/hydrate/archive-dossiers-apprenants/hydrate-archive-dossiersApprenants.js
@@ -41,6 +41,7 @@ const hydrateArchivesDossiersApprenants = async (ANNEE_SCOLAIRE_START_LIMIT = 20
 
   const cursor = dossiersApprenantsMigrationDb().find(query);
   while (await cursor.hasNext()) {
+    /** @type {import("mongodb").WithId<any>} */
     const dossierApprenantToArchive = await cursor.next();
 
     try {

--- a/server/src/jobs/hydrate/reseaux/hydrate-reseaux.js
+++ b/server/src/jobs/hydrate/reseaux/hydrate-reseaux.js
@@ -117,6 +117,7 @@ const hydrateReseauFile = async (filename) => {
         1 - Add réseau information to organisme in TDB, if found unique
       */
     // try to retrieve organisme in our database with UAI and SIRET if UAI is provided
+    /** @type {(import("mongodb").WithId<any>)[]} */
     const organismeInTdb = organismeParsedFromFile.uai
       ? [await findOrganismeByUaiAndSiret(organismeParsedFromFile.uai, organismeParsedFromFile.siret)].filter((o) => o)
       : await findOrganismesBySiret(organismeParsedFromFile.siret);

--- a/server/src/jobs/seed/start/index.js
+++ b/server/src/jobs/seed/start/index.js
@@ -208,7 +208,7 @@ const seedSampleUsers = async () => {
     await userAfterCreate({ user: userOfR, pending: false, notify: false, asRole: "organisme.admin" });
     // Get organisme id for user
     const organismeOff = await findOrganismeByUai("0142321X");
-    await addContributeurOrganisme(organismeOff._id, userOfR.email, "organisme.statsonly", false);
+    await addContributeurOrganisme(organismeOff?._id, userOfR?.email, "organisme.statsonly", false);
     logger.info("User ofr created");
   }
 

--- a/server/tests/integration/common/actions/organismes.actions.test.js
+++ b/server/tests/integration/common/actions/organismes.actions.test.js
@@ -85,11 +85,11 @@ describe("Test des actions Organismes", () => {
       });
 
       // Vérification des autres champs
-      assert.equal(created.nom_tokenized, buildTokenizedString(sampleOrganisme.nom.trim(), 4));
-      assert.equal(created.private_url !== null, true);
-      assert.equal(created.accessToken !== null, true);
-      assert.equal(created.created_at !== null, true);
-      assert.equal(created.updated_at !== null, true);
+      assert.equal(created?.nom_tokenized, buildTokenizedString(sampleOrganisme.nom.trim(), 4));
+      assert.equal(created?.private_url !== null, true);
+      assert.equal(created?.accessToken !== null, true);
+      assert.equal(created?.created_at !== null, true);
+      assert.equal(created?.updated_at !== null, true);
     });
 
     it("returns created organisme when valid with SIRET and no UAI & no API Calls", async () => {
@@ -119,11 +119,11 @@ describe("Test des actions Organismes", () => {
       });
 
       // Vérification des autres champs
-      assert.equal(created.nom_tokenized, buildTokenizedString(sampleOrganisme.nom.trim(), 4));
-      assert.equal(created.private_url !== null, true);
-      assert.equal(created.accessToken !== null, true);
-      assert.equal(created.created_at !== null, true);
-      assert.equal(created.updated_at !== null, true);
+      assert.equal(created?.nom_tokenized, buildTokenizedString(sampleOrganisme.nom.trim(), 4));
+      assert.equal(created?.private_url !== null, true);
+      assert.equal(created?.accessToken !== null, true);
+      assert.equal(created?.created_at !== null, true);
+      assert.equal(created?.updated_at !== null, true);
     });
 
     it("returns created organisme when valid with UAI & SIRET & API Calls", async () => {
@@ -149,18 +149,18 @@ describe("Test des actions Organismes", () => {
       });
 
       assert.deepEqual(
-        created.adresse,
+        created?.adresse,
         buildAdresseFromApiEntreprise(SAMPLES_ETABLISSEMENTS_API_ENTREPRISE.sample41461021200014.etablissement)
       );
 
       // TODO Tester les API pour les formations tree et les metiers LBA
 
       // Vérification des autres champs
-      assert.equal(created.nom_tokenized, buildTokenizedString(sampleOrganisme.nom.trim(), 4));
-      assert.equal(created.private_url !== null, true);
-      assert.equal(created.accessToken !== null, true);
-      assert.equal(created.created_at !== null, true);
-      assert.equal(created.updated_at !== null, true);
+      assert.equal(created?.nom_tokenized, buildTokenizedString(sampleOrganisme.nom.trim(), 4));
+      assert.equal(created?.private_url !== null, true);
+      assert.equal(created?.accessToken !== null, true);
+      assert.equal(created?.created_at !== null, true);
+      assert.equal(created?.updated_at !== null, true);
     });
 
     it("returns created organisme when valid with SIRET & no UAI & API Calls", async () => {
@@ -198,14 +198,14 @@ describe("Test des actions Organismes", () => {
         voie: `${adresse?.type_voie}${adresse.nom_voie}`,
       };
 
-      assert.deepEqual(created.adresse, adresseBuildFromApiEntreprise);
+      assert.deepEqual(created?.adresse, adresseBuildFromApiEntreprise);
 
       // Vérification des autres champs
-      assert.equal(created.nom_tokenized, buildTokenizedString(sampleOrganisme.nom.trim(), 4));
-      assert.equal(created.private_url !== null, true);
-      assert.equal(created.accessToken !== null, true);
-      assert.equal(created.created_at !== null, true);
-      assert.equal(created.updated_at !== null, true);
+      assert.equal(created?.nom_tokenized, buildTokenizedString(sampleOrganisme.nom.trim(), 4));
+      assert.equal(created?.private_url !== null, true);
+      assert.equal(created?.accessToken !== null, true);
+      assert.equal(created?.created_at !== null, true);
+      assert.equal(created?.updated_at !== null, true);
     });
   });
 
@@ -247,18 +247,18 @@ describe("Test des actions Organismes", () => {
       });
 
       assert.deepEqual(pick(updatedOrganisme, ["uai", "siret", "nom", "adresse", "nature"]), {
-        uai: updatedOrganisme.uai,
-        siret: updatedOrganisme.siret,
+        uai: updatedOrganisme?.uai,
+        siret: updatedOrganisme?.siret,
         nom: "UPDATED",
-        adresse: updatedOrganisme.adresse,
-        nature: updatedOrganisme.nature,
+        adresse: updatedOrganisme?.adresse,
+        nature: updatedOrganisme?.nature,
       });
 
-      assert.equal(updatedOrganisme.nom_tokenized, buildTokenizedString("UPDATED", 4));
-      assert.equal(updatedOrganisme.private_url !== null, true);
-      assert.equal(updatedOrganisme.accessToken !== null, true);
-      assert.equal(updatedOrganisme.created_at !== null, true);
-      assert.equal(updatedOrganisme.updated_at !== null, true);
+      assert.equal(updatedOrganisme?.nom_tokenized, buildTokenizedString("UPDATED", 4));
+      assert.equal(updatedOrganisme?.private_url !== null, true);
+      assert.equal(updatedOrganisme?.accessToken !== null, true);
+      assert.equal(updatedOrganisme?.created_at !== null, true);
+      assert.equal(updatedOrganisme?.updated_at !== null, true);
     });
 
     it("returns updated organisme when id valid and API Calls", async () => {
@@ -279,10 +279,10 @@ describe("Test des actions Organismes", () => {
       const updatedOrganisme = await updateOrganisme(_id, toUpdateOrganisme);
 
       assert.deepEqual(pick(updatedOrganisme, ["uai", "siret", "api_key", "nature"]), {
-        uai: updatedOrganisme.uai,
-        siret: updatedOrganisme.siret,
+        uai: updatedOrganisme?.uai,
+        siret: updatedOrganisme?.siret,
         api_key: "UPDATED",
-        nature: updatedOrganisme.nature,
+        nature: updatedOrganisme?.nature,
       });
 
       // Vérification de l'adresse construite depuis l'appel API Entreprise
@@ -300,14 +300,14 @@ describe("Test des actions Organismes", () => {
         voie: `${adresse?.type_voie}${adresse.nom_voie}`,
       };
 
-      assert.deepEqual(updatedOrganisme.adresse, adresseBuildFromApiEntreprise);
+      assert.deepEqual(updatedOrganisme?.adresse, adresseBuildFromApiEntreprise);
       // TODO Tester les API pour les formations tree et les metiers LBA
 
-      assert.equal(updatedOrganisme.nom_tokenized, buildTokenizedString(sampleOrganisme.nom.trim(), 4));
-      assert.equal(updatedOrganisme.private_url !== null, true);
-      assert.equal(updatedOrganisme.accessToken !== null, true);
-      assert.equal(updatedOrganisme.created_at !== null, true);
-      assert.equal(updatedOrganisme.updated_at !== null, true);
+      assert.equal(updatedOrganisme?.nom_tokenized, buildTokenizedString(sampleOrganisme.nom.trim(), 4));
+      assert.equal(updatedOrganisme?.private_url !== null, true);
+      assert.equal(updatedOrganisme?.accessToken !== null, true);
+      assert.equal(updatedOrganisme?.created_at !== null, true);
+      assert.equal(updatedOrganisme?.updated_at !== null, true);
     });
 
     it("returns updated organisme & update ferme field to false when id valid and no API Calls", async () => {
@@ -331,7 +331,7 @@ describe("Test des actions Organismes", () => {
         { buildFormationTree: false, buildInfosFromSiret: false, callLbaApi: false }
       );
 
-      assert.equal(updatedOrganisme.ferme, false);
+      assert.equal(updatedOrganisme?.ferme, false);
     });
 
     it("returns updated organisme & does not update ferme field when id valid and no API Calls", async () => {
@@ -355,7 +355,7 @@ describe("Test des actions Organismes", () => {
         { buildFormationTree: false, buildInfosFromSiret: false, callLbaApi: false }
       );
 
-      assert.equal(updatedOrganisme.ferme, true);
+      assert.equal(updatedOrganisme?.ferme, true);
     });
 
     it("returns updated organisme & update ferme field from API", async () => {
@@ -375,7 +375,7 @@ describe("Test des actions Organismes", () => {
       const { _id } = await createOrganisme(sampleOrganisme);
       const updatedOrganisme = await updateOrganisme(_id, { ...sampleOrganisme });
 
-      assert.equal(updatedOrganisme.ferme, false);
+      assert.equal(updatedOrganisme?.ferme, false);
     });
   });
 
@@ -494,13 +494,13 @@ describe("Test des actions Organismes", () => {
 
       // Vérification de la création sans first_transmission_date
       const created = await findOrganismeById(_id);
-      assert.deepStrictEqual(created.first_transmission_date, undefined);
+      assert.deepStrictEqual(created?.first_transmission_date, undefined);
 
       // MAJ de l'organisme et vérification de l'ajout de first_transmission_date
       await setOrganismeTransmissionDates(_id);
       const updated = await findOrganismeById(_id);
-      assert.notDeepStrictEqual(updated.first_transmission_date, undefined);
-      assert.notDeepStrictEqual(updated.last_transmission_date, undefined);
+      assert.notDeepStrictEqual(updated?.first_transmission_date, undefined);
+      assert.notDeepStrictEqual(updated?.last_transmission_date, undefined);
     });
 
     it("mets à jour la date last_transmission_date pour un organisme avec first_transmission_date", async () => {
@@ -528,13 +528,13 @@ describe("Test des actions Organismes", () => {
 
       // Vérification de la création avec first_transmission_date
       const created = await findOrganismeById(_id);
-      assert.deepStrictEqual(created.first_transmission_date, first_transmission_date);
+      assert.deepStrictEqual(created?.first_transmission_date, first_transmission_date);
 
       // MAJ de l'organisme et vérification de l'ajout de last_transmission_date
       await setOrganismeTransmissionDates(_id);
       const updated = await findOrganismeById(_id);
-      assert.deepStrictEqual(updated.first_transmission_date, first_transmission_date);
-      assert.notDeepStrictEqual(updated.last_transmission_date, undefined);
+      assert.deepStrictEqual(updated?.first_transmission_date, first_transmission_date);
+      assert.notDeepStrictEqual(updated?.last_transmission_date, undefined);
     });
   });
 });

--- a/server/tests/integration/common/actions/users.legacy.actions.test.js
+++ b/server/tests/integration/common/actions/users.legacy.actions.test.js
@@ -19,9 +19,9 @@ describe("Components Users Test", () => {
     it("Permet de créer un utilisateur avec mot de passe", async () => {
       const createdId = await createUserLegacy({ username: "user", password: "password" });
       const found = await usersDb().findOne({ _id: createdId });
-      assert.equal(found.username, "user");
-      assert.equal(found.permissions.length, 0);
-      assert.equal(found.password.startsWith("$6$rounds="), true);
+      assert.equal(found?.username, "user");
+      assert.equal(found?.permissions.length, 0);
+      assert.equal(found?.password.startsWith("$6$rounds="), true);
     });
 
     it("Renvoie une erreur lorsqu'un utilisateur avec le même username existe en base", async () => {
@@ -36,9 +36,9 @@ describe("Components Users Test", () => {
     it("Crée un utilisateur avec mot de passe random quand pas de mot de passe fourni", async () => {
       const createdId = await createUserLegacy({ username: "user" });
       const found = await usersDb().findOne({ _id: createdId });
-      assert.equal(found.username, "user");
-      assert.equal(found.permissions.length, 0);
-      assert.equal(found.password.startsWith("$6$rounds="), true);
+      assert.equal(found?.username, "user");
+      assert.equal(found?.permissions.length, 0);
+      assert.equal(found?.password.startsWith("$6$rounds="), true);
     });
 
     it("Permet de créer un utilisateur avec les droits d'admin", async () => {
@@ -48,7 +48,7 @@ describe("Components Users Test", () => {
         permissions: [apiRoles.administrator],
       });
       const found = await usersDb().findOne({ _id: createdId });
-      assert.equal(found.permissions.includes(apiRoles.administrator), true);
+      assert.equal(found?.permissions.includes(apiRoles.administrator), true);
     });
 
     it("Permet de créer un utilisateur avec un email, les droits de réseau et un réseau", async () => {
@@ -61,9 +61,9 @@ describe("Components Users Test", () => {
       });
       const found = await usersDb().findOne({ _id: createdId });
 
-      assert.equal(found.permissions.includes(tdbRoles.network), true);
-      assert.equal(found.network === "test", true);
-      assert.equal(found.email === "email@test.fr", true);
+      assert.equal(found?.permissions.includes(tdbRoles.network), true);
+      assert.equal(found?.network === "test", true);
+      assert.equal(found?.email === "email@test.fr", true);
     });
 
     it("Permet de créer un utilisateur avec un email, les droits de réseau et un réseau, une région et un organisme", async () => {
@@ -78,11 +78,11 @@ describe("Components Users Test", () => {
       });
       const found = await usersDb().findOne({ _id: createdId });
 
-      assert.equal(found.permissions.includes(tdbRoles.network), true);
-      assert.equal(found.network === "test", true);
-      assert.equal(found.region === "REGION", true);
-      assert.equal(found.organisme === "ORGANISME", true);
-      assert.equal(found.email === "email@test.fr", true);
+      assert.equal(found?.permissions.includes(tdbRoles.network), true);
+      assert.equal(found?.network === "test", true);
+      assert.equal(found?.region === "REGION", true);
+      assert.equal(found?.organisme === "ORGANISME", true);
+      assert.equal(found?.email === "email@test.fr", true);
     });
   });
 
@@ -107,8 +107,8 @@ describe("Components Users Test", () => {
         password: "password",
       });
       const user = await authenticateLegacy("user", "password");
-      assert.strictEqual(user.username, "user");
-      assert.strictEqual(!!user.last_connection, true);
+      assert.strictEqual(user?.username, "user");
+      assert.strictEqual(!!user?.last_connection, true);
     });
 
     it("Vérifie que le mot de passe est invalide", async () => {
@@ -130,13 +130,13 @@ describe("Components Users Test", () => {
       const token = await generatePasswordUpdateTokenLegacy("user");
       const userInDb = await usersDb().findOne({ _id: createdId });
 
-      assert.equal(userInDb.password_update_token, token);
+      assert.equal(userInDb?.password_update_token, token);
       // password token should expire in 48h ~ 2880 minutes, ±1 seconds tolerance
-      const diffSeconds = differenceInSeconds(userInDb.password_update_token_expiry, new Date());
+      const diffSeconds = differenceInSeconds(userInDb?.password_update_token_expiry, new Date());
       const _48hoursInSeconds = 48 * 60 * 60;
       assert.equal(_48hoursInSeconds - diffSeconds <= 1, true);
       assert.equal(_48hoursInSeconds - diffSeconds >= 0, true);
-      assert.equal(differenceInCalendarDays(userInDb.password_update_token_expiry, new Date()), 2);
+      assert.equal(differenceInCalendarDays(userInDb?.password_update_token_expiry, new Date()), 2);
     });
 
     it("renvoie une erreur quand le user n'est pas trouvé", async () => {
@@ -165,9 +165,9 @@ describe("Components Users Test", () => {
       await updatePasswordLegacy(token, "new-password-strong");
       const foundAfterUpdate = await usersDb().findOne({ _id: createdId });
 
-      assert.notEqual(foundAfterUpdate.password, foundBeforeUpdate.password);
-      assert.equal(foundAfterUpdate.password_update_token, null);
-      assert.equal(foundAfterUpdate.password_update_token_expiry, null);
+      assert.notEqual(foundAfterUpdate?.password, foundBeforeUpdate?.password);
+      assert.equal(foundAfterUpdate?.password_update_token, null);
+      assert.equal(foundAfterUpdate?.password_update_token_expiry, null);
     });
 
     it("renvoie une erreur quand le token passé ne permet pas de retrouver le user", async () => {
@@ -211,7 +211,7 @@ describe("Components Users Test", () => {
       const user = await usersDb().findOne({ _id: createdId });
 
       await usersDb().updateOne(
-        { _id: user._id },
+        { _id: user?._id },
         { $set: { password_update_token_expiry: subMinutes(new Date(), 10) } }
       );
 
@@ -276,14 +276,14 @@ describe("Components Users Test", () => {
       const createdId = await createUserLegacy(userProps);
       const found = await usersDb().findOne({ _id: createdId });
 
-      assert.equal(found.permissions.includes(tdbRoles.network), true);
-      assert.equal(found.network === "test", true);
-      assert.equal(found.email === "havertz@rma.es", true);
+      assert.equal(found?.permissions.includes(tdbRoles.network), true);
+      assert.equal(found?.network === "test", true);
+      assert.equal(found?.email === "havertz@rma.es", true);
 
       const results = await searchUsersLegacy({ searchTerm });
 
       assert.equal(results.length, 1);
-      assert.ok(results[0].username, found.username);
+      assert.ok(results[0].username, found?.username);
     });
 
     it("returns results matching username case insensitive", async () => {
@@ -302,9 +302,9 @@ describe("Components Users Test", () => {
 
       const found = await usersDb().findOne({ _id: createdId });
 
-      assert.equal(found.permissions.includes(tdbRoles.network), true);
-      assert.equal(found.network === "test", true);
-      assert.equal(found.email === "havertz@rma.es", true);
+      assert.equal(found?.permissions.includes(tdbRoles.network), true);
+      assert.equal(found?.network === "test", true);
+      assert.equal(found?.email === "havertz@rma.es", true);
 
       const results = await searchUsersLegacy({ searchTerm });
 
@@ -328,9 +328,9 @@ describe("Components Users Test", () => {
 
       const found = await usersDb().findOne({ _id: createdId });
 
-      assert.equal(found.permissions.includes(tdbRoles.network), true);
-      assert.equal(found.network === "test", true);
-      assert.equal(found.email === "havertz@rma.es", true);
+      assert.equal(found?.permissions.includes(tdbRoles.network), true);
+      assert.equal(found?.network === "test", true);
+      assert.equal(found?.email === "havertz@rma.es", true);
 
       const results = await searchUsersLegacy({ searchTerm });
 
@@ -353,9 +353,9 @@ describe("Components Users Test", () => {
 
       const found = await usersDb().findOne({ _id: createdId });
 
-      assert.equal(found.permissions.includes(tdbRoles.network), true);
-      assert.equal(found.network === "test", true);
-      assert.equal(found.email === "havertz@rma.es", true);
+      assert.equal(found?.permissions.includes(tdbRoles.network), true);
+      assert.equal(found?.network === "test", true);
+      assert.equal(found?.email === "havertz@rma.es", true);
 
       const results = await searchUsersLegacy({ searchTerm });
 
@@ -379,9 +379,9 @@ describe("Components Users Test", () => {
 
       const found = await usersDb().findOne({ _id: createdId });
 
-      assert.equal(found.permissions.includes(tdbRoles.network), true);
-      assert.equal(found.network === "test", true);
-      assert.equal(found.email === "havertz@rma.es", true);
+      assert.equal(found?.permissions.includes(tdbRoles.network), true);
+      assert.equal(found?.network === "test", true);
+      assert.equal(found?.email === "havertz@rma.es", true);
 
       const results = await searchUsersLegacy({ searchTerm });
 
@@ -405,9 +405,9 @@ describe("Components Users Test", () => {
 
       const found = await usersDb().findOne({ _id: createdId });
 
-      assert.equal(found.permissions.includes(tdbRoles.network), true);
-      assert.equal(found.network === "test", true);
-      assert.equal(found.email === "havertz@rma.es", true);
+      assert.equal(found?.permissions.includes(tdbRoles.network), true);
+      assert.equal(found?.network === "test", true);
+      assert.equal(found?.email === "havertz@rma.es", true);
 
       const results = await searchUsersLegacy({ searchTerm });
 
@@ -430,9 +430,9 @@ describe("Components Users Test", () => {
 
       const found = await usersDb().findOne({ _id: createdId });
 
-      assert.equal(found.permissions.includes(tdbRoles.network), true);
-      assert.equal(found.network === "test", true);
-      assert.equal(found.email === "havertz@rma.es", true);
+      assert.equal(found?.permissions.includes(tdbRoles.network), true);
+      assert.equal(found?.network === "test", true);
+      assert.equal(found?.email === "havertz@rma.es", true);
 
       const results = await searchUsersLegacy({ searchTerm });
 
@@ -456,9 +456,9 @@ describe("Components Users Test", () => {
 
       const found = await usersDb().findOne({ _id: createdId });
 
-      assert.equal(found.permissions.includes(tdbRoles.network), true);
-      assert.equal(found.network === "test", true);
-      assert.equal(found.email === "havertz@rma.es", true);
+      assert.equal(found?.permissions.includes(tdbRoles.network), true);
+      assert.equal(found?.network === "test", true);
+      assert.equal(found?.email === "havertz@rma.es", true);
 
       const results = await searchUsersLegacy({ searchTerm });
 
@@ -482,9 +482,9 @@ describe("Components Users Test", () => {
 
       const found = await usersDb().findOne({ _id: createdId });
 
-      assert.equal(found.permissions.includes(tdbRoles.network), true);
-      assert.equal(found.network === "test", true);
-      assert.equal(found.email === "havertz@rma.es", true);
+      assert.equal(found?.permissions.includes(tdbRoles.network), true);
+      assert.equal(found?.network === "test", true);
+      assert.equal(found?.email === "havertz@rma.es", true);
 
       const results = await searchUsersLegacy({ searchTerm });
 
@@ -507,9 +507,9 @@ describe("Components Users Test", () => {
 
       const found = await usersDb().findOne({ _id: createdId });
 
-      assert.equal(found.permissions.includes(tdbRoles.network), true);
-      assert.equal(found.network === "test", true);
-      assert.equal(found.email === "havertz@rma.es", true);
+      assert.equal(found?.permissions.includes(tdbRoles.network), true);
+      assert.equal(found?.network === "test", true);
+      assert.equal(found?.email === "havertz@rma.es", true);
 
       const results = await searchUsersLegacy({ searchTerm });
 
@@ -533,9 +533,9 @@ describe("Components Users Test", () => {
 
       const found = await usersDb().findOne({ _id: createdId });
 
-      assert.equal(found.permissions.includes(tdbRoles.network), true);
-      assert.equal(found.network === "test", true);
-      assert.equal(found.email === "havertz@rma.es", true);
+      assert.equal(found?.permissions.includes(tdbRoles.network), true);
+      assert.equal(found?.network === "test", true);
+      assert.equal(found?.email === "havertz@rma.es", true);
 
       const results = await searchUsersLegacy({ searchTerm });
 
@@ -553,8 +553,8 @@ describe("Components Users Test", () => {
 
       // find user
       const found = await usersDb().findOne({ username: usernameTest });
-      assert.equal(found.username === usernameTest, true);
-      assert.equal(found._id !== null, true);
+      assert.equal(found?.username === usernameTest, true);
+      assert.equal(found?._id !== null, true);
 
       // update user with bad id
       const objectId = new mongodb.ObjectId();
@@ -569,16 +569,16 @@ describe("Components Users Test", () => {
 
       // find user
       const found = await usersDb().findOne({ username: usernameTest });
-      assert.equal(found.username === usernameTest, true);
-      assert.equal(found._id !== null, true);
+      assert.equal(found?.username === usernameTest, true);
+      assert.equal(found?._id !== null, true);
 
       // update user
       const updatedUserName = "UPDATED";
-      await updateUserLegacy(found._id, { username: updatedUserName });
+      await updateUserLegacy(found?._id, { username: updatedUserName });
 
       // Check update
-      const foundAfterUpdate = await usersDb().findOne({ _id: found._id });
-      assert.equal(foundAfterUpdate.username === updatedUserName, true);
+      const foundAfterUpdate = await usersDb().findOne({ _id: found?._id });
+      assert.equal(foundAfterUpdate?.username === updatedUserName, true);
     });
 
     it("Permets la MAJ d'un utilisateur pour son email", async () => {
@@ -589,16 +589,16 @@ describe("Components Users Test", () => {
 
       // find user
       const found = await usersDb().findOne({ username: usernameTest });
-      assert.equal(found.email === "test@test.fr", true);
-      assert.equal(found._id !== null, true);
+      assert.equal(found?.email === "test@test.fr", true);
+      assert.equal(found?._id !== null, true);
 
       // update user
       const updateValue = "UPDATED@test.fr";
-      await updateUserLegacy(found._id, { email: updateValue });
+      await updateUserLegacy(found?._id, { email: updateValue });
 
       // Check update
-      const foundAfterUpdate = await usersDb().findOne({ _id: found._id });
-      assert.equal(foundAfterUpdate.email === updateValue, true);
+      const foundAfterUpdate = await usersDb().findOne({ _id: found?._id });
+      assert.equal(foundAfterUpdate?.email === updateValue, true);
     });
 
     it("Permets la MAJ d'un utilisateur pour son réseau", async () => {
@@ -609,16 +609,16 @@ describe("Components Users Test", () => {
 
       // find user
       const found = await usersDb().findOne({ username: usernameTest });
-      assert.equal(found._id !== null, true);
-      assert.equal(found.network === "TEST_RESEAU", true);
+      assert.equal(found?._id !== null, true);
+      assert.equal(found?.network === "TEST_RESEAU", true);
 
       // update user
       const updateValue = "UPDATED_NETWORK";
-      await updateUserLegacy(found._id, { network: updateValue });
+      await updateUserLegacy(found?._id, { network: updateValue });
 
       // Check update
-      const foundAfterUpdate = await usersDb().findOne({ _id: found._id });
-      assert.equal(foundAfterUpdate.network === updateValue, true);
+      const foundAfterUpdate = await usersDb().findOne({ _id: found?._id });
+      assert.equal(foundAfterUpdate?.network === updateValue, true);
     });
 
     it("Permets la MAJ d'un utilisateur pour sa région", async () => {
@@ -629,16 +629,16 @@ describe("Components Users Test", () => {
 
       // find user
       const found = await usersDb().findOne({ username: usernameTest });
-      assert.equal(found._id !== null, true);
-      assert.equal(found.region === "TEST_REGION", true);
+      assert.equal(found?._id !== null, true);
+      assert.equal(found?.region === "TEST_REGION", true);
 
       // update user
       const updateValue = "UPDATED_REGION";
-      await updateUserLegacy(found._id, { region: updateValue });
+      await updateUserLegacy(found?._id, { region: updateValue });
 
       // Check update
-      const foundAfterUpdate = await usersDb().findOne({ _id: found._id });
-      assert.equal(foundAfterUpdate.region === updateValue, true);
+      const foundAfterUpdate = await usersDb().findOne({ _id: found?._id });
+      assert.equal(foundAfterUpdate?.region === updateValue, true);
     });
 
     it("Permets la MAJ d'un utilisateur pour son organisme", async () => {
@@ -649,16 +649,16 @@ describe("Components Users Test", () => {
 
       // find user
       const found = await usersDb().findOne({ username: usernameTest });
-      assert.equal(found._id !== null, true);
-      assert.equal(found.organisme === "TEST_ORGANISME", true);
+      assert.equal(found?._id !== null, true);
+      assert.equal(found?.organisme === "TEST_ORGANISME", true);
 
       // update user
       const updateValue = "UPDATED_ORGANISME";
-      await updateUserLegacy(found._id, { organisme: updateValue });
+      await updateUserLegacy(found?._id, { organisme: updateValue });
 
       // Check update
-      const foundAfterUpdate = await usersDb().findOne({ _id: found._id });
-      assert.equal(foundAfterUpdate.organisme === updateValue, true);
+      const foundAfterUpdate = await usersDb().findOne({ _id: found?._id });
+      assert.equal(foundAfterUpdate?.organisme === updateValue, true);
     });
   });
 
@@ -671,8 +671,8 @@ describe("Components Users Test", () => {
 
       // find user
       const found = await usersDb().findOne({ username: usernameTest });
-      assert.equal(found.username === usernameTest, true);
-      assert.equal(found._id !== null, true);
+      assert.equal(found?.username === usernameTest, true);
+      assert.equal(found?._id !== null, true);
 
       // get user with bad id
       const objectId = "^pkazd^pkazd";
@@ -687,11 +687,11 @@ describe("Components Users Test", () => {
 
       // find user
       const found = await usersDb().findOne({ username: usernameTest });
-      assert.equal(found.username === usernameTest, true);
+      assert.equal(found?.username === usernameTest, true);
 
       // get user with id
-      const gettedUser = await getUserLegacyById(found._id);
-      assert.equal(gettedUser.username === found.username, true);
+      const gettedUser = await getUserLegacyById(found?._id);
+      assert.equal(gettedUser.username === found?.username, true);
     });
   });
 });

--- a/server/tests/integration/http/dossiersApprenants.route.legacy.test.js
+++ b/server/tests/integration/http/dossiersApprenants.route.legacy.test.js
@@ -121,7 +121,7 @@ describe("Dossiers Apprenants Route", () => {
       const userWithoutPermission = await usersDb().findOne({ _id: createdId });
 
       const { data } = await httpClient.post("/api/login", {
-        username: userWithoutPermission.username,
+        username: userWithoutPermission?.username,
         password: "password",
       });
 
@@ -505,10 +505,10 @@ describe("Dossiers Apprenants Route", () => {
         permissions: [],
       });
       const userWithoutPermission = await usersDb().findOne({ _id: createdId });
-      assert.deepEqual(userWithoutPermission.permissions.length, 0);
+      assert.deepEqual(userWithoutPermission?.permissions.length, 0);
 
       const { data } = await httpClient.post("/api/login", {
-        username: userWithoutPermission.username,
+        username: userWithoutPermission?.username,
         password: "password",
       });
 


### PR DESCRIPTION
- Ajout du type MongoClient au mongoClient global dans `server/src/common/mongodb.js`
Désormais, le type est propagé dans toutes les fonctions qui utilisent du Mongo. En revanche, le typage des documents récupérés / mis à jour est toujours en any.
- Quelques corrections faites pour du code en erreur