### PR TITLE
fix(server): fiab sur uai lieux fiables + fix qualiopi hydrate

### DIFF
--- a/server/src/common/model/@types/Organisme.ts
+++ b/server/src/common/model/@types/Organisme.ts
@@ -918,7 +918,7 @@ export interface Organisme {
   /**
    * L'organisme est qualiopi
    */
-  qualiopo?: boolean;
+  qualiopi?: boolean;
   /**
    * Le token permettant l'accès au CFA à sa propre page
    */

--- a/server/src/common/model/@types/Organisme.ts
+++ b/server/src/common/model/@types/Organisme.ts
@@ -916,6 +916,10 @@ export interface Organisme {
    */
   ferme?: boolean;
   /**
+   * L'organisme est qualiopi
+   */
+  qualiopo?: boolean;
+  /**
    * Le token permettant l'accès au CFA à sa propre page
    */
   access_token?: string;

--- a/server/src/common/model/@types/OrganismesReferentiel.ts
+++ b/server/src/common/model/@types/OrganismesReferentiel.ts
@@ -46,6 +46,7 @@ export interface OrganismesReferentiel {
   qualiopi?: boolean;
   lieux_de_formation: {
     uai?: string;
+    uai_fiable?: boolean;
   }[];
   /**
    * Formations de cet organisme

--- a/server/src/common/model/organismesReferentiel.model.ts
+++ b/server/src/common/model/organismesReferentiel.model.ts
@@ -88,7 +88,7 @@ const schema = object(
       { required: ["code", "label"] }
     ),
     qualiopi: boolean(),
-    lieux_de_formation: arrayOf(object({ uai: string() }, { additionalProperties: true })),
+    lieux_de_formation: arrayOf(object({ uai: string(), uai_fiable: boolean() }, { additionalProperties: true })),
     contacts: arrayOf(
       object(
         {

--- a/server/src/jobs/fiabilisation/uai-siret/build-fiabilisation/index.ts
+++ b/server/src/jobs/fiabilisation/uai-siret/build-fiabilisation/index.ts
@@ -272,12 +272,12 @@ export const buildFiabilisationCoupleForTdbCouple = async (
         }
 
         // Phase 2. Recherche dans les lieux de formation
-        const lieuFormationMatchUai = organismesRespOrRespFormateurForUaiTdb[0].lieux_de_formation.find(
-          (item) => item.uai === currentMultipleUaisCouple.uai
+        const lieuFormationFiableMatchUai = organismesRespOrRespFormateurForUaiTdb[0].lieux_de_formation.find(
+          (item) => item.uai === currentMultipleUaisCouple.uai && item.uai_fiable
         );
 
-        // Si l'UAI Match sur un des lieux alors on peut fiabiliser tel quel en marquant que c'est un couple de lieu de formation
-        if (lieuFormationMatchUai) {
+        // Si l'UAI Match sur un des lieux fiables alors on peut fiabiliser tel quel en marquant que c'est un couple de lieu de formation
+        if (lieuFormationFiableMatchUai) {
           await fiabilisationUaiSiretDb().updateOne(
             { uai: coupleUaiSiretTdbToCheck.uai, siret: coupleUaiSiretTdbToCheck.siret },
             {

--- a/server/src/jobs/hydrate/organismes/hydrate-organismes.ts
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes.ts
@@ -64,7 +64,7 @@ const resetOrganismesReferentielPresence = async () => {
  * @param {*} organismeFromReferentiel
  */
 const insertOrUpdateOrganisme = async (organismeFromReferentiel) => {
-  const { uai, siret, nature, raison_sociale, adresse, etat_administratif } = organismeFromReferentiel;
+  const { uai, siret, nature, raison_sociale, adresse, etat_administratif, qualiopi } = organismeFromReferentiel;
 
   const adresseFormatted = mapAdresseReferentielToAdresseTdb(adresse);
   const isFerme = etat_administratif ? (etat_administratif === "fermé" ? true : false) : false;
@@ -83,7 +83,7 @@ const insertOrUpdateOrganisme = async (organismeFromReferentiel) => {
           nature,
           adresse: adresseFormatted,
           ferme: isFerme,
-          qualiopi: organismeFromReferentiel.qualiopi,
+          qualiopi: qualiopi || false,
           est_dans_le_referentiel: true,
         },
         {
@@ -110,6 +110,7 @@ const insertOrUpdateOrganisme = async (organismeFromReferentiel) => {
       nature: nature,
       adresse: adresseFormatted,
       ferme: isFerme,
+      qualiopi: qualiopi || false,
       nature_validity_warning: false,
       est_dans_le_referentiel: true,
     };


### PR DESCRIPTION
Ajout de la récupération de la notion d'uai fiable dans le référentiel et update du script pour ne matcher que sur les uai fiables.
Fix de la property qualiopi (certains organismes n'ont pas le champ dans le référentiel)