### PR TITLE
chore(server): récupération des réseaux fiables uniquement

### DIFF
--- a/server/src/http/routes/specific.routes/old/referentiel.route.js
+++ b/server/src/http/routes/specific.routes/old/referentiel.route.js
@@ -9,7 +9,11 @@ export default () => {
   router.get(
     "/networks",
     tryCatch(async (req, res) => {
-      const networks = Object.keys(RESEAUX_CFAS).map((id) => ({ id, nom: RESEAUX_CFAS[id].nomReseau }));
+      // TODO : TMP on ne renvoie que les réseaux fiabilisés pour l'instant - débloquer le reste quand ce sera fiable
+      const RESEAUX_CFAS_INVALID = ["ANASUP", "GRETA_VAUCLUSE", "CCI", "BTP_CFA"];
+      const networks = Object.keys(RESEAUX_CFAS)
+        .filter((item) => !RESEAUX_CFAS_INVALID.includes(item))
+        .map((id) => ({ id, nom: RESEAUX_CFAS[id].nomReseau }));
       return res.json(networks);
     })
   );

--- a/server/tests/integration/http/referentiel.route.test.js
+++ b/server/tests/integration/http/referentiel.route.test.js
@@ -9,7 +9,8 @@ describe("Referentiel Route", () => {
     const response = await httpClient.get("/api/referentiel/networks");
 
     assert.deepStrictEqual(response.status, 200);
-    assert.deepEqual(response.data.length, Object.values(RESEAUX_CFAS).length);
-    assert.deepEqual(response.data[0].nom, RESEAUX_CFAS.ADEN.nomReseau);
+    const RESEAUX_CFAS_INVALID = ["ANASUP", "GRETA_VAUCLUSE", "CCI", "BTP_CFA"];
+    assert.deepStrictEqual(response.data.length, Object.values(RESEAUX_CFAS).length - RESEAUX_CFAS_INVALID.length);
+    assert.deepStrictEqual(response.data[0].nom, RESEAUX_CFAS.ADEN.nomReseau);
   });
 });


### PR DESCRIPTION
Vu avec Anne, on ne doit pas afficher les réseaux non fiables dans le filtre.
Fix temporaire, on ne stock pas l'info de la fiabilité d'un réseau donc on passe par une const pour l'instant.