### PR TITLE
fix: changement de texte pour les indicateurs

### DIFF
--- a/ui/modules/indicateurs/IndicateursForm.tsx
+++ b/ui/modules/indicateurs/IndicateursForm.tsx
@@ -305,7 +305,7 @@ function IndicateursForm() {
           <Text color="grey.800" mx={3}>
             Retrouvez ici les indicateurs et les organismes de formation de votre territoire uniquement. Vous avez la
             possibilité de télécharger les listes <Text as="strong">nominatives</Text> pour les jeunes en formation sans
-            contrat, rupturants et sortis d’apprentissage.
+            contrat, rupturants et sorties d’apprentissage.
           </Text>
         </Ribbons>
 

--- a/ui/modules/indicateurs/IndicateursForm.tsx
+++ b/ui/modules/indicateurs/IndicateursForm.tsx
@@ -303,7 +303,9 @@ function IndicateursForm() {
       <Box flex="1">
         <Ribbons>
           <Text color="grey.800" mx={3}>
-            Retrouvez ici les indicateurs et les organismes de formation de votre territoire uniquement.
+            Retrouvez ici les indicateurs et les organismes de formation de votre territoire uniquement. Vous avez la
+            possibilité de télécharger les listes <Text as="strong">nominatives</Text> pour les jeunes en formation sans
+            contrat, rupturants et sortis d’apprentissage.
           </Text>
         </Ribbons>
 


### PR DESCRIPTION
J'ai repris le texte du figma, mais j'ai adapté : `pour les jeunes sans contrat` en `pour les jeunes en formation sans contrat` (cf conversations précédentes) et `sorties` (faute d'accord afaik) en `sortis d’apprentissage`. Je peux changer les textes si besoin.

<img width="1324" alt="Capture d’écran 2023-06-09 à 15 42 35" src="https://github.com/mission-apprentissage/flux-retour-cfas/assets/1575946/767cdf85-89bf-4a79-b988-f0eab345d9b6">
