### PR TITLE
feat: filtrage bassins emploi pour dreets

### DIFF
--- a/ui/components/Page/components/Header.tsx
+++ b/ui/components/Page/components/Header.tsx
@@ -1,21 +1,20 @@
 import {
   Box,
   Button,
+  MenuItem as ChakraMenuItem,
   Container,
   Flex,
-  Heading,
   HStack,
+  Heading,
+  Image,
   Menu,
   MenuButton,
   MenuDivider,
   MenuGroup,
   MenuList,
-  MenuItem as ChakraMenuItem,
   Tag,
   Text,
-  Image,
 } from "@chakra-ui/react";
-import React from "react";
 
 import { PRODUCT_NAME_TITLE } from "@/common/constants/product";
 import { _post } from "@/common/httpClient";
@@ -119,9 +118,6 @@ const Header = () => {
                 BETA
               </Tag>
             </Heading>
-            <Text fontFamily="Marianne" color="grey.700" fontSize="zeta" mt={1}>
-              Mettre à disposition des différents acteurs les données clés de l&apos;apprentissage en temps réel
-            </Text>
           </Box>
 
           <Flex

--- a/ui/modules/indicateurs/IndicateursForm.tsx
+++ b/ui/modules/indicateurs/IndicateursForm.tsx
@@ -89,13 +89,14 @@ function getFiltreTerritoiresConfig(organisation: Organisation): FiltreOrganisme
           (departement) => departement.code
         ),
         academies: [],
-        bassinsEmploi: [],
       };
 
     case "DDETS":
       return {
         defaultLabel: DEPARTEMENTS_BY_CODE[organisation.code_departement]?.nom,
-        disabled: true,
+        regions: [],
+        departements: [],
+        academies: [],
       };
     case "ACADEMIE":
       return {
@@ -105,7 +106,6 @@ function getFiltreTerritoiresConfig(organisation: Organisation): FiltreOrganisme
           (departement) => departement.academie.code === organisation.code_academie
         ).map((departement) => departement.code),
         academies: [],
-        bassinsEmploi: [],
       };
     case "OPERATEUR_PUBLIC_NATIONAL":
     case "ADMINISTRATEUR":


### PR DESCRIPTION
- [x] supprime la phrase d'accroche qui peut porter à confusion sur le cloisonnement des données pour les OF (validé par Nadine)
- [x] affiche l'onglet bassins d'emploi pour les profils dreets, deets, etc. (non filtrés par territoires)
