### PR TITLE
fix(ui): en cas d'absence de nature d'organisme, le texte inconnu pouvait passer sur deux lignes

### DIFF
--- a/ui/modules/indicateurs/NatureOrganismeTag.tsx
+++ b/ui/modules/indicateurs/NatureOrganismeTag.tsx
@@ -22,7 +22,7 @@ function NatureOrganismeTag({ nature, ...props }: NatureOrganismeTagProps) {
       px={3}
       py={1}
       maxWidth="min-content"
-      whiteSpace={nature === "inconnue" ? "nowrap" : "normal"}
+      whiteSpace={nature === "inconnue" || !NATURE_ORGANISME[nature] ? "nowrap" : "normal"}
       {...props}
     >
       {NATURE_ORGANISME[nature] ?? "⚠ Inconnue"}


### PR DESCRIPTION
J'avais encore le problème sur mon poste, maintenant c'est bon tout le temps.

<img width="1034" alt="Capture d’écran 2023-06-02 à 11 25 52" src="https://github.com/mission-apprentissage/flux-retour-cfas/assets/1575946/649e04a7-8bd1-4d82-acf4-9fa542682e84">
