### PR TITLE
chore(server): refacto vérification organisme fiable

### DIFF
--- a/server/src/common/actions/engine/engine.organismes.utils.ts
+++ b/server/src/common/actions/engine/engine.organismes.utils.ts
@@ -26,10 +26,9 @@ export const mapFiabilizedOrganismeUaiSiretCouple = async ({ uai, siret = null }
 
 /**
  * Fonction de vérification d'un couple UAI-SIRET correspondant à un organisme fiable
- * @param {Object} options
- * @param {string|null} options.uai
- * @param {string|null} options.siret
- * @param {OrganismesReferentiel[]|[]} options.organismesFromReferentiel
+ * @param {string|null} uai
+ * @param {string|null} siret
+ * @param {OrganismesReferentiel[]|[]} organismesFromReferentiel
  * @returns
  */
 export const isOrganismeFiableForCouple = async (
@@ -43,12 +42,11 @@ export const isOrganismeFiableForCouple = async (
       organismesFromReferentiel = await organismesReferentielDb().find().toArray();
     }
 
+    // Si uai ou siret non fourni alors non fiable
+    if (!uai || !siret) return false;
+
     // Si on trouve un organisme ouvert dans le référentiel avec ce couple uai / siret alors il est fiable
-    return organismesFromReferentiel.some(
-      (item) => item.siret === siret && item.uai === uai && item.etat_administratif !== "fermé"
-    )
-      ? true
-      : false;
+    return (await organismesReferentielDb().countDocuments({ siret, uai, etat_administratif: { $ne: "fermé" } })) > 0;
   } catch (err) {
     logger.warn({ uai, siret }, "organisme non trouvé pour ce couple");
     return false;

--- a/server/src/common/actions/engine/engine.organismes.utils.ts
+++ b/server/src/common/actions/engine/engine.organismes.utils.ts
@@ -1,5 +1,7 @@
 import { STATUT_FIABILISATION_COUPLES_UAI_SIRET } from "@/common/constants/fiabilisation";
-import { fiabilisationUaiSiretDb } from "@/common/model/collections";
+import logger from "@/common/logger";
+import { OrganismesReferentiel } from "@/common/model/@types";
+import { fiabilisationUaiSiretDb, organismesReferentielDb } from "@/common/model/collections";
 
 /**
  * Renvoi le couple UAI-SIRET fiabilisé si présent dans le fichier de fiabilisation
@@ -20,4 +22,35 @@ export const mapFiabilizedOrganismeUaiSiretCouple = async ({ uai, siret = null }
     .map(({ uai_fiable, siret_fiable }) => ({ cleanUai: uai_fiable, cleanSiret: siret_fiable }));
 
   return foundCouple[0] || { cleanUai: uai, cleanSiret: siret }; // Take only first match
+};
+
+/**
+ * Fonction de vérification d'un couple UAI-SIRET correspondant à un organisme fiable
+ * @param {Object} options
+ * @param {string|null} options.uai
+ * @param {string|null} options.siret
+ * @param {OrganismesReferentiel[]|[]} options.organismesFromReferentiel
+ * @returns
+ */
+export const isOrganismeFiableForCouple = async (
+  uai: string | null,
+  siret: string | null,
+  organismesFromReferentiel: OrganismesReferentiel[] = []
+) => {
+  try {
+    // Si la liste des of du référentiel fournie est vide on refresh les données depuis la base
+    if (organismesFromReferentiel.length === 0) {
+      organismesFromReferentiel = await organismesReferentielDb().find().toArray();
+    }
+
+    // Si on trouve un organisme ouvert dans le référentiel avec ce couple uai / siret alors il est fiable
+    return organismesFromReferentiel.some(
+      (item) => item.siret === siret && item.uai === uai && item.etat_administratif !== "fermé"
+    )
+      ? true
+      : false;
+  } catch (err) {
+    logger.warn({ uai, siret }, "organisme non trouvé pour ce couple");
+    return false;
+  }
 };

--- a/server/src/jobs/fiabilisation/uai-siret/build.rules.ts
+++ b/server/src/jobs/fiabilisation/uai-siret/build.rules.ts
@@ -1,8 +1,10 @@
+import { isOrganismeFiableForCouple } from "@/common/actions/engine/engine.organismes.utils";
 import {
   STATUT_FIABILISATION_COUPLES_UAI_SIRET,
   STATUT_FIABILISATION_ORGANISME,
 } from "@/common/constants/fiabilisation";
 import { NATURE_ORGANISME_DE_FORMATION } from "@/common/constants/organisme";
+import { OrganismesReferentiel } from "@/common/model/@types";
 import {
   fiabilisationUaiSiretDb,
   organismesDb,
@@ -17,12 +19,17 @@ import {
  * @param coupleUaiSiretTdbToCheck
  * @returns
  */
-export const checkCoupleFiable = async (coupleUaiSiretTdbToCheck, organismesFromReferentiel) => {
-  const organismeFoundInReferentielViaSiret = organismesFromReferentiel.find(
-    (item) => item.siret === coupleUaiSiretTdbToCheck.siret
+export const checkCoupleFiable = async (
+  coupleUaiSiretTdbToCheck,
+  organismesFromReferentiel: OrganismesReferentiel[] = []
+) => {
+  const organismeFiableForCouple = await isOrganismeFiableForCouple(
+    coupleUaiSiretTdbToCheck.uai,
+    coupleUaiSiretTdbToCheck.siret,
+    organismesFromReferentiel
   );
 
-  if (organismeFoundInReferentielViaSiret && organismeFoundInReferentielViaSiret.uai === coupleUaiSiretTdbToCheck.uai) {
+  if (organismeFiableForCouple) {
     await fiabilisationUaiSiretDb().updateOne(
       { uai: coupleUaiSiretTdbToCheck.uai, siret: coupleUaiSiretTdbToCheck.siret },
       { $set: { type: STATUT_FIABILISATION_COUPLES_UAI_SIRET.FIABLE } },

--- a/server/tests/integration/common/actions/engine.organismes.utils.test.ts
+++ b/server/tests/integration/common/actions/engine.organismes.utils.test.ts
@@ -1,5 +1,3 @@
-import { strict as assert } from "assert";
-
 import { isOrganismeFiableForCouple } from "@/common/actions/engine/engine.organismes.utils";
 import { organismesReferentielDb } from "@/common/model/collections";
 

--- a/server/tests/integration/common/actions/engine.organismes.utils.test.ts
+++ b/server/tests/integration/common/actions/engine.organismes.utils.test.ts
@@ -1,0 +1,74 @@
+import { strict as assert } from "assert";
+
+import { isOrganismeFiableForCouple } from "@/common/actions/engine/engine.organismes.utils";
+import { organismesReferentielDb } from "@/common/model/collections";
+
+describe("Tests des actions  engine utilitaires organismes", () => {
+  describe("isOrganismeFiableForCouple", () => {
+    const UAI_REFERENTIEL = "7722672E";
+    const SIRET_REFERENTIEL = "99370584100099";
+
+    const UAI_REFERENTIEL_FERME = "4422672E";
+    const SIRET_REFERENTIEL_FERME = "44370584100099";
+
+    beforeEach(async () => {
+      // Création d'un organisme dans le référentiel avec un couple fiable
+      await organismesReferentielDb().findOneAndUpdate(
+        { uai: UAI_REFERENTIEL, siret: SIRET_REFERENTIEL, nature: "formateur" },
+        { $set: { lieux_de_formation: [{ uai: UAI_REFERENTIEL }], relations: [] } },
+        { upsert: true, returnDocument: "after" }
+      );
+
+      // Création d'un organisme FERME dans le référentiel avec un couple
+      await organismesReferentielDb().findOneAndUpdate(
+        { uai: UAI_REFERENTIEL_FERME, siret: SIRET_REFERENTIEL_FERME, nature: "formateur" },
+        { $set: { lieux_de_formation: [{ uai: UAI_REFERENTIEL_FERME }], relations: [], etat_administratif: "fermé" } },
+        { upsert: true, returnDocument: "after" }
+      );
+    });
+
+    describe("Vérification des cas de couples non fiables", () => {
+      it("Vérifie qu'on couple sans UAI fourni n'est pas fiable", async () => {
+        const isOrganismeFiable = await isOrganismeFiableForCouple(null, SIRET_REFERENTIEL);
+        assert.equal(isOrganismeFiable, false);
+      });
+
+      it("Vérifie qu'on couple sans SIRET fourni n'est pas fiable", async () => {
+        const isOrganismeFiable = await isOrganismeFiableForCouple(UAI_REFERENTIEL, null);
+        assert.equal(isOrganismeFiable, false);
+      });
+
+      it("Vérifie qu'on couple sans UAI ni SIRET fourni n'est pas fiable", async () => {
+        const isOrganismeFiable = await isOrganismeFiableForCouple(null, null);
+        assert.equal(isOrganismeFiable, false);
+      });
+
+      it("Vérifie qu'on couple avec un UAI non présent dans le référentiel n'est pas fiable", async () => {
+        const UNKNOWN_UAI = "1111111A";
+        const isOrganismeFiable = await isOrganismeFiableForCouple(UNKNOWN_UAI, SIRET_REFERENTIEL);
+        assert.equal(isOrganismeFiable, false);
+      });
+
+      it("Vérifie qu'on couple avec un SIRET non présent dans le référentiel n'est pas fiable", async () => {
+        const UNKNOWN_SIRET = "22222222220099";
+        const isOrganismeFiable = await isOrganismeFiableForCouple(UAI_REFERENTIEL, UNKNOWN_SIRET);
+        assert.equal(isOrganismeFiable, false);
+      });
+
+      it("Vérifie qu'on couple fermé dans le référentiel n'est pas fiable", async () => {
+        const organismeFerme = await organismesReferentielDb().findOne({ uai: UAI_REFERENTIEL_FERME });
+        assert.equal(organismeFerme?.etat_administratif, "fermé");
+
+        const isOrganismeFiable = await isOrganismeFiableForCouple(UAI_REFERENTIEL_FERME, SIRET_REFERENTIEL_FERME);
+        assert.equal(isOrganismeFiable, false);
+      });
+    });
+
+    describe("Vérification des cas de couples fiables", () => {
+      it("Vérifie qu'on couple dont l'UAI et le SIRET matchent dans le référentiel est pas fiable", async () => {
+        const isOrganismeFiable = await isOrganismeFiableForCouple(UAI_REFERENTIEL, SIRET_REFERENTIEL);
+        assert.equal(isOrganismeFiable, true);
+      });
+    });
+  });
+});

--- a/server/tests/integration/jobs/fiabilisation/uai-siret/build-fiabilisation-uai-siret.test.ts
+++ b/server/tests/integration/jobs/fiabilisation/uai-siret/build-fiabilisation-uai-siret.test.ts
@@ -4,6 +4,7 @@ import {
   STATUT_FIABILISATION_COUPLES_UAI_SIRET,
   STATUT_FIABILISATION_ORGANISME,
 } from "@/common/constants/fiabilisation";
+import { OrganismesReferentiel } from "@/common/model/@types";
 import {
   organismesReferentielDb,
   fiabilisationUaiSiretDb,
@@ -48,7 +49,7 @@ describe("Job Build Fiabilisation UAI SIRET", () => {
         relatedFormations: [],
       });
 
-      const allReferentielOrganismes = [organismeReferentiel];
+      const allReferentielOrganismes: OrganismesReferentiel[] = [organismeReferentiel];
       const isCoupleFiable = await checkCoupleFiable(coupleTdb, allReferentielOrganismes);
       assert.deepEqual(isCoupleFiable, true);
 
@@ -82,7 +83,7 @@ describe("Job Build Fiabilisation UAI SIRET", () => {
         relatedFormations: [],
       });
 
-      const allReferentielOrganismes = [organismeReferentiel];
+      const allReferentielOrganismes: OrganismesReferentiel[] = [organismeReferentiel];
       const isCoupleFiable = await checkCoupleFiable(coupleTdb, allReferentielOrganismes);
 
       // Vérification de la non création du couple en tant que FIABLE


### PR DESCRIPTION
Petite PR de refacto / mutualisation de la logique de vérification d'un organisme fiable via un couple UAI SIRET.

MAJ coté script de fiabilisation + tests