### PR TITLE
feat: ajout du champ cle_ministere_educatif dans formations

### DIFF
--- a/server/src/common/actions/formations.actions.ts
+++ b/server/src/common/actions/formations.actions.ts
@@ -67,7 +67,15 @@ export const getNiveauFormationFromLibelle = (niveauFormationLibelle) => {
  * @param {string|null} [formation.annee] - Année de la formation issue du catalogue si fournie
  * @returns {Promise<ObjectId>} Id de la formation crée en base
  */
-export const createFormation = async ({ cfd, duree = null, annee = null }) => {
+export const createFormation = async ({
+  cfd,
+  duree = null,
+  annee = null,
+}: {
+  cfd: string;
+  duree?: string | null;
+  annee?: string | null;
+}) => {
   if (!validateCfd(cfd)) {
     throw Error("Invalid CFD");
   }

--- a/server/src/common/apis/apiCatalogueMna.ts
+++ b/server/src/common/apis/apiCatalogueMna.ts
@@ -1,6 +1,7 @@
 import parentLogger from "@/common/logger";
 import config from "@/config";
 
+import CatalogueFormation from "./@types/CatalogueFormation";
 import getApiClient from "./client";
 
 // Cf Documentation : https://catalogue.apprentissage.beta.gouv.fr/api/v1/docs
@@ -15,11 +16,8 @@ const axiosClient = getApiClient({
 
 /**
  * Méthode de récupération depuis l'API Catalogue des formations liées à un UAI d'organisme
- * @param {string} uai
- * @param {number} [page=1]
- * @returns {Promise<import("./@types/CatalogueFormation").default[]>}
  */
-export const getCatalogFormationsForOrganisme = async (uai, page = 1) => {
+export const getCatalogFormationsForOrganisme = async (uai: string, page = 1): Promise<CatalogueFormation[]> => {
   try {
     // On cherche parmi les formations publiées ayant soit l'UAI formateur soit l'UAI gestionnaire
     const response = await axiosClient.get("/entity/formations", {

--- a/server/src/common/model/organismes.model.ts
+++ b/server/src/common/model/organismes.model.ts
@@ -74,6 +74,9 @@ const schema = object(
       object(
         {
           formation_id: objectId(),
+          cle_ministere_educatif: string({
+            description: "Clé unique de la formation",
+          }),
           annee_formation: integer({
             description: "Année millésime de la formation pour cet organisme",
           }),

--- a/server/tests/integration/common/utils/miscUtils.test.ts
+++ b/server/tests/integration/common/utils/miscUtils.test.ts
@@ -20,31 +20,33 @@ describe("generateRandomAlphanumericPhrase", () => {
 });
 
 describe("stripEmptyFields", () => {
-  const output = stripEmptyFields({
-    a: 1,
-    b: 2,
-    c: 3,
-    d: null,
-    e: undefined,
-    f: "",
-    g: 0,
-    h: false,
-    i: [],
-    j: [null, "", undefined],
-    nested: {
+  it('supprime les champs undefined, null, et "" à la racine et imbriqués', () => {
+    const output = stripEmptyFields({
       a: 1,
-      b: undefined,
-      c: [],
-    },
-  });
-  assert.deepStrictEqual(output, {
-    a: 1,
-    b: 2,
-    c: 3,
-    g: 0,
-    h: false,
-    i: [],
-    j: [null, "", undefined],
-    nested: { a: 1, c: [] },
+      b: 2,
+      c: 3,
+      d: null,
+      e: undefined,
+      f: "",
+      g: 0,
+      h: false,
+      i: [],
+      j: [null, "", undefined],
+      nested: {
+        a: 1,
+        b: undefined,
+        c: [],
+      },
+    });
+    assert.deepStrictEqual(output, {
+      a: 1,
+      b: 2,
+      c: 3,
+      g: 0,
+      h: false,
+      i: [],
+      j: [null, "", undefined],
+      nested: { a: 1, c: [] },
+    });
   });
 });


### PR DESCRIPTION
#2521 

PR minimale avec un nouveau champ dans organismes.relatedFormations[].
Je ne touche pas du tout à la collection formations, qu'on pourra peut-être supprimer après les futurs dashboards d'indicateurs.

Il faudra attendre que le job `update:organismes-with-apis` soit exécuté pour avoir les données à jour. (toutes les nuits) 

---

Mis en pause en attendant d'avoir plus d'informations sur les spécifications.
L'objectif dans le futur est de pouvoir proposer une route pour retourner par exemple la liste des apprentis sans contrat sur la région PACA avec email + avec clé ministère (il faut donc pouvoir lier la clé ministère et l'effectif)

Les formations (collection formations) ne sont créées qu'à l'ajout/mise à jour des organismes.

Après discussion avec @antoinebigard, il apparait que notre modèle de données autour des formations n'est pas méga adapté, car notre collection formations possède un champ cfd unique, or dans le catalogue, il peut exister plusieurs clés ministères éducatifs pour un même cfd.

Les questions :
- Est-ce qu'il faut récupérer l'intégralité des formations du catalogue pour peupler la collection formations ?
- Est-ce qu'on peut "juste" référencer la collection formations depuis chaque organismes.formations et effectifs.formation ?
- Doit-on faire du ménage ? (oui...)
