### PR TITLE
chore: migration de ts-node vers tsx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ install-root:
 	yarn install
 
 install-server:
-	yarn --cwd server install --frozen-lockfile
+	yarn --cwd server install --frozen-lockfile --ignore-platform
 
 install-ui:
 	yarn --cwd ui install --frozen-lockfile

--- a/server/.yarnrc
+++ b/server/.yarnrc
@@ -1,1 +1,0 @@
-save-prefix ""

--- a/server/.yarnrc.yml
+++ b/server/.yarnrc.yml
@@ -1,0 +1,9 @@
+# https://esbuild.github.io/getting-started/#simultaneous-platforms
+save-prefix: ""
+supportedArchitectures:
+  os:
+    - "current"
+    - "linux"
+  cpu:
+    - "current"
+    - "arm64"

--- a/server/package.json
+++ b/server/package.json
@@ -9,14 +9,14 @@
   "exports": "./src/index.js",
   "type": "module",
   "scripts": {
-    "start": "ts-node src/index.ts",
+    "start": "tsx src/index.ts",
     "build": "tsc --build",
-    "start:dev": "nodemon --ignore tests/ --exec 'ts-node' src/index.ts -e ts",
+    "start:dev": "nodemon --ignore tests/ --exec yarn start -e ts",
     "test": "yarn test:cmd tests/integration/**/*.ts",
     "test:coverage": "c8 --check-coverage yarn test",
-    "test:cmd": "cross-env NODE_ENV=test DOTENV_CONFIG_PATH=.env.test ts-mocha -n loader=ts-node/esm",
+    "test:cmd": "cross-env NODE_ENV=test DOTENV_CONFIG_PATH=.env.test ts-mocha -r tsx",
     "lint": "eslint --cache . --ext .ts",
-    "cli": "ts-node --transpileOnly src/jobs/cli.ts",
+    "cli": "tsx src/jobs/cli.ts",
     "migration:create": "migrate-mongo create",
     "migration:up": "migrate-mongo up",
     "migration:down": "migrate-mongo down"
@@ -116,6 +116,7 @@
     ]
   },
   "devDependencies": {
+    "@esbuild/linux-arm64": "^0.17.17",
     "@faker-js/faker": "7.6.0",
     "@types/boom": "7.3.2",
     "@types/bunyan": "1.8.8",
@@ -139,6 +140,7 @@
     "nodemon": "2.0.16",
     "prettier": "2.8.7",
     "ts-mocha": "10.0.0",
+    "tsx": "3.12.6",
     "typescript": "5.0.2"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -52,6 +52,7 @@
     "eslint-import-resolver-typescript": "3.5.3",
     "express": "4.18.1",
     "express-async-errors": "3.1.1",
+    "express-list-endpoints": "^6.0.0",
     "fs-extra": "10.1.0",
     "iconv-lite": "0.6.3",
     "joi": "17.6.0",

--- a/server/src/common/utils/cryptoUtils.ts
+++ b/server/src/common/utils/cryptoUtils.ts
@@ -26,7 +26,7 @@ export function checksum() {
     algorithm: "md5",
   });
 
-  let promise = new Promise((resolve, reject) => {
+  let promise = new Promise<string>((resolve, reject) => {
     stream.on("digest", resolve);
     stream.on("error", reject);
   });

--- a/server/src/http/middlewares/helpers.ts
+++ b/server/src/http/middlewares/helpers.ts
@@ -1,8 +1,7 @@
 import Boom from "boom";
-import { NextFunction, Request, RequestHandler, Response, Locals } from "express";
+import { NextFunction, Request, RequestHandler, Response } from "express";
 
 import { AuthContext } from "../../common/model/internal/AuthContext.js";
-
 
 // catch errors and return the result of the request handler
 export function returnResult<TParams = any, TQuery = any, TBody = any, TLocals extends Record<string, any> = any>(

--- a/server/src/http/middlewares/helpers.ts
+++ b/server/src/http/middlewares/helpers.ts
@@ -1,13 +1,15 @@
-import { AuthContext } from "../../common/model/internal/AuthContext.js";
 import Boom from "boom";
-import { NextFunction, Request, Response } from "express";
+import { NextFunction, Request, RequestHandler, Response, Locals } from "express";
 
-type Handler = (req: Request, res: Response, next: NextFunction) => any | Promise<any>;
+import { AuthContext } from "../../common/model/internal/AuthContext.js";
+
 
 // catch errors and return the result of the request handler
-export function returnResult(serviceFunc: Handler) {
-  return async (req: Request, res: Response, next: NextFunction) => {
-    const result = await serviceFunc(req, res, next);
+export function returnResult<TParams = any, TQuery = any, TBody = any, TLocals extends Record<string, any> = any>(
+  serviceFunc: RequestHandler<TParams, any, TBody, TQuery, TLocals>
+): RequestHandler<TParams, any, TBody, TQuery, TLocals> {
+  return async (req, res, next) => {
+    const result = (await serviceFunc(req, res, next)) as any;
     // le résultat est à renvoyer en JSON par défaut
     if (!res.getHeader("Content-Type")) {
       res.set("Content-Type", "application/json");

--- a/server/src/http/middlewares/validateRequestMiddleware.ts
+++ b/server/src/http/middlewares/validateRequestMiddleware.ts
@@ -1,4 +1,4 @@
-import { ErrorRequestHandler, NextFunction, RequestHandler } from "express";
+import { NextFunction, RequestHandler } from "express";
 import { ZodEffects, ZodError, ZodSchema } from "zod";
 
 declare type RequestValidation<TParams, TQuery, TBody> = {

--- a/server/src/http/routes/specific.routes/organisme.routes.ts
+++ b/server/src/http/routes/specific.routes/organisme.routes.ts
@@ -10,7 +10,7 @@ import { isEligibleSIFA } from "../../../common/actions/sifa.actions/sifa.action
 import { AuthContext } from "../../../common/model/internal/AuthContext.js";
 import { requireManageOrganismeEffectifsPermission } from "../../../common/actions/helpers/permissions.js";
 import { ObjectId } from "mongodb";
-import { Effectif } from "@/src/common/model/@types/Effectif.js";
+import { Effectif } from "@/common/model/@types/Effectif.js";
 
 export async function getOrganismeEffectifs(
   ctx: AuthContext,

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -8,8 +8,11 @@ import * as Sentry from "@sentry/node";
 import * as Tracing from "@sentry/tracing";
 import Boom from "boom";
 import swaggerUi from "swagger-ui-express";
+import listEndpoints from "express-list-endpoints";
 
 import { apiRoles } from "../common/roles.js";
+// catch all unhandled promise rejections and call the error middleware
+import "express-async-errors";
 
 import { logMiddleware } from "./middlewares/logMiddleware.js";
 import errorMiddleware from "./middlewares/errorMiddleware.js";
@@ -40,8 +43,6 @@ import statsAdmin from "./routes/admin.routes/stats.routes.js";
 import maintenancesAdmin from "./routes/admin.routes/maintenances.routes.js";
 import config from "../config.js";
 
-// catch all unhandled promise rejections and call the error middleware
-import "express-async-errors";
 import { requireAdministrator, returnResult } from "./middlewares/helpers.js";
 import { jobEventsDb, usersMigrationDb } from "../common/model/collections.js";
 import { packageJson } from "../common/utils/esmUtils.js";
@@ -550,4 +551,8 @@ function setupRoutes(app: Application) {
   authRouter.use("/api/v1/admin", adminRouter);
 
   app.use(authRouter);
+
+  listEndpoints(app).map(({ path, methods }: { path: string; methods: string[] }) =>
+    console.info(`${methods.join(", ").padStart(20)} ${path}`)
+  );
 }

--- a/server/src/jobs/fiabilisation/dossiersApprenants/process-effectifs-queue.ts
+++ b/server/src/jobs/fiabilisation/dossiersApprenants/process-effectifs-queue.ts
@@ -18,7 +18,7 @@ import {
   structureOrganisme,
 } from "../../../common/actions/organismes/organismes.actions.js";
 import dossierApprenantSchema from "../../../common/validation/dossierApprenantSchema.js";
-import { EffectifsQueue } from "@/src/common/model/@types/EffectifsQueue.js";
+import { EffectifsQueue } from "@/common/model/@types/EffectifsQueue.js";
 
 const sleep = (m) => new Promise((r) => setTimeout(r, m));
 const sleepDuration = 10_000;

--- a/server/tests/utils/permissions.ts
+++ b/server/tests/utils/permissions.ts
@@ -1,8 +1,8 @@
-import { NewOrganisation } from "@/src/common/model/organisations.model.js";
-import { Organisme } from "@/src/common/model/@types/Organisme.js";
+import { NewOrganisation } from "@/common/model/organisations.model.js";
+import { Organisme } from "@/common/model/@types/Organisme.js";
 import { ObjectId } from "mongodb";
 import { id } from "./testUtils.js";
-import { Effectif } from "@/src/common/model/@types/Effectif.js";
+import { Effectif } from "@/common/model/@types/Effectif.js";
 
 /*
 Quelques sirets générés à utiliser pour une meilleure lisibilité :

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -33,7 +33,7 @@
     "baseUrl": "./", /* Specify the base directory to resolve non-relative module names. */
     "paths": {
       "@/*": [
-        "*"
+        "./src/*"
       ],
     }, /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -3024,6 +3024,11 @@ express-async-errors@3.1.1:
   resolved "https://registry.yarnpkg.com/express-async-errors/-/express-async-errors-3.1.1.tgz#6053236d61d21ddef4892d6bd1d736889fc9da41"
   integrity sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==
 
+express-list-endpoints@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/express-list-endpoints/-/express-list-endpoints-6.0.0.tgz#903f000b0cc954bbc35ca44e7aa3917e5292d0c2"
+  integrity sha512-1I30bSVego+AU/eSsX/bV2xrOXW5tFhsuXZp7wZd9396bAAxH7KHaAwLXQYra0Aw33xA67HmNiceGf2SOvXaLg==
+
 express@4.18.1:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.1.tgz#7797de8b9c72c857b9cd0e14a5eea80666267caf"

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -783,6 +783,140 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@esbuild-kit/cjs-loader@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@esbuild-kit/cjs-loader/-/cjs-loader-2.4.2.tgz#cb4dde00fbf744a68c4f20162ea15a8242d0fa54"
+  integrity sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==
+  dependencies:
+    "@esbuild-kit/core-utils" "^3.0.0"
+    get-tsconfig "^4.4.0"
+
+"@esbuild-kit/core-utils@^3.0.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@esbuild-kit/core-utils/-/core-utils-3.1.0.tgz#49945d533dbd5e1b7620aa0fc522c15e6ec089c5"
+  integrity sha512-Uuk8RpCg/7fdHSceR1M6XbSZFSuMrxcePFuGgyvsBn+u339dk5OeL4jv2EojwTN2st/unJGsVm4qHWjWNmJ/tw==
+  dependencies:
+    esbuild "~0.17.6"
+    source-map-support "^0.5.21"
+
+"@esbuild-kit/esm-loader@^2.5.5":
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/@esbuild-kit/esm-loader/-/esm-loader-2.5.5.tgz#b82da14fcee3fc1d219869756c06f43f67d1ca71"
+  integrity sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==
+  dependencies:
+    "@esbuild-kit/core-utils" "^3.0.0"
+    get-tsconfig "^4.4.0"
+
+"@esbuild/android-arm64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.17.tgz#164b054d58551f8856285f386e1a8f45d9ba3a31"
+  integrity sha512-jaJ5IlmaDLFPNttv0ofcwy/cfeY4bh/n705Tgh+eLObbGtQBK3EPAu+CzL95JVE4nFAliyrnEu0d32Q5foavqg==
+
+"@esbuild/android-arm@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.17.17.tgz#1b3b5a702a69b88deef342a7a80df4c894e4f065"
+  integrity sha512-E6VAZwN7diCa3labs0GYvhEPL2M94WLF8A+czO8hfjREXxba8Ng7nM5VxV+9ihNXIY1iQO1XxUU4P7hbqbICxg==
+
+"@esbuild/android-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.17.17.tgz#6781527e3c4ea4de532b149d18a2167f06783e7f"
+  integrity sha512-446zpfJ3nioMC7ASvJB1pszHVskkw4u/9Eu8s5yvvsSDTzYh4p4ZIRj0DznSl3FBF0Z/mZfrKXTtt0QCoFmoHA==
+
+"@esbuild/darwin-arm64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.17.17.tgz#c5961ef4d3c1cc80dafe905cc145b5a71d2ac196"
+  integrity sha512-m/gwyiBwH3jqfUabtq3GH31otL/0sE0l34XKpSIqR7NjQ/XHQ3lpmQHLHbG8AHTGCw8Ao059GvV08MS0bhFIJQ==
+
+"@esbuild/darwin-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.17.17.tgz#b81f3259cc349691f67ae30f7b333a53899b3c20"
+  integrity sha512-4utIrsX9IykrqYaXR8ob9Ha2hAY2qLc6ohJ8c0CN1DR8yWeMrTgYFjgdeQ9LIoTOfLetXjuCu5TRPHT9yKYJVg==
+
+"@esbuild/freebsd-arm64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.17.tgz#db846ad16cf916fd3acdda79b85ea867cb100e87"
+  integrity sha512-4PxjQII/9ppOrpEwzQ1b0pXCsFLqy77i0GaHodrmzH9zq2/NEhHMAMJkJ635Ns4fyJPFOlHMz4AsklIyRqFZWA==
+
+"@esbuild/freebsd-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.17.17.tgz#4dd99acbaaba00949d509e7c144b1b6ef9e1815b"
+  integrity sha512-lQRS+4sW5S3P1sv0z2Ym807qMDfkmdhUYX30GRBURtLTrJOPDpoU0kI6pVz1hz3U0+YQ0tXGS9YWveQjUewAJw==
+
+"@esbuild/linux-arm64@0.17.17", "@esbuild/linux-arm64@^0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.17.17.tgz#7f9274140b2bb9f4230dbbfdf5dc2761215e30f6"
+  integrity sha512-2+pwLx0whKY1/Vqt8lyzStyda1v0qjJ5INWIe+d8+1onqQxHLLi3yr5bAa4gvbzhZqBztifYEu8hh1La5+7sUw==
+
+"@esbuild/linux-arm@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.17.17.tgz#5c8e44c2af056bb2147cf9ad13840220bcb8948b"
+  integrity sha512-biDs7bjGdOdcmIk6xU426VgdRUpGg39Yz6sT9Xp23aq+IEHDb/u5cbmu/pAANpDB4rZpY/2USPhCA+w9t3roQg==
+
+"@esbuild/linux-ia32@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.17.17.tgz#18a6b3798658be7f46e9873fa0c8d4bec54c9212"
+  integrity sha512-IBTTv8X60dYo6P2t23sSUYym8fGfMAiuv7PzJ+0LcdAndZRzvke+wTVxJeCq4WgjppkOpndL04gMZIFvwoU34Q==
+
+"@esbuild/linux-loong64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.17.17.tgz#a8d93514a47f7b4232716c9f02aeb630bae24c40"
+  integrity sha512-WVMBtcDpATjaGfWfp6u9dANIqmU9r37SY8wgAivuKmgKHE+bWSuv0qXEFt/p3qXQYxJIGXQQv6hHcm7iWhWjiw==
+
+"@esbuild/linux-mips64el@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.17.17.tgz#4784efb1c3f0eac8133695fa89253d558149ee1b"
+  integrity sha512-2kYCGh8589ZYnY031FgMLy0kmE4VoGdvfJkxLdxP4HJvWNXpyLhjOvxVsYjYZ6awqY4bgLR9tpdYyStgZZhi2A==
+
+"@esbuild/linux-ppc64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.17.17.tgz#ef6558ec5e5dd9dc16886343e0ccdb0699d70d3c"
+  integrity sha512-KIdG5jdAEeAKogfyMTcszRxy3OPbZhq0PPsW4iKKcdlbk3YE4miKznxV2YOSmiK/hfOZ+lqHri3v8eecT2ATwQ==
+
+"@esbuild/linux-riscv64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.17.17.tgz#13a87fdbcb462c46809c9d16bcf79817ecf9ce6f"
+  integrity sha512-Cj6uWLBR5LWhcD/2Lkfg2NrkVsNb2sFM5aVEfumKB2vYetkA/9Uyc1jVoxLZ0a38sUhFk4JOVKH0aVdPbjZQeA==
+
+"@esbuild/linux-s390x@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.17.17.tgz#83cb16d1d3ac0dca803b3f031ba3dc13f1ec7ade"
+  integrity sha512-lK+SffWIr0XsFf7E0srBjhpkdFVJf3HEgXCwzkm69kNbRar8MhezFpkIwpk0qo2IOQL4JE4mJPJI8AbRPLbuOQ==
+
+"@esbuild/linux-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.17.17.tgz#7bc400568690b688e20a0c94b2faabdd89ae1a79"
+  integrity sha512-XcSGTQcWFQS2jx3lZtQi7cQmDYLrpLRyz1Ns1DzZCtn898cWfm5Icx/DEWNcTU+T+tyPV89RQtDnI7qL2PObPg==
+
+"@esbuild/netbsd-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.17.17.tgz#1b5dcfbc4bfba80e67a11e9148de836af5b58b6c"
+  integrity sha512-RNLCDmLP5kCWAJR+ItLM3cHxzXRTe4N00TQyQiimq+lyqVqZWGPAvcyfUBM0isE79eEZhIuGN09rAz8EL5KdLA==
+
+"@esbuild/openbsd-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.17.17.tgz#e275098902291149a5dcd012c9ea0796d6b7adff"
+  integrity sha512-PAXswI5+cQq3Pann7FNdcpSUrhrql3wKjj3gVkmuz6OHhqqYxKvi6GgRBoaHjaG22HV/ZZEgF9TlS+9ftHVigA==
+
+"@esbuild/sunos-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.17.17.tgz#10603474866f64986c0370a2d4fe5a2bb7fee4f5"
+  integrity sha512-V63egsWKnx/4V0FMYkr9NXWrKTB5qFftKGKuZKFIrAkO/7EWLFnbBZNM1CvJ6Sis+XBdPws2YQSHF1Gqf1oj/Q==
+
+"@esbuild/win32-arm64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.17.17.tgz#521a6d97ee0f96b7c435930353cc4e93078f0b54"
+  integrity sha512-YtUXLdVnd6YBSYlZODjWzH+KzbaubV0YVd6UxSfoFfa5PtNJNaW+1i+Hcmjpg2nEe0YXUCNF5bkKy1NnBv1y7Q==
+
+"@esbuild/win32-ia32@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.17.17.tgz#56f88462ebe82dad829dc2303175c0e0ccd8e38e"
+  integrity sha512-yczSLRbDdReCO74Yfc5tKG0izzm+lPMYyO1fFTcn0QNwnKmc3K+HdxZWLGKg4pZVte7XVgcFku7TIZNbWEJdeQ==
+
+"@esbuild/win32-x64@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.17.17.tgz#2b577b976e6844106715bbe0cdc57cd1528063f9"
+  integrity sha512-FNZw7H3aqhF9OyRQbDDnzUApDXfC1N6fgBhkqEO2jvYCJ+DxMTfZVqg3AX0R1khg1wHTBRD5SdcibSJ+XF6bFg==
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.3.0.tgz#a556790523a351b4e47e9d385f47265eaaf9780a"
@@ -2632,6 +2766,34 @@ es6-weak-map@^2.0.3:
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.1"
 
+esbuild@~0.17.6:
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.17.17.tgz#fa906ab11b11d2ed4700f494f4f764229b25c916"
+  integrity sha512-/jUywtAymR8jR4qsa2RujlAF7Krpt5VWi72Q2yuLD4e/hvtNcFQ0I1j8m/bxq238pf3/0KO5yuXNpuLx8BE1KA==
+  optionalDependencies:
+    "@esbuild/android-arm" "0.17.17"
+    "@esbuild/android-arm64" "0.17.17"
+    "@esbuild/android-x64" "0.17.17"
+    "@esbuild/darwin-arm64" "0.17.17"
+    "@esbuild/darwin-x64" "0.17.17"
+    "@esbuild/freebsd-arm64" "0.17.17"
+    "@esbuild/freebsd-x64" "0.17.17"
+    "@esbuild/linux-arm" "0.17.17"
+    "@esbuild/linux-arm64" "0.17.17"
+    "@esbuild/linux-ia32" "0.17.17"
+    "@esbuild/linux-loong64" "0.17.17"
+    "@esbuild/linux-mips64el" "0.17.17"
+    "@esbuild/linux-ppc64" "0.17.17"
+    "@esbuild/linux-riscv64" "0.17.17"
+    "@esbuild/linux-s390x" "0.17.17"
+    "@esbuild/linux-x64" "0.17.17"
+    "@esbuild/netbsd-x64" "0.17.17"
+    "@esbuild/openbsd-x64" "0.17.17"
+    "@esbuild/sunos-x64" "0.17.17"
+    "@esbuild/win32-arm64" "0.17.17"
+    "@esbuild/win32-ia32" "0.17.17"
+    "@esbuild/win32-x64" "0.17.17"
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -3192,6 +3354,11 @@ get-tsconfig@^4.2.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.4.0.tgz#64eee64596668a81b8fce18403f94f245ee0d4e5"
   integrity sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==
+
+get-tsconfig@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.5.0.tgz#6d52d1c7b299bd3ee9cd7638561653399ac77b0f"
+  integrity sha512-MjhiaIWCJ1sAU4pIQ5i5OfOuHHxVo1oYeNsWTON7jxYkod8pHocXeh+SSbmu5OZZZK73B6cbJ2XADzXehLyovQ==
 
 get-value@^2.0.3:
   version "2.0.6"
@@ -6029,7 +6196,7 @@ socks@^2.7.1:
     ip "^2.0.0"
     smart-buffer "^4.2.0"
 
-source-map-support@^0.5.6:
+source-map-support@^0.5.21, source-map-support@^0.5.6:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -6437,6 +6604,17 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+tsx@3.12.6:
+  version "3.12.6"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-3.12.6.tgz#36b3693e48b8392da374487190972c7b80e433b4"
+  integrity sha512-q93WgS3lBdHlPgS0h1i+87Pt6n9K/qULIMNYZo07nSeu2z5QE2CellcAZfofVXBo2tQg9av2ZcRMQ2S2i5oadQ==
+  dependencies:
+    "@esbuild-kit/cjs-loader" "^2.4.2"
+    "@esbuild-kit/core-utils" "^3.0.0"
+    "@esbuild-kit/esm-loader" "^2.5.5"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Une PR pour pouvoir utiliser les paths dans tsconfig, sur la partie server. J'ai été obligé de passer sur tsx, qui supporte bcp mieux cela que ts-node.

J'en ai profité pour ajouté express-list-endpoints pour lister toutes les URLs sur le server express (il y en a bcp, du coup on s'y perd un peu).
