### PR TITLE
chore: upgrade to typescript 5

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -93,7 +93,7 @@
     "prettier": "2.8.4",
     "storybook-addon-mock": "3.2.0",
     "storybook-addon-next": "1.7.3",
-    "typescript": "4.9.5"
+    "typescript": "5.0.4"
   },
   "prettier": {
     "printWidth": 120,

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -14153,10 +14153,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
une petite PR pour aligner toutes les versions de ts sur le projet, et fixer l'erreur `Expression produces a union type that is too complex to represent.ts(2590)`

