### PR TITLE
chore(server): upgrade mem limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     container_name: flux_retour_cfas_server
     build:
       context: server
-    mem_limit: 2g
+    mem_limit: 3g
     restart: unless-stopped
     networks:
       - flux_retour_cfas_network
@@ -65,7 +65,7 @@ services:
     container_name: flux_retour_cfas_processor
     build:
       context: server
-    command: ["yarn", "cli", "process:effectifs-queue"]
+    command: [ "yarn", "cli", "process:effectifs-queue" ]
     mem_limit: 2g
     restart: always
     networks:
@@ -94,7 +94,7 @@ services:
     networks:
       - flux_retour_cfas_network
     healthcheck:
-      test: ["CMD", "/usr/local/bin/clamdcheck.sh"]
+      test: [ "CMD", "/usr/local/bin/clamdcheck.sh" ]
       interval: 60s
       retries: 3
       start_period: 120s


### PR DESCRIPTION
Proposition d'upgrade de la memlimit du server.

J'ai constaté que le job hydrate:organismes dépasse le quota 2G depuis qqs jours sur la prod / recette. Il y a peut etre une alternative à creuser ensemble

