### PR TITLE
fix(ui): ajout d'un hover sur les tables

### DIFF
--- a/ui/modules/indicateurs/NewTable.tsx
+++ b/ui/modules/indicateurs/NewTable.tsx
@@ -76,6 +76,18 @@ function NewTable<T>(props: NewTableProps<T>) {
                     cursor={header.column.getCanSort() ? "pointer" : "default"}
                     userSelect={header.column.getCanSort() ? "none" : "initial"}
                     onClick={header.column.getToggleSortingHandler()}
+                    _hover={
+                      header.column.getCanSort() && !header.column.getIsSorted()
+                        ? {
+                            backgroundColor: "grey.100",
+                            "::after": {
+                              color: "grey.500",
+                              content: '"▼"',
+                              marginLeft: "-14px", // Negative margin to pull icon to the left, based on following Box
+                            },
+                          }
+                        : undefined
+                    }
                   >
                     {header.isPlaceholder ? null : (
                       <>


### PR DESCRIPTION
J’ai une solution _(à l’arrache potable)_ pour le hover de la table

<img width="958" alt="Capture d’écran 2023-06-15 à 15 43 13" src="https://github.com/mission-apprentissage/flux-retour-cfas/assets/1575946/189d8688-fa93-41fa-ac10-3a99b9fc0c84">
