### PR TITLE
chore(server): suppression des organismes (& effectifs/dossiersApprenants liés) non fiabilisables mapping

### DIFF
--- a/server/src/common/actions/organismes/organismes.actions.js
+++ b/server/src/common/actions/organismes/organismes.actions.js
@@ -1,7 +1,7 @@
 import { ObjectId } from "mongodb";
 
 import { getMetiersBySiret } from "../../apis/apiLba.js";
-import { organismesDb, effectifsDb, permissionsDb } from "../../model/collections.js";
+import { organismesDb, effectifsDb, permissionsDb, dossiersApprenantsMigrationDb } from "../../model/collections.js";
 import { defaultValuesOrganisme, validateOrganisme } from "../../model/organismes.model.js";
 import { buildAdresseFromApiEntreprise } from "../../utils/adresseUtils.js";
 import { buildTokenizedString } from "../../utils/buildTokenizedString.js";
@@ -490,4 +490,28 @@ export const searchOrganismes = async (searchCriteria) => {
       departement: organisme.uai ? getDepartementCodeFromUai(organisme.uai) : null,
     };
   });
+};
+
+/**
+ * Supprime l'organisme identifié par son id et supprime tous ses effectifs & dossiersApprenantsMigration liés s'ils existent
+ * @param {*} id
+ */
+export const deleteOrganismeAndEffectifsAndDossiersApprenantsMigration = async (id) => {
+  const _id = typeof id === "string" ? new ObjectId(id) : id;
+  if (!ObjectId.isValid(_id)) throw new Error("Invalid id passed");
+
+  const organisme = await organismesDb().findOne({ _id });
+  if (!organisme) throw new Error(`Unable to find organisme ${_id.toString()}`);
+
+  // Suppression des dossiersApprenants liés sur la base du couple uai siret
+  const { deletedCount: deletedDossiersApprenantsMigration } = await dossiersApprenantsMigrationDb().deleteMany({
+    uai_etablissement: organisme.uai,
+    siret_etablissement: organisme.siret,
+  });
+
+  // Suppression des effectifs liés puis de l'organisme
+  const { deletedCount: deletedEffectifs } = await effectifsDb().deleteMany({ organisme_id: id });
+  const { deletedCount: deletedOrganisme } = await organismesDb().deleteOne({ _id: id });
+
+  return { deletedDossiersApprenantsMigration, deletedEffectifs, deletedOrganisme };
 };


### PR DESCRIPTION
MAJ du script de fiabilisation suite au pt avec Anne / Félix : suppression des organismes non fiabilisables (mapping) et leurs dossiersApprenants / effectifs après avoir corrigé les effectifs sur le bon organisme fiable.

Ajout de la fonction de delete d'un organisme et ses effectifs / dossiersApprenants liés dans les actions si besoin de la réutiliser (ca sera le cas dans la suite des étapes de fiabilisation)