### PR TITLE
fix(server): fiabilisation - suppression des organismes non fiables

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "start:dev": "nodemon --ignore tests/ --exec 'ts-node' src/index.ts -e ts",
     "test": "yarn test:cmd tests/integration/**/*.ts",
     "test:coverage": "c8 --check-coverage yarn test",
-    "test:cmd": "NODE_ENV=test cross-env DOTENV_CONFIG_PATH=.env.test ts-mocha -n loader=ts-node/esm",
+    "test:cmd": "cross-env NODE_ENV=test DOTENV_CONFIG_PATH=.env.test ts-mocha -n loader=ts-node/esm",
     "lint": "eslint --cache . --ext .ts",
     "cli": "ts-node src/jobs/cli.ts",
     "migration:create": "migrate-mongo create",

--- a/server/src/jobs/fiabilisation/uai-siret/apply-fiabilisation/index.ts
+++ b/server/src/jobs/fiabilisation/uai-siret/apply-fiabilisation/index.ts
@@ -209,7 +209,8 @@ const updateOrganismesNonFiabilisablesMapping = async () => {
 const updateOrganismeForCurrentCoupleNonFiabilisableMapping = async (currentFiabilisationCouple) => {
   const { modifiedCount } = await organismesDb().updateMany(
     { uai: currentFiabilisationCouple.uai, siret: currentFiabilisationCouple.siret },
-    { $set: { fiabilisation_statut: STATUT_FIABILISATION_COUPLES_UAI_SIRET.NON_FIABILISABLE_MAPPING } }
+    { $set: { fiabilisation_statut: STATUT_FIABILISATION_COUPLES_UAI_SIRET.NON_FIABILISABLE_MAPPING } },
+    { bypassDocumentValidation: true }
   );
   nbOrganismesNonFiabilisablesMapping += modifiedCount;
 };


### PR DESCRIPTION
Correction du script de fiabilisation car il y avait certains cas d'organismes non fiables qui restaient en base.

1. Une partie qui n'étaient pas supprimés sont sans SIRET et non fiabilisables (mapping), à cause de la validation mongodb il n'étaient pas mis à jour
2. D'autres dans le flow des A FIABILISER, on ne supprimait pas les organismes non fiables.

- Petit correctif sur la commande de lancement des tests avec le cross-env en premier (je suis sous Windows 🥲) 👉🏼 https://github.com/mission-apprentissage/flux-retour-cfas/pull/2793/commits/f1d1361e8dd601ff6ce33b7125489b41ad7bccd6
- Ajout du byPassValidation pour MAJ des organismes sans siret afin de les identifier comme Non Fiabilisables Mapping et de les supprimer ensuite 👉🏼 https://github.com/mission-apprentissage/flux-retour-cfas/pull/2793/commits/59afe744d1867f16500b862a0c37587af55fa47d
- Correction du flow des organismes A FIABILISER, désormais on déplace les effectifs / dossiersApprenants puis on supprime l'organisme non fiable 👉🏼 https://github.com/mission-apprentissage/flux-retour-cfas/pull/2793/commits/6d81e4de6bd0612103846976fae7232505d222bf