### PR TITLE
fix(server): bypass validation on migrations

### DIFF
--- a/server/migrations/20230309120000-remove-unused-fields.js
+++ b/server/migrations/20230309120000-remove-unused-fields.js
@@ -1,9 +1,13 @@
 export const up = async (db) => {
-  await db.collection("users").updateMany({}, { $unset: { orign_register: "" } });
+  await db.collection("users").updateMany({}, { $unset: { orign_register: "" } }, { bypassDocumentValidation: true });
 
   await db
     .collection("usersMigration")
-    .updateMany({}, { $unset: { orign_register: "", description: "", custom_acl: "", tour_guide: "" } });
+    .updateMany(
+      {},
+      { $unset: { orign_register: "", description: "", custom_acl: "", tour_guide: "" } },
+      { bypassDocumentValidation: true }
+    );
 
-  await db.collection("permissions").updateMany({}, { $unset: { custom_acl: "" } });
+  await db.collection("permissions").updateMany({}, { $unset: { custom_acl: "" } }, { bypassDocumentValidation: true });
 };

--- a/server/migrations/20230309150000-update-account-status.js
+++ b/server/migrations/20230309150000-update-account-status.js
@@ -20,7 +20,8 @@ export const up = async (db) => {
           $set: {
             account_status: newStatus,
           },
-        }
+        },
+        { bypassDocumentValidation: true }
       );
     })
   );

--- a/server/migrations/20230313000000-fix-wrong-organisme-no-uai.js
+++ b/server/migrations/20230313000000-fix-wrong-organisme-no-uai.js
@@ -45,7 +45,8 @@ export const up = async (/** @type {import('mongodb').Db} */ db) => {
           $set: {
             main_organisme_id: organisme._id,
           },
-        }
+        },
+        { bypassDocumentValidation: true }
       );
 
       // si après étape de demande des permissions
@@ -59,7 +60,8 @@ export const up = async (/** @type {import('mongodb').Db} */ db) => {
             $set: {
               organisme_id: organisme._id,
             },
-          }
+          },
+          { bypassDocumentValidation: true }
         );
       }
     })


### PR DESCRIPTION
ByPass de la validation sur l'update des 3 dernières migrations.

A discuter ensemble sur le mécanisme le plus propre à retenir pour gérer les migrations de données et/ou de schéma avec validation