### PR TITLE
fix: hostname des agents de monitoring

### DIFF
--- a/.infra/ansible/roles/setup/files/app/.overrides/production/docker-compose.env.yml
+++ b/.infra/ansible/roles/setup/files/app/.overrides/production/docker-compose.env.yml
@@ -48,3 +48,9 @@ services:
   metabase:
     environment:
       MB_SITE_URL: https://cfas.apprentissage.beta.gouv.fr/metabase
+
+  nodeexporter:
+    hostname: tableau-de-bord-production
+
+  cadvisor:
+    hostname: tableau-de-bord-production

--- a/.infra/ansible/roles/setup/files/app/.overrides/recette/docker-compose.env.yml
+++ b/.infra/ansible/roles/setup/files/app/.overrides/recette/docker-compose.env.yml
@@ -60,3 +60,9 @@ services:
       - MH_STORAGE=mongodb
       - MH_MONGO_URI=mongodb:27017
       - MH_AUTH_FILE=/home/mailhog/auth
+
+  nodeexporter:
+    hostname: tableau-de-bord-recette
+
+  cadvisor:
+    hostname: tableau-de-bord-recette


### PR DESCRIPTION
Sur prod et recette, comme les agents sont recréés à chaque déploiement. De nouveaux conteneurs sont recréés et les dashboard actuels utilisent le nom d'hôte /etc/hostname (= id du conteneur par défaut) pour identifier l'hôte à monitorer.

Avec cette PR, on surcharge l'hôte dans la configuration des conteneurs nodeexporter et cadvisor.

Il faudra encore faire un setup-vm une fois la PR mergée. :)