### PR TITLE
chore: petit lot d'améliorations

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -108,6 +108,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "7.6.0",
+    "@types/bunyan": "1.8.8",
     "@types/mocha": "10.0.1",
     "axiosist": "0.10.0",
     "c8": "7.12.0",

--- a/server/src/common/actions/formations.actions.js
+++ b/server/src/common/actions/formations.actions.js
@@ -47,15 +47,6 @@ export const findFormationById = async (id, projection = {}) => {
 };
 
 /**
- * Construction du libelle de la formation depuis TCO
- * @param {*} formationFromTCO
- * @returns
- */
-const buildFormationLibelle = (formationFromTCO) => {
-  return formationFromTCO.intitule_long || "";
-};
-
-/**
  * Méthode d'extraction du niveau depuis le libelle de la formation
  * @param {*} niveauFormationLibelle
  * @returns
@@ -90,7 +81,7 @@ export const createFormation = async ({ cfd, duree = null, annee = null }) => {
   const formationInfo = await getCfdInfo(cfd);
 
   // Libelle
-  const libelleFormationBuilt = buildFormationLibelle(formationInfo);
+  const libelleFormationBuilt = formationInfo?.intitule_long || "";
   const tokenizedLibelle = buildTokenizedString(libelleFormationBuilt || "", 3);
 
   const { insertedId } = await formationsDb().insertOne(

--- a/server/src/common/actions/infoSiret.actions.js
+++ b/server/src/common/actions/infoSiret.actions.js
@@ -7,7 +7,7 @@ export const findDataFromSiret = async (providedSiret, non_diffusables = true, g
     return {
       result: {},
       messages: {
-        error: `Le Siret ${providedSiret} n'est pas valide, un Siret doit être définit et au format 14 caractères`,
+        error: `Le Siret ${providedSiret} n'est pas valide, un Siret doit être défini et au format 14 caractères`,
       },
     };
   }

--- a/server/src/common/actions/organismes/organismes.actions.js
+++ b/server/src/common/actions/organismes/organismes.actions.js
@@ -45,7 +45,7 @@ export const createOrganisme = async (
   { uai, siret, nom: nomIn, adresse: adresseIn, ferme: fermeIn, ...data },
   options = { callLbaApi: true, buildFormationTree: true, buildInfosFromSiret: true }
 ) => {
-  if (await organismesDb().countDocuments({ uai, siret })) {
+  if ((await organismesDb().countDocuments({ uai, siret })) > 0) {
     throw new Error(`Un organisme avec l'UAI ${uai} et le siret ${siret} existe déjà`);
   }
 

--- a/server/src/common/actions/organismes/organismes.formations.actions.js
+++ b/server/src/common/actions/organismes/organismes.formations.actions.js
@@ -25,15 +25,14 @@ export const getFormationsTreeForOrganisme = async (uai) => {
   // Construction d'une liste de formations pour cet organisme
   let formationsForOrganismeArray = [];
   let nbFormationsCreatedForOrganisme = 0;
-  // let nbFormationsUpdatedForOrganisme = 0;
   let nbFormationsNotCreatedForOrganisme = 0;
 
   if (catalogFormationsForOrganisme?.length) {
     await asyncForEach(catalogFormationsForOrganisme, async (currentFormation) => {
       let currentFormationId;
 
-      // Récupération de la formation du catalogue dans le TDB, si pas présente on la créé
-      // On count les formations créés / non crées (erreur)
+      // Récupération de la formation du catalogue dans le TDB, si pas présente on la crée
+      // On compte les formations créées / non créées (erreur)
       const formationFoundInTdb = await getFormationWithCfd(currentFormation.cfd);
       if (!formationFoundInTdb) {
         try {

--- a/server/src/common/apis/ApiCfaDock.js
+++ b/server/src/common/apis/ApiCfaDock.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import config from "../../config.js";
 import logger from "../logger.js";
 import { ApiError, apiRateLimiter } from "../utils/apiUtils.js";
 
@@ -8,7 +9,7 @@ const executeWithRateLimiting = apiRateLimiter("apiCfaDock", {
   nbRequests: 2,
   durationInSeconds: 1,
   client: axios.create({
-    baseURL: "https://www.cfadock.fr/api",
+    baseURL: config.cfadockApi.endpoint,
     timeout: 5000,
   }),
 });

--- a/server/src/common/logger.js
+++ b/server/src/common/logger.js
@@ -31,5 +31,6 @@ const createStreams = () => {
 export default bunyan.createLogger({
   name: config.appName,
   serializers: bunyan.stdSerializers,
+  /** @ts-expect-error */
   streams: createStreams(),
 });

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -34,18 +34,6 @@ const config = {
       permissions: env.get("FLUX_RETOUR_CFAS_USERS_DEFAULT_ADMIN_PERMISSIONS").default([]).asArray(),
     },
   },
-  tablesCorrespondances: {
-    endpoint: "https://tables-correspondances.apprentissage.beta.gouv.fr/api",
-  },
-  mnaCatalogApi: {
-    endpoint: "https://catalogue.apprentissage.beta.gouv.fr/api",
-  },
-  lbaApi: {
-    endpoint: "https://labonnealternance.apprentissage.beta.gouv.fr/api",
-  },
-  mnaReferentielApi: {
-    endpoint: "https://referentiel.apprentissage.onisep.fr/api/v1",
-  },
   smtp: {
     host: env.get("FLUX_RETOUR_CFAS_SMTP_HOST").asString(),
     port: env.get("FLUX_RETOUR_CFAS_SMTP_PORT").asString(),
@@ -79,11 +67,28 @@ const config = {
   sentry: {
     dsn: env.get("FLUX_RETOUR_CFAS_SENTRY_DSN").asString(),
   },
-  apiEntreprise: {
-    key: env.get("FLUX_RETOUR_CFAS_API_ENTREPRISE_KEY").asString(),
-    endpoint: "https://entreprise.api.gouv.fr/v2",
-  },
   organismesConsultationApiKey: env.get("FLUX_RETOUR_CFAS_ORGANISMES_CONSULTATION_API_KEY").asString(),
+
+  // API métiers externes
+  tablesCorrespondances: {
+    endpoint: "https://tables-correspondances.apprentissage.beta.gouv.fr/api",
+  },
+  mnaCatalogApi: {
+    endpoint: "https://catalogue.apprentissage.beta.gouv.fr/api",
+  },
+  lbaApi: {
+    endpoint: "https://labonnealternance.apprentissage.beta.gouv.fr/api",
+  },
+  mnaReferentielApi: {
+    endpoint: "https://referentiel.apprentissage.onisep.fr/api/v1",
+  },
+  cfadockApi: {
+    endpoint: "https://www.cfadock.fr/api",
+  },
+  apiEntreprise: {
+    endpoint: "https://entreprise.api.gouv.fr/v2",
+    key: env.get("FLUX_RETOUR_CFAS_API_ENTREPRISE_KEY").asString(),
+  },
 };
 
 export default config;

--- a/server/tests/integration/common/actions/organismes.actions.test.js
+++ b/server/tests/integration/common/actions/organismes.actions.test.js
@@ -38,7 +38,11 @@ describe("Test des actions Organismes", () => {
   describe("createOrganisme", () => {
     it("throws when given organisme is null", async () => {
       try {
-        await createOrganisme(null);
+        await createOrganisme(null, {
+          buildFormationTree: false,
+          buildInfosFromSiret: false,
+          callLbaApi: false,
+        });
       } catch (err) {
         assert.notEqual(err, undefined);
       }
@@ -47,10 +51,24 @@ describe("Test des actions Organismes", () => {
     it("throws when cfa with given uai already exists", async () => {
       const uai = "0802004U";
       const randomOrganisme = createRandomOrganisme();
-      await createOrganisme({ ...randomOrganisme, uai });
+      await createOrganisme(
+        { ...randomOrganisme, uai },
+        {
+          buildFormationTree: false,
+          buildInfosFromSiret: false,
+          callLbaApi: false,
+        }
+      );
 
       try {
-        await createOrganisme({ ...randomOrganisme, uai });
+        await createOrganisme(
+          { ...randomOrganisme, uai },
+          {
+            buildFormationTree: false,
+            buildInfosFromSiret: false,
+            callLbaApi: false,
+          }
+        );
       } catch (err) {
         assert.notEqual(err, undefined);
       }
@@ -138,7 +156,11 @@ describe("Test des actions Organismes", () => {
           academie: "10",
         },
       };
-      const { _id } = await createOrganisme(sampleOrganisme);
+      const { _id } = await createOrganisme(sampleOrganisme, {
+        buildFormationTree: true,
+        buildInfosFromSiret: true,
+        callLbaApi: true,
+      });
       const created = await findOrganismeById(_id);
 
       assert.deepEqual(pick(created, ["uai", "siret", "nom", "nature"]), {
@@ -174,7 +196,11 @@ describe("Test des actions Organismes", () => {
           academie: "10",
         },
       };
-      const { _id } = await createOrganisme(sampleOrganisme);
+      const { _id } = await createOrganisme(sampleOrganisme, {
+        buildFormationTree: true,
+        buildInfosFromSiret: true,
+        callLbaApi: true,
+      });
       const created = await findOrganismeById(_id);
 
       assert.deepEqual(pick(created, ["siret", "nom", "nature"]), {
@@ -238,7 +264,11 @@ describe("Test des actions Organismes", () => {
           academie: "10",
         },
       };
-      const { _id } = await createOrganisme(sampleOrganisme);
+      const { _id } = await createOrganisme(sampleOrganisme, {
+        buildFormationTree: false,
+        buildInfosFromSiret: false,
+        callLbaApi: false,
+      });
       const toUpdateOrganisme = { ...sampleOrganisme, nom: "UPDATED" };
       const updatedOrganisme = await updateOrganisme(_id, toUpdateOrganisme, {
         buildFormationTree: false,
@@ -273,7 +303,11 @@ describe("Test des actions Organismes", () => {
           academie: "10",
         },
       };
-      const { _id } = await createOrganisme(sampleOrganisme);
+      const { _id } = await createOrganisme(sampleOrganisme, {
+        buildFormationTree: false,
+        buildInfosFromSiret: false,
+        callLbaApi: false,
+      });
       // Test d'update sur le champ api_key
       const toUpdateOrganisme = { ...sampleOrganisme, api_key: "UPDATED" };
       const updatedOrganisme = await updateOrganisme(_id, toUpdateOrganisme);
@@ -324,7 +358,11 @@ describe("Test des actions Organismes", () => {
         },
       };
 
-      const { _id } = await createOrganisme(sampleOrganisme);
+      const { _id } = await createOrganisme(sampleOrganisme, {
+        buildFormationTree: false,
+        buildInfosFromSiret: false,
+        callLbaApi: false,
+      });
       const updatedOrganisme = await updateOrganisme(
         _id,
         { ...sampleOrganisme, ferme: false },
@@ -348,7 +386,11 @@ describe("Test des actions Organismes", () => {
         },
       };
 
-      const { _id } = await createOrganisme(sampleOrganisme);
+      const { _id } = await createOrganisme(sampleOrganisme, {
+        buildFormationTree: false,
+        buildInfosFromSiret: false,
+        callLbaApi: false,
+      });
       const updatedOrganisme = await updateOrganisme(
         _id,
         { ...sampleOrganisme },
@@ -372,7 +414,11 @@ describe("Test des actions Organismes", () => {
         },
       };
 
-      const { _id } = await createOrganisme(sampleOrganisme);
+      const { _id } = await createOrganisme(sampleOrganisme, {
+        buildFormationTree: false,
+        buildInfosFromSiret: false,
+        callLbaApi: false,
+      });
       const updatedOrganisme = await updateOrganisme(_id, { ...sampleOrganisme });
 
       assert.equal(updatedOrganisme?.ferme, false);

--- a/server/tests/integration/common/actions/users.legacy.actions.test.js
+++ b/server/tests/integration/common/actions/users.legacy.actions.test.js
@@ -145,7 +145,7 @@ describe("Components Users Test", () => {
 
       await assert.rejects(
         () => generatePasswordUpdateTokenLegacy("user"),
-        (err) => {
+        (/** @type {Error} */ err) => {
           assert.equal(err.message, "User not found");
           return true;
         }
@@ -178,7 +178,7 @@ describe("Components Users Test", () => {
 
       await assert.rejects(
         () => updatePasswordLegacy("wrong token", "new-password-strong"),
-        (err) => {
+        (/** @type {Error} */ err) => {
           assert.equal(err.message, "User not found");
           return true;
         }
@@ -195,7 +195,7 @@ describe("Components Users Test", () => {
 
       await assert.rejects(
         () => updatePasswordLegacy(token, shortPassword),
-        (err) => {
+        (/** @type {Error} */ err) => {
           assert.equal(err.message, "Password must be valid (at least 16 characters)");
           return true;
         }
@@ -217,7 +217,7 @@ describe("Components Users Test", () => {
 
       await assert.rejects(
         () => updatePasswordLegacy(token, "super-long-strong-password"),
-        (err) => {
+        (/** @type {Error} */ err) => {
           assert.equal(err.message, "Password update token has expired");
           return true;
         }
@@ -230,7 +230,7 @@ describe("Components Users Test", () => {
 
       await assert.rejects(
         () => updatePasswordLegacy(null, "super-long-strong-password"),
-        (err) => {
+        (/** @type {Error} */ err) => {
           assert.equal(err.message, "User not found");
           return true;
         }
@@ -250,7 +250,7 @@ describe("Components Users Test", () => {
       // try again
       await assert.rejects(
         () => updatePasswordLegacy(token, "super-long-strong-password"),
-        (err) => {
+        (/** @type {Error} */ err) => {
           assert.equal(err.message, "User not found");
           return true;
         }

--- a/server/tests/integration/http/dossiersApprenants.route.legacy.test.js
+++ b/server/tests/integration/http/dossiersApprenants.route.legacy.test.js
@@ -45,7 +45,11 @@ describe("Dossiers Apprenants Route", () => {
     randomOrganisme = createRandomOrganisme({ uai, siret });
 
     try {
-      const { _id } = await createOrganisme(randomOrganisme);
+      const { _id } = await createOrganisme(randomOrganisme, {
+        buildFormationTree: false,
+        buildInfosFromSiret: false,
+        callLbaApi: false,
+      });
       createdOrganisme = await findOrganismeById(_id);
     } catch (/** @type {any}*/ err) {
       console.error("Error with the following randomOrganisme", randomOrganisme);

--- a/server/tests/integration/http/indicateurs.route.test.js
+++ b/server/tests/integration/http/indicateurs.route.test.js
@@ -88,7 +88,15 @@ describe("Effectifs Route", () => {
       const app = await startServer();
       httpClient = app.httpClient;
 
-      await Promise.all(organismes.map((organisme) => createOrganisme(organisme)));
+      await Promise.all(
+        organismes.map((organisme) =>
+          createOrganisme(organisme, {
+            buildFormationTree: false,
+            buildInfosFromSiret: false,
+            callLbaApi: false,
+          })
+        )
+      );
 
       apiClient = await createAndAuthenticateUser(httpClient, {
         siret: "44492238900010",

--- a/server/tests/integration/http/organismes.routes.test.js
+++ b/server/tests/integration/http/organismes.routes.test.js
@@ -25,7 +25,11 @@ describe("Routes Organismes", () => {
 
     // TODO Tester la création d'un organisme + nock des API Entreprise & Catalog
     // const randomOrganisme = createRandomOrganisme();
-    // const { _id } = await createOrganisme(randomOrganisme);
+    // const { _id } = await createOrganisme(randomOrganisme, {
+    //   buildFormationTree: false,
+    //   buildInfosFromSiret: false,
+    //   callLbaApi: false,
+    // });
     // const created = await findOrganismeById(_id);
 
     // const expected = pick(created, [

--- a/server/tests/utils/nockApis/nock-apiCatalogue.js
+++ b/server/tests/utils/nockApis/nock-apiCatalogue.js
@@ -1,9 +1,9 @@
 import nock from "nock";
 
-import { API_ENDPOINT } from "../../../src/common/apis/apiCatalogueMna.js";
+import config from "../../../src/config.js";
 
 export const nockGetFormations = (callback) => {
-  nock(API_ENDPOINT)
+  nock(config.mnaCatalogApi.endpoint)
     .persist()
     .get(new RegExp("\\/entity\\/formations.*"))
     .reply(200, () => {

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -975,6 +975,13 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/bunyan@1.8.8":
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.8.tgz#8d6d33f090f37c07e2a80af30ae728450a101008"
+  integrity sha512-Cblq+Yydg3u+sGiz2mjHjC5MPmdjY+No4qvHrF+BUhblsmSfMvsHLbOG62tPbonsqBj6sbWv1LHcsoe5Jw+/Ow==
+  dependencies:
+    "@types/node" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz"


### PR DESCRIPTION
Quelques améliorations découvertes pendant mon investigation sur #2734.

A noter que `createOrganisme()` est systématiquement appelé avec les paramètres.
```js
{
  buildFormationTree: false,
  buildInfosFromSiret: false,
  callLbaApi: false,
}
```
Seul `updateOrganisme()` est appelé avec ces paramètres à true (aussi valeur par défaut...) lors du job `update:organismes-with-apis`. Donc pas mal de duplication / code mort :(