### PR TITLE
fix(server): dossierApprenantSchema - date métier isoDate

### DIFF
--- a/server/src/common/validation/utils/zodPrimitives.ts
+++ b/server/src/common/validation/utils/zodPrimitives.ts
@@ -72,7 +72,7 @@ export const primitivesV1 = {
         enum: CODES_STATUT_APPRENANT_ENUM,
         type: "integer",
       }),
-    date_metier_mise_a_jour_statut: extensions.iso8601Datetime().openapi({
+    date_metier_mise_a_jour_statut: extensions.iso8601Date().openapi({
       description: "Date de dernière mise à jour du statut de l'apprenant, au format ISO-8601",
     }),
     id_erp: z.string().openapi({


### PR DESCRIPTION
A discuter ensemble, j'ai l'impression que le schema ZOD qui est utilisé pour la queue requiert un **iso8601DateTime** pour le champ **date_maj_metier** mais il me semble qu'on attends un champ **iso8601Date** en théorie 🤔 

