### PR TITLE
fix: require mongodb authentication

### DIFF
--- a/.infra/ansible/roles/setup/files/app/.overrides/common/docker-compose.common.yml
+++ b/.infra/ansible/roles/setup/files/app/.overrides/common/docker-compose.common.yml
@@ -19,7 +19,7 @@ services:
       - /opt/flux-retour-cfas/data/server:/data
 
   mongodb:
-    # command: mongod --auth
+    command: mongod --auth
     volumes:
       - /opt/flux-retour-cfas/data/mongodb/db:/data/db
       - /opt/flux-retour-cfas/data/mongodb/configdb:/data/configdb


### PR DESCRIPTION
Le docker-compose.common.yml semble utilisé pour les environnements déployés. J'ai juste décommenté pour rendre obligatoire l'authentification pour chaque connexion.
Les utilisateurs admin, user, metabase et backup existent déjà et sont déjà bien configurés en principe.