### PR TITLE
feat: ajout tracking plausible page d'accueil

### DIFF
--- a/server/src/jobs/seed/plausible/goals.ts
+++ b/server/src/jobs/seed/plausible/goals.ts
@@ -6,39 +6,32 @@ const plausibleDomains = [
   "cfas-dev.apprentissage.beta.gouv.fr",
 ];
 
+// https://www.notion.so/mission-apprentissage/Tracking-Plausible-TDB-86c1845affea4d759fc022093af95837
+// identique à la liste côté UI ui/common/plausible-goals.ts
 const goals = [
   // Page Statistiques
   "clic_statistiques",
   "clic_stats_visites",
-  "clic_stats_profil-utilisateur",
+  "clic_stats_profils-utilisateur",
   "clic_stats_acquisition",
   "clic_stats_qualite",
   "clic_stats_couverture",
 
-  // page aide
-  "clic_bouton_aide",
-  "clic_aide_footer",
+  // Header
+  "clic_homepage_inscription_header",
+  "clic_homepage_connexion_header",
 
-  // vue dreets
-  "clic_dreets_vue_territoriale",
-  "clic_dreets_vue_reseau",
-  "clic_dreets_vue_of",
-  "clic_dreets_vue_formation",
-  "clic_filtre_territoire",
-  "clic_selection_territoire",
-  "clic_onglet_vue_globale",
-  "clic_onglet_effectifs_organisme",
-  "clic_onglet_vue_effectifs_niveau",
-  "clic_organisme",
-  "telechargement_donnees_territoire_dreets",
+  // Page d'accueil
+  "clic_homepage_inscription_bandeau",
+  "clic_homepage_connexion_bandeau",
+  "clic_homepage_inscription_carto",
+  "clic_homepage_connexion_carto",
+  "clic_homepage_page_linkedin",
 
-  // Vue OF
-  "clic_organisme",
-  "telechargement_effectifs_of",
-  "clic_toggle",
-  "clic_filtre_annee_scolaire",
-  "clic_mes_parametres",
-  "clic_nb_lignes_liste",
+  // Menu
+  "clic_homepage_questions",
+  "clic_homepage_page_aide",
+  "clic_homepage_envoi_message",
 ];
 
 const PLAUSIBLE_TOKEN = process.env.PLAUSIBLE_TOKEN;

--- a/ui/common/plausible-goals.ts
+++ b/ui/common/plausible-goals.ts
@@ -1,0 +1,30 @@
+// identique au script server/src/jobs/seed/plausible/goals.ts
+export const plausibleGoals = [
+  // Page Statistiques
+  "clic_statistiques",
+  "clic_stats_visites",
+  "clic_stats_profils-utilisateur",
+  "clic_stats_acquisition",
+  "clic_stats_qualite",
+  "clic_stats_couverture",
+
+  // Header
+  "clic_homepage_inscription_header",
+  "clic_homepage_connexion_header",
+
+  // Page d'accueil
+  "clic_homepage_inscription_bandeau",
+  "clic_homepage_connexion_bandeau",
+  "clic_homepage_inscription_carto",
+  "clic_homepage_connexion_carto",
+  "clic_homepage_page_linkedin",
+
+  // Menu
+  "clic_homepage_questions",
+  "clic_homepage_page_aide",
+  "clic_homepage_envoi_message",
+] as const;
+
+type PlausibleGoalType = (typeof plausibleGoals)[number];
+
+export type PlausibleGoalsEvents = { [key in PlausibleGoalType]: any };

--- a/ui/components/Links/Link.tsx
+++ b/ui/components/Links/Link.tsx
@@ -1,15 +1,28 @@
-import { Link as ChakraLink, SystemProps, LinkProps as ChakraLinkProps } from "@chakra-ui/react";
+import { Link as ChakraLink, LinkProps as ChakraLinkProps, SystemProps } from "@chakra-ui/react";
 import NavLink from "next/link";
+import { usePlausible } from "next-plausible";
 import { ReactNode } from "react";
+
+import { plausibleGoals } from "@/common/plausible-goals";
 
 interface LinkProps extends ChakraLinkProps, SystemProps {
   href: string;
   children: ReactNode;
   shallow?: boolean;
+  plausibleGoal?: (typeof plausibleGoals)[number];
 }
-const Link = ({ children, href, shallow, ...rest }: LinkProps) => {
+const Link = ({ children, href, shallow, plausibleGoal, ...rest }: LinkProps) => {
+  const plausible = usePlausible();
   return (
-    <ChakraLink {...rest} as={NavLink} href={href} shallow={shallow ?? false}>
+    <ChakraLink
+      {...rest}
+      as={NavLink}
+      href={href}
+      shallow={shallow ?? false}
+      onClick={() => {
+        plausibleGoal && plausible(plausibleGoal);
+      }}
+    >
       {children}
     </ChakraLink>
   );

--- a/ui/components/Page/components/Header.tsx
+++ b/ui/components/Page/components/Header.tsx
@@ -39,13 +39,13 @@ const UserMenu = () => {
     <>
       {!auth && (
         <HStack>
-          <Link href="/auth/inscription" variant="pill" px={3} py={1}>
+          <Link href="/auth/inscription" plausibleGoal="clic_homepage_inscription_header" variant="pill" px={3} py={1}>
             <Text lineHeight={6}>
               <AccountUnfill boxSize={5} mr={2} />
               S&apos;inscrire
             </Text>
           </Link>
-          <Link href="/auth/connexion" variant="pill" px={3} py={1}>
+          <Link href="/auth/connexion" plausibleGoal="clic_homepage_connexion_header" variant="pill" px={3} py={1}>
             <Text lineHeight={6}>
               <AccountFill boxSize={5} mr={2} />
               Se connecter

--- a/ui/components/Page/components/NavigationMenu.tsx
+++ b/ui/components/Page/components/NavigationMenu.tsx
@@ -1,11 +1,13 @@
 import { ChevronDownIcon } from "@chakra-ui/icons";
 import { Box, Container, Flex, Menu, MenuButton, MenuItem, MenuList, Text, Tooltip } from "@chakra-ui/react";
 import { useRouter } from "next/router";
+import { usePlausible } from "next-plausible";
 import { ReactElement, useState } from "react";
 
 import { CONTACT_ADDRESS } from "@/common/constants/product";
 import { AuthContext } from "@/common/internal/AuthContext";
 import { OrganisationType } from "@/common/internal/Organisation";
+import { PlausibleGoalsEvents } from "@/common/plausible-goals";
 import Link from "@/components/Links/Link";
 import { useOrganisationOrganisme, useOrganisationOrganismes } from "@/hooks/organismes";
 import useAuth from "@/hooks/useAuth";
@@ -233,6 +235,7 @@ function getNavBarComponent(auth?: AuthContext): ReactElement {
 }
 
 const MenuQuestions = () => {
+  const plausible = usePlausible<PlausibleGoalsEvents>();
   return (
     <>
       <Menu>
@@ -243,6 +246,7 @@ const MenuQuestions = () => {
           borderColor="transparent"
           bg="transparent"
           _hover={{ textDecoration: "none", color: "grey.800", bg: "grey.200" }}
+          onClick={() => plausible("clic_homepage_questions")}
         >
           <Text display="block">
             Question ? <ChevronDownIcon />
@@ -254,10 +258,17 @@ const MenuQuestions = () => {
             href="https://www.notion.so/mission-apprentissage/Documentation-dbb1eddc954441eaa0ba7f5c6404bdc0"
             target="_blank"
             rel="noopener noreferrer"
+            onClick={() => plausible("clic_homepage_page_aide")}
           >
             Page d’aide
           </MenuItem>
-          <MenuItem as="a" href={`mailto:${CONTACT_ADDRESS}`} target="_blank" rel="noopener noreferrer">
+          <MenuItem
+            as="a"
+            href={`mailto:${CONTACT_ADDRESS}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => plausible("clic_homepage_envoi_message")}
+          >
             Nous envoyer un message
           </MenuItem>
         </MenuList>

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -92,10 +92,10 @@ function PublicLandingPage() {
               dans les territoires.
             </Text>
             <HStack gap={5} mt={5}>
-              <Link variant="primary" href="/auth/inscription">
+              <Link variant="primary" href="/auth/inscription" plausibleGoal="clic_homepage_inscription_bandeau">
                 Je m’inscris
               </Link>
-              <Link variant="secondary" href="/auth/connexion">
+              <Link variant="secondary" href="/auth/connexion" plausibleGoal="clic_homepage_connexion_bandeau">
                 J’ai déjà un compte
               </Link>
             </HStack>
@@ -324,6 +324,7 @@ function PublicLandingPage() {
           display="inline-flex"
           alignItems="center"
           href="https://fr.linkedin.com/company/mission-apprentissage"
+          plausibleGoal="clic_homepage_page_linkedin"
           isExternal
         >
           <Image src="/images/landing-cards/linkedin.svg" alt="" userSelect="none" mr="3" />
@@ -589,11 +590,21 @@ function SectionApercuChiffresCles() {
         <LockFill color="bluefrance" boxSize="4" />
         <Text>
           Pour visualiser l’intégralité des données consultables,{" "}
-          <Link href="/auth/connexion" borderBottom="1px solid" _hover={{ textDecoration: "none" }}>
+          <Link
+            href="/auth/connexion"
+            plausibleGoal="clic_homepage_connexion_carto"
+            borderBottom="1px solid"
+            _hover={{ textDecoration: "none" }}
+          >
             connectez-vous
           </Link>{" "}
           ou{" "}
-          <Link href="/auth/inscription" borderBottom="1px solid" _hover={{ textDecoration: "none" }}>
+          <Link
+            href="/auth/inscription"
+            plausibleGoal="clic_homepage_inscription_carto"
+            borderBottom="1px solid"
+            _hover={{ textDecoration: "none" }}
+          >
             créez un compte
           </Link>
           .


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/TM-10

Contenu :
- nettoyage des goals obsolètes
- tracking des boutons de la page d'accueil (+ menus globaux)
- ajout d'interfaces TS pour s'assurer qu'on nomme bien les gloals.
- je n'ai pas touché à la page stats qui construit les événements dynamiquement, donc embêtant pour TS.

Idéalement, Félix aurait voulu tracker l'utilisation de la carte sur la page d'accueil, avec comme définition : si on affiche les popups de départements pendant au moins 5 secondes, alors on envoie un événement.
=> Pas réalisé car c'est plus long à développer