### PR TITLE
fix(server): validation req query string

### DIFF
--- a/server/src/http/routes/specific.routes/organismes.routes.ts
+++ b/server/src/http/routes/specific.routes/organismes.routes.ts
@@ -19,8 +19,8 @@ export default () => {
     returnResult(async (req) => {
       const params = await validateFullZodObjectSchema(req.query, {
         query: z.string().optional(),
-        page: z.number().optional(),
-        limit: z.number().optional(),
+        page: z.string().optional(),
+        limit: z.string().optional(),
       });
 
       const query = params.query ?? "{}";


### PR DESCRIPTION
Je viens de voir que la validation Zod des req.query ne passait pas car ce sont des query string parameters. 

Cette route est appelée par le référentiel et du coup les organismes du tdb ne sont plus remontés.