### PR TITLE
fix(server): replacement de getNbDistinctOrganismes en se basant sur la collection effectifs

### DIFF
--- a/server/src/common/actions/dossiersApprenants.actions.ts
+++ b/server/src/common/actions/dossiersApprenants.actions.ts
@@ -204,14 +204,3 @@ export const buildNewHistoriqueStatutApprenant = (
 
   return newHistoriqueStatutApprenant;
 };
-
-/**
- * Récupération du nb distinct d'organismes
- * On récupère le nombre distinct d'organismes id dans la collection dossiersApprenantsMigrationDb
- * @param {import("mongodb").Filter<any>} filters
- * @returns
- */
-export const getNbDistinctOrganismes = async (filters = {}) => {
-  const distinctOrganismes = await dossiersApprenantsMigrationDb().distinct("organisme_id", filters);
-  return distinctOrganismes ? distinctOrganismes.length : 0;
-};

--- a/server/src/common/actions/effectifs/effectifs.actions.ts
+++ b/server/src/common/actions/effectifs/effectifs.actions.ts
@@ -8,6 +8,7 @@ import {
   inscritsSansContratsIndicator,
   rupturantsIndicator,
 } from "./indicators.js";
+import { effectifsDb } from "../../model/collections.js";
 
 export const getIndicateurs = async (filters: any) => {
   const filterStages = buildMongoPipelineFilterStages(filters);
@@ -314,4 +315,14 @@ export const getDataListEffectifsAtDate = async (filters: any = {}) => {
     abandonsIndicator.getFullExportFormattedListAtDate(filters.date, filterStages, EFFECTIF_INDICATOR_NAMES.abandons),
   ]);
   return [...apprentis, ...inscritsSansContrat, ...rupturants, ...abandons];
+};
+
+/**
+ * Récupération du nb distinct d'organismes transmettant des effectifs (distinct organisme_id dans la collection effectifs)
+ * @param {import("mongodb").Filter<any>} filters
+ * @returns
+ */
+export const getNbDistinctOrganismes = async (filters = {}) => {
+  const distinctOrganismes = await effectifsDb().distinct("organisme_id", filters);
+  return distinctOrganismes ? distinctOrganismes.length : 0;
 };

--- a/server/src/http/routes/specific.routes/indicateurs-national.routes.ts
+++ b/server/src/http/routes/specific.routes/indicateurs-national.routes.ts
@@ -2,10 +2,9 @@ import express from "express";
 import { format } from "date-fns";
 import Joi from "joi";
 import { getAnneesScolaireListFromDate } from "../../../common/utils/anneeScolaireUtils.js";
-import { getNbDistinctOrganismes } from "../../../common/actions/dossiersApprenants.actions.js";
 import { validateFullObjectSchema } from "../../../common/utils/validationUtils.js";
 import { returnResult, tryCachedExecution } from "../../middlewares/helpers.js";
-import { getIndicateurs } from "../../../common/actions/effectifs/effectifs.actions.js";
+import { getIndicateurs, getNbDistinctOrganismes } from "../../../common/actions/effectifs/effectifs.actions.js";
 
 export default ({ cache }) => {
   const router = express.Router();
@@ -20,7 +19,7 @@ export default ({ cache }) => {
       return tryCachedExecution(cache, cacheKey, async () => {
         const [indicateurs, totalOrganismes] = await Promise.all([
           getIndicateurs({ date }),
-          getNbDistinctOrganismes(filters), // reads from dossiersApprenantsMigration, does not use EffectifsFilters yet
+          getNbDistinctOrganismes(filters),
         ]);
         indicateurs.totalOrganismes = totalOrganismes;
         return indicateurs;


### PR DESCRIPTION
Je propose de baser le calcul du nb d'organismes distinct en se basant sur la collection effectifs (la collection dossiersApprenantsMigration est vouée à disparaitre).

Déplacement de la méthode dans effectifs.actions.js.