### PR TITLE
fix: démarrage automatique des services en dev

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -81,6 +81,7 @@ services:
   smtp:
     image: axllent/mailpit:v1.5.5
     container_name: flux_retour_cfas_smtp
+    restart: unless-stopped
     mem_limit: 128m
     ports:
       - 1025:1025

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     build:
       context: ui
     mem_limit: 256m
+    restart: unless-stopped
     networks:
       - flux_retour_cfas_network
     depends_on:
@@ -67,7 +68,7 @@ services:
       context: server
     command: [ "yarn", "cli", "process:effectifs-queue" ]
     mem_limit: 2g
-    restart: always
+    restart: unless-stopped
     networks:
       - flux_retour_cfas_network
     depends_on:


### PR DESCRIPTION
Au démarrage de mon PC, la stack n'est jamais correctement démarrée entre autres car nginx se vautre car le smtp n'est pas démarré.
Cette PR corrige les politiques de restart des conteneurs pour unless-stopped (qui est safe à utiliser partout)
