### PR TITLE
fix: cacher filtre réseau pour les têtes de réseau

### DIFF
--- a/ui/modules/indicateurs/IndicateursForm.tsx
+++ b/ui/modules/indicateurs/IndicateursForm.tsx
@@ -306,12 +306,14 @@ function IndicateursForm() {
           <Text fontWeight="700" textTransform="uppercase">
             Organisme
           </Text>
-          <IndicateursFilter label="Réseau d’organismes">
-            <FiltreOrganismeReseau
-              value={effectifsFilters.organisme_reseaux}
-              onChange={(reseaux) => updateState({ organisme_reseaux: reseaux })}
-            />
-          </IndicateursFilter>
+          {auth.organisation.type !== "TETE_DE_RESEAU" && (
+            <IndicateursFilter label="Réseau d’organismes">
+              <FiltreOrganismeReseau
+                value={effectifsFilters.organisme_reseaux}
+                onChange={(reseaux) => updateState({ organisme_reseaux: reseaux })}
+              />
+            </IndicateursFilter>
+          )}
           <IndicateursFilter label="Établissement">
             <FiltreOrganismeSearch
               value={effectifsFilters.organisme_search}


### PR DESCRIPTION
Problème remonté par Nadine : Cela n'a pas de sens d'afficher le filtre réseau pour une tête de réseau.



