### PR TITLE
chore(server): script de suppression des inscrits sans contrats non recus depuis X semaines

### DIFF
--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -1,4 +1,5 @@
 import { Option, program } from "commander";
+import { addDays } from "date-fns";
 import HttpTerminator from "lil-http-terminator";
 
 import logger from "./common/logger";
@@ -11,6 +12,7 @@ import { findInvalidDocuments } from "./jobs/db/findInvalidDocuments";
 import { recreateIndexes } from "./jobs/db/recreateIndexes";
 import { processEffectifsQueueEndlessly } from "./jobs/fiabilisation/dossiersApprenants/process-effectifs-queue";
 import { removeDuplicatesEffectifsQueue } from "./jobs/fiabilisation/dossiersApprenants/process-effectifs-queue-remove-duplicates";
+import { removeInscritsSansContratsNonRecusDepuis } from "./jobs/fiabilisation/dossiersApprenants/remove-nonRecus-depuis";
 import { getStats } from "./jobs/fiabilisation/stats";
 import { buildFiabilisationUaiSiret } from "./jobs/fiabilisation/uai-siret/build";
 import { updateOrganismesFiabilisationUaiSiret } from "./jobs/fiabilisation/uai-siret/update";
@@ -449,6 +451,20 @@ program
       const updateResults = await updateOrganismesFiabilisationUaiSiret();
 
       return { buildResults, updateResults };
+    })
+  );
+/**
+ * Job de suppression des inscrits sans contrats non reçus depuis une date donnée
+ */
+program
+  .command("fiabilisation:effectifs:remove-inscritsSansContrats-nonRecus-depuis")
+  .description("Suppression des inscrits sans contrats non reçus depuis une date donnée")
+  .addOption(new Option("--dateReception <date>", "Date de dernière réception"))
+  .action(
+    runJob(async ({ dateReception }) => {
+      // Lancement du script pour une date de réception il y a 90 jours par défaut
+      const dateDerniereReception = dateReception ? new Date(dateReception) : addDays(new Date(), -90);
+      return removeInscritsSansContratsNonRecusDepuis(dateDerniereReception);
     })
   );
 

--- a/server/src/jobs/fiabilisation/dossiersApprenants/remove-nonRecus-depuis/index.js
+++ b/server/src/jobs/fiabilisation/dossiersApprenants/remove-nonRecus-depuis/index.js
@@ -1,0 +1,21 @@
+import { inscritsSansContratsIndicator } from "@/common/actions/effectifs/indicators";
+import logger from "@/common/logger";
+import { effectifsDb } from "@/common/model/collections";
+
+const CURRENT_ANNEES_SCOLAIRES = ["2022-2023", "2023-2023"];
+
+/**
+ * Méthode de suppression des effectifs inscrits sans contrats pour les années scolaires courantes,
+ * qui n'ont pas été envoyé au TDB depuis la date fournie en paramètre
+ */
+export const removeInscritsSansContratsNonRecusDepuis = async (dateDerniereReception) => {
+  const filterStages = [{ $match: { annee_scolaire: { $in: CURRENT_ANNEES_SCOLAIRES } } }];
+  const inscritsSansContratsIdsToRemove = (
+    await inscritsSansContratsIndicator.getListAtDate(dateDerniereReception, filterStages)
+  ).map((item) => item._id);
+
+  const { deletedCount } = await effectifsDb().deleteMany({ _id: { $in: inscritsSansContratsIdsToRemove } });
+  logger.info(
+    `Suppression de ${deletedCount} effectifs inscrits non recus depuis le ${dateDerniereReception.toISOString()} !`
+  );
+};


### PR DESCRIPTION
Ajout d'un script de suppression des inscrits sans contrats depuis 90 jours par défaut.

Avant de l'exécuter en prod il faudra que @nadinelouchart affiche un bandeau coté métier pour prévenir de la suppression de 13K+ effectifs correspondants.