### PR TITLE
chore(server): add lieux de formation to organismesReferentiel

### DIFF
--- a/server/src/common/apis/apiReferentielMna.ts
+++ b/server/src/common/apis/apiReferentielMna.ts
@@ -18,6 +18,7 @@ const DEFAULT_REFERENTIEL_FIELDS_TO_FETCH = [
   "siret",
   "siege_social",
   "uai",
+  "lieux_de_formation",
 ];
 
 /**

--- a/server/src/common/model/organismesReferentiel.model.ts
+++ b/server/src/common/model/organismesReferentiel.model.ts
@@ -1,4 +1,4 @@
-import { object, objectId, string, boolean, number, array } from "./json-schema/jsonSchemaTypes.js";
+import { object, objectId, string, boolean, number, array, arrayOf } from "./json-schema/jsonSchemaTypes.js";
 
 const collectionName = "organismesReferentiel";
 
@@ -90,8 +90,9 @@ const schema = object(
       { required: ["code", "label"] }
     ),
     qualiopi: boolean(),
+    lieux_de_formation: arrayOf(object({ uai: string() }, { additionalProperties: true })),
   },
-  { required: ["siret", "nature"] }
+  { required: ["siret", "nature", "lieux_de_formation"] }
 );
 
 export default { schema, indexes, collectionName };

--- a/server/src/jobs/hydrate/organismes/hydrate-organismes-referentiel.ts
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes-referentiel.ts
@@ -49,6 +49,7 @@ const insertOrganismeReferentiel = async (organismeReferentiel) => {
     siret,
     siege_social,
     uai,
+    lieux_de_formation,
   } = organismeReferentiel;
 
   // Ajout de l'organisme dans la collection
@@ -64,6 +65,7 @@ const insertOrganismeReferentiel = async (organismeReferentiel) => {
       ...(raison_sociale ? { raison_sociale } : {}),
       ...(siret ? { siret } : {}),
       ...(siege_social ? { siege_social } : {}),
+      ...(lieux_de_formation ? { lieux_de_formation } : { lieux_de_formation: [] }),
       ...(uai ? { uai } : {}),
     });
     nbOrganismeCreated++;


### PR DESCRIPTION
Ajout des lieux de formation dans les organismes du référentiel.

Sera utile pour faire un match sur les uai des lieux de formation afin de poursuivre la fiabilisation des couples UAI SIRET que l'on a versus ce qu'on trouve dans le référentiel.
