### PR TITLE
fix: borne min à 0 pour l'échelle des cartes

### DIFF
--- a/ui/modules/models/graphs.test.ts
+++ b/ui/modules/models/graphs.test.ts
@@ -8,7 +8,7 @@ describe("calculateBins()", () => {
   it("create bins like metabase", () => {
     expect(calculateBins(indicateurs, 5, "#000000", "#ff0000")).toStrictEqual([
       {
-        minValue: 123,
+        minValue: 0,
         maxValue: 10414,
         color: "#000000",
       },

--- a/ui/modules/models/graphs.ts
+++ b/ui/modules/models/graphs.ts
@@ -10,7 +10,7 @@ export function calculateBins(data: number[], numberOfBuckets: number, minColor:
   const dataMax = sortedData[sortedData.length - 1];
   const binSize = (dataMax - dataMin) / numberOfBuckets;
 
-  return Array.from({ length: numberOfBuckets }, (_, i) => {
+  const bins = Array.from({ length: numberOfBuckets }, (_, i) => {
     const minValue: number = dataMin + i * binSize;
     const maxValue: number = minValue + binSize;
 
@@ -19,6 +19,9 @@ export function calculateBins(data: number[], numberOfBuckets: number, minColor:
 
     return { minValue, maxValue, color };
   });
+  // borne min à zéro pour un meilleur affichage
+  bins[0].minValue = 0;
+  return bins;
 }
 
 // Fonction pour interpoler les couleurs


### PR DESCRIPTION
Vu avec @felixat13, quickfix pour positionner la borne minimale à zéro car les utilisateurs s'y perdent.

Plus tard, éventuellement, on pourra changer la façon dont les bins sont créés.