### PR TITLE
feat: ajout du monitoring des métriques de l'hôte et des conteneurs

### DIFF
--- a/.infra/ansible/roles/setup/files/app/.overrides/common/docker-compose.common.yml
+++ b/.infra/ansible/roles/setup/files/app/.overrides/common/docker-compose.common.yml
@@ -49,3 +49,31 @@ services:
     restart: always
     networks:
       - flux_retour_cfas_network
+
+  nodeexporter:
+    image: prom/node-exporter:v1.5.0
+    restart: unless-stopped
+    container_name: nodeexporter
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.46.0
+    restart: unless-stopped
+    container_name: cadvisor
+    privileged: true
+    devices:
+      - /dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro

--- a/reverse_proxy/app/nginx/templates/includes/location_monitoring.conf.template
+++ b/reverse_proxy/app/nginx/templates/includes/location_monitoring.conf.template
@@ -1,0 +1,8 @@
+location /_monitoring/cadvisor {
+    set $upstream http://cadvisor:8080/;
+    include includes/proxy.conf;
+}
+location /_monitoring/nodeexporter {
+    set $upstream http://nodeexporter:9100/;
+    include includes/proxy.conf;
+}


### PR DESCRIPTION
Ajoute 2 services sur les environnements (recette et prod) :
- node-exporter qui va collecter des métriques liées à l'hôte (le VPS)
- cadvisor qui va collecter des métriques des conteneurs docker

Les métriques sont exposées derrière le nginx via les routes /_monitoring/cadvisor et /_monitoring/nodeexporter.

Je ne suis pas complètement sûr que la conf nginx redirige comme je veux (elle doit supprimer le préfixe avant d'appeler l'upstream), on verra une fois déployé !.