### PR TITLE
fix: restauration typage client mongo

### DIFF
--- a/server/src/common/actions/emails.actions.ts
+++ b/server/src/common/actions/emails.actions.ts
@@ -117,8 +117,7 @@ export async function unsubscribeUser(id) {
 }
 
 export async function renderEmail({ templates }, token) {
-  /** @type {any} */
-  const user = await usersMigrationDb().findOne({ "emails.token": token });
+  const user: any = await usersMigrationDb().findOne({ "emails.token": token });
   const { templateName, payload } = user.emails.find((e) => e.token === token);
   const template = templates[templateName]({ to: user.email, payload }, token);
 

--- a/server/src/common/actions/engine/engine.actions.ts
+++ b/server/src/common/actions/engine/engine.actions.ts
@@ -1,5 +1,6 @@
 import Joi from "joi";
 import { capitalize, cloneDeep, get } from "lodash-es";
+import { ObjectId, WithId } from "mongodb";
 import { getCodePostalInfo } from "../../apis/apiTablesCorrespondances.js";
 import { ACADEMIES, REGIONS, DEPARTEMENTS } from "../../constants/territoiresConstants.js";
 import { dateFormatter, dateStringToLuxon, jsDateToLuxon } from "../../utils/formatterUtils.js";
@@ -218,7 +219,7 @@ export const hydrateEffectif = async (effectifData: any, options?: any) => {
  */
 const hydrateOrganisme = async (organisme: any) => {
   let organismeToCreate = null;
-  let organismeFoundId = null;
+  let organismeFoundId: ObjectId | null = null;
   let organismeFoundError: string | null = null;
 
   // Applique le mapping de fiabilisation
@@ -351,8 +352,7 @@ export const runEngine = async ({ effectifData }, organismeData) => {
       await updateEffectifAndLock(effectifUpdatedId, effectif);
     } else {
       effectifCreatedId = await insertEffectif(effectif);
-      /** @type {import("mongodb").WithId<any>} */
-      const effectifCreated = await findEffectifById(effectifCreatedId);
+      const effectifCreated: WithId<any> = await findEffectifById(effectifCreatedId);
       await updateEffectifAndLock(effectifCreatedId, {
         apprenant: effectifCreated.apprenant,
         formation: effectifCreated.formation,

--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -315,7 +315,7 @@ export const addContributeurOrganisme = async (organisme_id, userEmail, roleName
   }
 
   await createPermission({
-    organisme_id: organisme._id,
+    organisme_id: organisme._id as any,
     userEmail: userEmail.toLowerCase(),
     roleName,
     pending,

--- a/server/src/common/actions/uploads.actions.ts
+++ b/server/src/common/actions/uploads.actions.ts
@@ -1,5 +1,5 @@
 import { uploadsDb } from "../model/collections.js";
-import { ObjectId } from "mongodb";
+import { ObjectId, WithId } from "mongodb";
 import { find, findIndex } from "lodash-es";
 import { defaultValuesUpload } from "../model/uploads.model/uploads.model.js";
 
@@ -127,10 +127,10 @@ export const updateDocument = async (organisme_id, { nom_fichier, taille_fichier
   return updated.value;
 };
 
-/**
- * @returns {Promise<any>}
- */
-export const removeDocument = async (organismeId, { nom_fichier, chemin_fichier, taille_fichier }) => {
+export const removeDocument = async (
+  organismeId,
+  { nom_fichier, chemin_fichier, taille_fichier }
+): Promise<WithId<any>> => {
   const found = await getUploadEntryByOrgaId(organismeId);
 
   let newDocuments = [...found.documents];

--- a/server/src/common/actions/users.actions.ts
+++ b/server/src/common/actions/users.actions.ts
@@ -1,6 +1,6 @@
 import { addHours } from "date-fns";
 import { uniq } from "lodash-es";
-import { ObjectId } from "mongodb";
+import { ObjectId, WithId } from "mongodb";
 
 import { USER_ACCOUNT_STATUS } from "../constants/usersConstants.js";
 import { rolesDb, usersMigrationDb } from "../model/collections.js";
@@ -34,9 +34,8 @@ import { findActivePermissionsForUser, hasAtLeastOneContributeurNotPending } fro
  * @param {boolean} [options.is_admin] - Is an admin
  * @param {boolean} [options.is_cross_organismes] - Is cross organismes
  * @param {string} [options.account_status] - account status
- * @returns {Promise<import("mongodb").WithId<any>>}
  */
-export const createUser = async ({ email, password }, options: any = {}) => {
+export const createUser = async ({ email, password }, options: any = {}): Promise<WithId<any>> => {
   const passwordHash = hashUtil(password);
   const {
     civility,
@@ -345,8 +344,7 @@ export const updateMainOrganismeUser = async ({ organisme_id, userEmail }) => {
 };
 
 export const structureUser = async (user) => {
-  /** @type {import("mongodb").WithId<any>[]} */
-  const rolesList = user.roles?.length
+  const rolesList: WithId<any>[] = user.roles?.length
     ? await rolesDb()
         .find({ _id: { $in: user.roles } })
         .toArray()

--- a/server/src/common/mongodb.ts
+++ b/server/src/common/mongodb.ts
@@ -3,8 +3,7 @@ import omitDeep from "omit-deep";
 import logger from "./logger.js";
 import { asyncForEach } from "./utils/asyncUtils.js";
 
-/** @type {MongoClient} */
-let mongodbClient;
+let mongodbClient: MongoClient;
 
 const ensureInitialization = () => {
   if (!mongodbClient) {

--- a/server/src/http/routes/specific.routes/organismes.routes.ts
+++ b/server/src/http/routes/specific.routes/organismes.routes.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import Joi from "joi";
 import pick from "lodash.pick";
+import { Filter } from "mongodb";
 
 import { organismesDb } from "../../../common/model/collections.js";
 
@@ -23,8 +24,7 @@ export default () => {
     const limit = Number(params.limit ?? 50);
     const skip = (page - 1) * limit;
 
-    /** @type {import("mongodb").Filter<any>} */
-    const jsonQuery = JSON.parse(query);
+    const jsonQuery: Filter<any> = JSON.parse(query);
     const allData = await organismesDb().find(jsonQuery).skip(skip).limit(limit).toArray();
     const count = await organismesDb().countDocuments(jsonQuery);
     const omittedData = allData.map((item) =>

--- a/server/src/http/routes/specific.routes/serp.routes/upload.routes.ts
+++ b/server/src/http/routes/specific.routes/serp.routes/upload.routes.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import Joi from "joi";
 import { createWriteStream } from "fs";
-import { ObjectId } from "mongodb";
+import { ObjectId, WithId } from "mongodb";
 import { DateTime } from "luxon";
 import csvToJson from "convert-csv-to-json";
 import { accumulateData, oleoduc, writeData } from "oleoduc";
@@ -233,7 +233,7 @@ export default ({ clamav }) => {
       })
         .unknown()
         .validateAsync(req.query, { abortEarly: false });
-      let upload = null;
+      let upload: WithId<any> = null;
       try {
         upload = await getUploadEntryByOrgaId(organisme_id, { last_snapshot_effectifs: 0 });
       } catch (/** @type {any}*/ error: any) {

--- a/server/src/jobs/fiabilisation/dossiersApprenants/analyse-fiabilite-dossiers-apprenants-recus.ts
+++ b/server/src/jobs/fiabilisation/dossiersApprenants/analyse-fiabilite-dossiers-apprenants-recus.ts
@@ -73,8 +73,7 @@ export const analyseFiabiliteDossierApprenantsRecus = async () => {
   // iterate over data and create an entry for each dossier apprenant sent with fiabilité metadata
   logger.info("Iterating over all dossiers apprenants received in the last 24h to analyse their data");
   while (await latestReceivedDossiersApprenantsCursor.hasNext()) {
-    /** @type {any} */
-    const { data, username, date } = await latestReceivedDossiersApprenantsCursor.next();
+    const { data, username, date }: any = await latestReceivedDossiersApprenantsCursor.next();
     latestReceivedDossiersApprenantsCount++;
 
     const newDossierApprenantApiInputFiabiliteEntry = createDossierApprenantApiInputFiabilite({

--- a/server/src/jobs/hydrate/archive-dossiers-apprenants/hydrate-archive-dossiersApprenants.ts
+++ b/server/src/jobs/hydrate/archive-dossiers-apprenants/hydrate-archive-dossiersApprenants.ts
@@ -2,6 +2,7 @@ import { validateAnneeScolaire } from "../../../common/utils/validationsUtils/an
 import logger from "../../../common/logger.js";
 import { dossiersApprenantsMigrationDb } from "../../../common/model/collections.js";
 import { updateDossierApprenant } from "../../../common/actions/dossiersApprenants.actions.js";
+import { WithId } from "mongodb";
 
 /**
  * Fonction principale d'archivage des dossiersApprenants et des effectifs
@@ -41,8 +42,7 @@ const hydrateArchivesDossiersApprenants = async (ANNEE_SCOLAIRE_START_LIMIT = 20
 
   const cursor = dossiersApprenantsMigrationDb().find(query);
   while (await cursor.hasNext()) {
-    /** @type {import("mongodb").WithId<any>} */
-    const dossierApprenantToArchive = await cursor.next();
+    const dossierApprenantToArchive: WithId<any> = await cursor.next();
 
     try {
       await updateDossierApprenant(dossierApprenantToArchive._id, { ...dossierApprenantToArchive, archive: true });

--- a/server/src/jobs/hydrate/reseaux/hydrate-reseaux.ts
+++ b/server/src/jobs/hydrate/reseaux/hydrate-reseaux.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../common/actions/organismes/organismes.actions.js";
 import { arraysContainSameValues } from "../../../common/utils/miscUtils.js";
 import { organismesDb } from "../../../common/model/collections.js";
+import { WithId } from "mongodb";
 
 const INPUT_FILE_COLUMN_NAMES = {
   SIRET: "Siret",
@@ -140,7 +141,7 @@ const hydrateReseauFile = async (filename) => {
     // and update our organisme with the updated list of reseaux
     if (foundUnique) {
       foundUniqueCount++;
-      const uniqueOrganismeFromTdb = organismeInTdb[0];
+      const uniqueOrganismeFromTdb: WithId<any> = organismeInTdb[0];
 
       const reseauxFromDb = uniqueOrganismeFromTdb.reseaux || [];
       const reseauxFromFile = organismeParsedFromFile.reseaux || [];

--- a/server/tests/integration/common/actions/formations.actions.test.ts
+++ b/server/tests/integration/common/actions/formations.actions.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../../src/common/actions/formations.actions.js";
 import { createSampleEffectif } from "../../../data/randomizedSample.js";
 import { NATURE_ORGANISME_DE_FORMATION } from "../../../../src/common/utils/validationsUtils/organisme-de-formation/nature.js";
+import { WithId } from "mongodb";
 
 describe("Tests des actions Formations", () => {
   describe("existsFormation", () => {
@@ -53,7 +54,7 @@ describe("Tests des actions Formations", () => {
       const cfd = "2502000D";
       const { insertedId } = await formationsDb().insertOne({ cfd });
 
-      const found = await getFormationWithCfd(cfd);
+      const found: WithId<any> = await getFormationWithCfd(cfd);
       assert.equal(insertedId.equals(found._id), true);
     });
   });


### PR DESCRIPTION
Petite PR pour restaurer le type sur le mongoClient pour avoir le typage sur toutes les requêtes qui en découlent.

J'en ai besoin pour mon refacto des permissions :smiley: 