### PR TITLE
2593 création dun utilisateur par ladmin rendre plus clair le message derreur en cas dinvalidité dun des champs

### DIFF
--- a/server/src/common/model/usersMigration.model.ts
+++ b/server/src/common/model/usersMigration.model.ts
@@ -149,7 +149,7 @@ export function validateUser(props) {
     extensions: [
       {
         name: "email",
-        base: Joi.string().email(),
+        base: Joi.string(),
       },
       {
         name: "password",

--- a/server/src/common/validation/userSchema.ts
+++ b/server/src/common/validation/userSchema.ts
@@ -11,7 +11,7 @@ const userSchema = ({ isNew }) =>
       : {}),
     prenom: z.string(),
     nom: z.string(),
-    email: z.string(),
+    email: z.string().email(),
     roles: z.string().array(),
     is_admin: z.boolean().optional(),
   });

--- a/ui/modules/admin/UserForm.jsx
+++ b/ui/modules/admin/UserForm.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useFormik } from "formik";
+import { toFormikValidationSchema } from "zod-formik-adapter";
 import {
   Accordion,
   AccordionButton,
@@ -11,6 +12,7 @@ import {
   Checkbox,
   FormControl,
   FormLabel,
+  FormErrorMessage,
   Grid,
   HStack,
   Input,
@@ -27,6 +29,7 @@ import useToaster from "@/hooks/useToaster";
 import { DEPARTEMENTS_BY_ID, REGIONS_BY_ID, ACADEMIES_BY_ID } from "@/common/constants/territoiresConstants";
 import { getUserOrganisationLabel } from "@/common/constants/usersConstants";
 import Link from "next/link";
+import userSchema from "./userSchema";
 
 const buildRolesAcl = (newRoles, roles) => {
   let acl = [];
@@ -44,7 +47,6 @@ const buildRolesAcl = (newRoles, roles) => {
 export const UserForm = ({ user, roles, afterSubmit }) => {
   const [, setRolesAcl] = useState(buildRolesAcl(user?.roles || [], roles));
   const { toastSuccess, toastError } = useToaster();
-  const rolesById = roles?.reduce((acc, role) => ({ ...acc, [role._id]: role }), {});
 
   useEffect(() => {
     async function run() {
@@ -53,10 +55,11 @@ export const UserForm = ({ user, roles, afterSubmit }) => {
     run();
   }, [roles, user]);
 
-  const { values, handleSubmit, handleChange, setFieldValue, resetForm } = useFormik({
+  const { values, errors, touched, handleSubmit, handleChange, setFieldValue, resetForm } = useFormik({
+    validationSchema: toFormikValidationSchema(userSchema()),
     initialValues: {
       accessAllCheckbox: user?.is_admin ? ["on"] : [],
-      roles: roles.filter((role) => user?.roles.includes(role._id)).map((role) => role.name) || [],
+      roles: roles?.filter((role) => user?.roles.includes(role._id)).map((role) => role.name) || [],
       nom: user?.nom || "",
       prenom: user?.prenom || "",
       email: user?.email || "",
@@ -186,17 +189,20 @@ export const UserForm = ({ user, roles, afterSubmit }) => {
   return (
     <form onSubmit={handleSubmit}>
       <Grid gridTemplateColumns="repeat(2, 2fr)" gridGap="2w">
-        <FormControl py={2}>
+        <FormControl py={2} isInvalid={errors.nom}>
           <FormLabel>Nom</FormLabel>
-          <Input type="text" id="nom" name="nom" value={values.nom} onChange={handleChange} required />
+          <Input type="text" id="nom" name="nom" value={values.nom} onChange={handleChange} />
+          {errors.nom && touched.nom && <FormErrorMessage>{errors.nom}</FormErrorMessage>}
         </FormControl>
-        <FormControl py={2}>
+        <FormControl py={2} isInvalid={errors.email}>
           <FormLabel>Prenom</FormLabel>
-          <Input type="text" id="prenom" name="prenom" value={values.prenom} onChange={handleChange} required />
+          <Input type="text" id="prenom" name="prenom" value={values.prenom} onChange={handleChange} />
+          {errors.prenom && touched.prenom && <FormErrorMessage>{errors.prenom}</FormErrorMessage>}
         </FormControl>
-        <FormControl py={2}>
+        <FormControl py={2} isInvalid={errors.email}>
           <FormLabel>Email</FormLabel>
-          <Input type="email" id="email" name="email" value={values.email} onChange={handleChange} required />
+          <Input type="email" id="email" name="email" value={values.email} onChange={handleChange} />
+          {errors.email && touched.email && <FormErrorMessage>{errors.email}</FormErrorMessage>}
         </FormControl>
       </Grid>
 

--- a/ui/modules/admin/userSchema.js
+++ b/ui/modules/admin/userSchema.js
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+const userSchema = () =>
+  z.object({
+    prenom: z.string({ required_error: "Champ obligatoire" }),
+    nom: z.string({ required_error: "Champ obligatoire" }),
+    email: z.string({ required_error: "Champ obligatoire" }).email("Email invalide"),
+    roles: z.string({ required_error: "Champ obligatoire" }).array(),
+    is_admin: z.boolean({}).optional(),
+  });
+
+export default userSchema;

--- a/ui/package.json
+++ b/ui/package.json
@@ -62,7 +62,9 @@
     "recoil": "0.7.7",
     "remixicon": "2.5.0",
     "yup": "0.32.11",
-    "yup-password": "0.2.2"
+    "yup-password": "0.2.2",
+    "zod": "3.21.4",
+    "zod-formik-adapter": "1.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -15049,6 +15049,16 @@ yup@0.32.11:
     property-expr "^2.0.4"
     toposort "^2.0.2"
 
+zod-formik-adapter@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/zod-formik-adapter/-/zod-formik-adapter-1.2.0.tgz#b2b76f9388bee0fa72fceda2af0f15152d5fa3df"
+  integrity sha512-62U+Mf8U05pvLsIMUTC1H6d4K5SmsrXM+YgiZhCpPin5GNhnVuXCGySmJCs0FHuTJCBy7Et5Z1i8KF5ffuLttg==
+
+zod@3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==
+
 zustand@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.0.0.tgz#739cba69209ffe67b31e7d6741c25b51496114a7"


### PR DESCRIPTION
fix #2593

J'utilise maintenant le meme schema Zod coté backend et frontend pour harmoniser les validation, et à terme mettre en commun dans un dossier partagé. 
Petit bemol, j'ai été obligé de supprimer la validation Joi  au niveau du schema de données, parce qu'elle teste aussi l'email, avec des regles plus strictes (en particulier, Joi teste si le tld existe). 

<img width="752" alt="Screenshot 2023-03-16 at 14 17 14" src="https://user-images.githubusercontent.com/966303/225672156-1af43454-7218-4bb9-8ef7-2a1c209ea4c7.png">


