### PR TITLE
fix: corrections mineures sur les indicateurs et nouveau calcul sur les apprenants

### DIFF
--- a/server/src/common/actions/indicateurs/indicateurs.actions.ts
+++ b/server/src/common/actions/indicateurs/indicateurs.actions.ts
@@ -420,7 +420,7 @@ export async function getIndicateursEffectifsParOrganisme(
           nature: "$organisme.nature",
 
           apprenants: {
-            $sum: ["$apprentis", "$inscritsSansContrat"],
+            $sum: ["$apprentis", "$inscritsSansContrat", "$rupturants"],
           },
           apprentis: 1,
           inscritsSansContrat: 1,

--- a/server/src/common/actions/indicateurs/indicateurs.actions.ts
+++ b/server/src/common/actions/indicateurs/indicateurs.actions.ts
@@ -174,7 +174,7 @@ export async function getIndicateursEffectifsParDepartement(
           _id: 0,
           departement: "$_id",
           apprenants: {
-            $sum: ["$apprentis", "$inscritsSansContrat"],
+            $sum: ["$apprentis", "$inscritsSansContrat", "$rupturants"],
           },
           apprentis: 1,
           inscritsSansContrat: 1,

--- a/ui/modules/dashboard/CarteFrance.tsx
+++ b/ui/modules/dashboard/CarteFrance.tsx
@@ -13,6 +13,7 @@ interface Props<Data extends object> {
   dataKey: string; // 1 seule via param pour l'instant, sera géré plus tard via filtre interne uniquement
   minColor: string;
   maxColor: string;
+  pourcentage?: boolean;
 }
 
 function CarteFrance<Data extends object>(props: Props<Data>) {
@@ -113,7 +114,9 @@ function CarteFrance<Data extends object>(props: Props<Data>) {
               }}
               whiteSpace="nowrap"
             >
-              {prettyFormatNumber(bin.minValue)} - {prettyFormatNumber(bin.maxValue)}
+              {prettyFormatNumber(bin.minValue)}
+              {props.pourcentage && "%"} - {prettyFormatNumber(bin.maxValue)}
+              {props.pourcentage && "%"}
             </Box>
           ))}
         </Box>

--- a/ui/modules/dashboard/DashboardTransverse.tsx
+++ b/ui/modules/dashboard/DashboardTransverse.tsx
@@ -23,6 +23,7 @@ import {
   OrganisationOperateurPublicDepartement,
   OrganisationOperateurPublicRegion,
 } from "@/common/internal/Organisation";
+import { formatDateDayMonthYear } from "@/common/utils/dateUtils";
 import { formatNumber, prettyFormatNumber } from "@/common/utils/stringUtils";
 import Link from "@/components/Links/Link";
 import SecondarySelectButton from "@/components/SelectButton/SecondarySelectButton";
@@ -177,19 +178,13 @@ const DashboardTransverse = () => {
           effectifs de l’apprentissage
         </Text>
         <Text fontSize={14} mt="4">
-          Le{" "}
+          Le <strong>{formatDateDayMonthYear(effectifsFilters.date)}</strong>, le tableau de bord de l’apprentissage
+          recense <strong>{formatNumber(indicateursEffectifsNationaux.apprenants)} apprenants</strong> dans votre
+          territoire, dont <strong>{formatNumber(indicateursEffectifsNationaux.apprentis)} apprentis</strong>,{" "}
           <strong>
-            {effectifsFilters.date.toLocaleDateString(undefined, {
-              month: "long",
-              day: "numeric",
-              year: "numeric",
-            })}
-          </strong>
-          , le tableau de bord de l’apprentissage recense{" "}
-          <strong>{formatNumber(indicateursEffectifsNationaux.apprenants)} apprenants</strong> dans votre territoire,
-          dont <strong>{formatNumber(indicateursEffectifsNationaux.apprentis)} apprentis</strong>,{" "}
-          <strong>{formatNumber(indicateursEffectifsNationaux.rupturants)} rupturants</strong> et{" "}
-          <strong>{formatNumber(indicateursEffectifsNationaux.inscritsSansContrat)} jeunes sans contrat</strong>.
+            {formatNumber(indicateursEffectifsNationaux.inscritsSansContrat)} jeunes en formation sans contrat
+          </strong>{" "}
+          et <strong>{formatNumber(indicateursEffectifsNationaux.rupturants)} rupturants</strong>.
         </Text>
         <HStack mt={8}>
           <Box>Filtrer par</Box>

--- a/ui/modules/dashboard/DashboardTransverse.tsx
+++ b/ui/modules/dashboard/DashboardTransverse.tsx
@@ -23,7 +23,7 @@ import {
   OrganisationOperateurPublicDepartement,
   OrganisationOperateurPublicRegion,
 } from "@/common/internal/Organisation";
-import { prettyFormatNumber } from "@/common/utils/stringUtils";
+import { formatNumber, prettyFormatNumber } from "@/common/utils/stringUtils";
 import Link from "@/components/Links/Link";
 import SecondarySelectButton from "@/components/SelectButton/SecondarySelectButton";
 import withAuth from "@/components/withAuth";
@@ -168,11 +168,28 @@ const DashboardTransverse = () => {
           Aperçu des données de l’apprentissage
         </Heading>
         <Text fontSize={14} mt="8">
-          Ces chiffres reflètent partiellement les effectifs de l’apprentissage
+          Ces chiffres reflètent partiellement les effectifs de l’apprentissage&nbsp;:
           <Text as="span" fontWeight="bold">
             {auth.organisation.type === "TETE_DE_RESEAU" && " dans votre réseau"}
-          </Text>{" "}
-          : une partie des organismes de formation ne transmettent pas encore leurs données au tableau de bord.
+          </Text>
+          &nbsp;: une partie des organismes de formation en apprentissage ne transmettent pas encore leurs données au
+          tableau de bord (voir carte “Taux de couverture” ci-dessous). Ces chiffres reflètent partiellement les
+          effectifs de l’apprentissage
+        </Text>
+        <Text fontSize={14} mt="4">
+          Le{" "}
+          <strong>
+            {effectifsFilters.date.toLocaleDateString(undefined, {
+              month: "long",
+              day: "numeric",
+              year: "numeric",
+            })}
+          </strong>
+          , le tableau de bord de l’apprentissage recense{" "}
+          <strong>{formatNumber(indicateursEffectifsNationaux.apprenants)} apprenants</strong> dans votre territoire,
+          dont <strong>{formatNumber(indicateursEffectifsNationaux.apprentis)} apprentis</strong>,{" "}
+          <strong>{formatNumber(indicateursEffectifsNationaux.rupturants)} rupturants</strong> et{" "}
+          <strong>{formatNumber(indicateursEffectifsNationaux.inscritsSansContrat)} jeunes sans contrat</strong>.
         </Text>
         <HStack mt={8}>
           <Box>Filtrer par</Box>
@@ -261,10 +278,11 @@ const DashboardTransverse = () => {
                 color="white"
                 label={
                   <Box padding="1w">
-                    Ce taux traduit le nombre d’organismes (sauf responsables) qui transmettent au tableau de bord. Les
-                    organismes qui transmettent mais ne font pas partie du référentiel ne rentrent pas en compte dans ce
-                    taux. Il est conseillé d’avoir un minimum de 80% d’établissements transmetteurs afin de garantir la
-                    viabilité des enquêtes menées auprès de ces derniers.
+                    Ce taux traduit le nombre d’organismes dispensant une formation en apprentissage (sauf responsables)
+                    qui transmettent au tableau de bord. Les organismes qui transmettent mais ne font pas partie du
+                    référentiel ne rentrent pas en compte dans ce taux. Il est conseillé d’avoir un minimum de 80%
+                    d’établissements transmetteurs afin de garantir la viabilité des enquêtes menées auprès de ces
+                    derniers.
                   </Box>
                 }
                 aria-label="Informations sur le taux de couverture des organismes"
@@ -291,6 +309,7 @@ const DashboardTransverse = () => {
                 dataKey="tauxCouverture"
                 minColor="#ECF5E0"
                 maxColor="#4F6C21"
+                pourcentage
                 tooltipContent={(indicateurs) =>
                   indicateurs ? (
                     <>

--- a/ui/modules/dashboard/IndicateursGrid.tsx
+++ b/ui/modules/dashboard/IndicateursGrid.tsx
@@ -221,7 +221,7 @@ function IndicateursGrid({
       </GridItem>
       <GridItem bg="galt" colSpan={2}>
         <Card
-          label="dont sorties d’apprentissage"
+          label="sorties d’apprentissage"
           count={indicateursEffectifs.abandons}
           tooltipLabel={
             <div>


### PR DESCRIPTION
See: https://www.notion.so/mission-apprentissage/Feedbacks-User-Research-Juin-e08663e783f04dfc890de4d53a9c145d

Liste des actions : 
 - Nouveau calcul "apprenant"
 - [Amélioration] Cartographie du taux de couverture : rajouter %
- Tooltip à préciser “Taux de couverture”
- Phrase à changer “Ces chiffres reflètent…” selon maquette