### PR TITLE
feat: imposture d'organisations

### DIFF
--- a/server/src/common/actions/sessions.actions.ts
+++ b/server/src/common/actions/sessions.actions.ts
@@ -1,7 +1,7 @@
 import { jwtSessionsDb } from "@/common/model/collections";
 import { createUserTokenSimple } from "@/common/utils/jwtUtils";
 
-export async function createSession(email: string, additionalProperties?: any): Promise<string> {
+export async function createSession(email: string, additionalProperties?: Record<string, any>): Promise<string> {
   const token = createUserTokenSimple({ payload: { email, ...additionalProperties } });
   await jwtSessionsDb().insertOne({ jwt: token });
   return token;

--- a/server/src/common/actions/sessions.actions.ts
+++ b/server/src/common/actions/sessions.actions.ts
@@ -1,26 +1,16 @@
 import { jwtSessionsDb } from "@/common/model/collections";
 import { createUserTokenSimple } from "@/common/utils/jwtUtils";
 
-export async function createSession(email: string): Promise<string> {
-  const token = createUserTokenSimple({ payload: { email } });
+export async function createSession(email: string, additionalProperties?: any): Promise<string> {
+  const token = createUserTokenSimple({ payload: { email, ...additionalProperties } });
   await jwtSessionsDb().insertOne({ jwt: token });
   return token;
 }
 
-/**
- * Méthode de vérification d'existance
- * @param {*} jwt
- * @returns
- */
-export const findJwt = async (jwt) => {
-  const session = await jwtSessionsDb().findOne({ jwt });
-  return !!session;
+export const findSessionByToken = async (token: string) => {
+  return await jwtSessionsDb().findOne({ jwt: token });
 };
 
-/**
- * Méthode de suppression de seesion
- * @param {*} jwt
- */
-export const removeJwt = async (jwt) => {
-  await jwtSessionsDb().deleteOne({ jwt });
+export const removeSession = async (token: string) => {
+  await jwtSessionsDb().deleteOne({ jwt: token });
 };

--- a/server/src/common/model/internal/AuthContext.ts
+++ b/server/src/common/model/internal/AuthContext.ts
@@ -11,6 +11,7 @@ export interface AuthContext<IOrganisation = Organisation> {
   organisation_id: ObjectId;
   account_status: "PENDING_EMAIL_VALIDATION" | "PENDING_ADMIN_VALIDATION" | "CONFIRMED";
   has_accept_cgu_version: string;
+  invalided_token?: boolean;
 
   // populated via $lookup
   organisation: IOrganisation;

--- a/server/src/common/model/internal/AuthContext.ts
+++ b/server/src/common/model/internal/AuthContext.ts
@@ -19,4 +19,7 @@ export interface AuthContext<IOrganisation = Organisation> {
   source?: string;
   // legacy field used for ERPs
   username: string;
+
+  // only admins can impersonate organisations
+  impersonating?: boolean;
 }

--- a/server/src/common/utils/jwtUtils.ts
+++ b/server/src/common/utils/jwtUtils.ts
@@ -2,6 +2,8 @@ import jwt from "jsonwebtoken";
 
 import config from "@/config";
 
+import { generateKey } from "./cryptoUtils";
+
 const createToken = (type: string, subject: string | null = null, options: any = {}): string => {
   const defaults = config.auth[type];
   const secret = options.secret || defaults.jwtSecret;
@@ -11,6 +13,7 @@ const createToken = (type: string, subject: string | null = null, options: any =
   let opts: any = {
     issuer: config.appName,
     expiresIn: expiresIn,
+    jwtid: generateKey(5, "hex"), // = 10c, fait en sorte que chaque token généré soit unique
   };
   if (subject) {
     opts.subject = subject;

--- a/server/src/http/helpers/passport-handlers.ts
+++ b/server/src/http/helpers/passport-handlers.ts
@@ -40,6 +40,7 @@ export const authMiddleware = () => {
 
           if (jwtPayload.impersonatedOrganisation) {
             (user as unknown as AuthContext).impersonating = true;
+            (user as unknown as AuthContext).organisation_id = new ObjectId(jwtPayload.impersonatedOrganisation._id);
           }
           (user as unknown as AuthContext).organisation =
             jwtPayload.impersonatedOrganisation ?? (await getOrganisationById(user.organisation_id as ObjectId));

--- a/server/src/http/helpers/passport-handlers.ts
+++ b/server/src/http/helpers/passport-handlers.ts
@@ -25,7 +25,7 @@ export const authMiddleware = () => {
           if (Date.now() > exp * 1000) {
             throw Boom.unauthorized("Vous n'êtes pas connecté");
           }
-          const user = await getUserByEmail(jwtPayload.email);
+          const user = (await getUserByEmail(jwtPayload.email)) as AuthContext | null;
           if (!user) {
             throw Boom.unauthorized("Vous n'êtes pas connecté");
           }
@@ -39,10 +39,10 @@ export const authMiddleware = () => {
           }
 
           if (jwtPayload.impersonatedOrganisation) {
-            (user as unknown as AuthContext).impersonating = true;
-            (user as unknown as AuthContext).organisation_id = new ObjectId(jwtPayload.impersonatedOrganisation._id);
+            user.impersonating = true;
+            user.organisation_id = new ObjectId(jwtPayload.impersonatedOrganisation._id);
           }
-          (user as unknown as AuthContext).organisation =
+          user.organisation =
             jwtPayload.impersonatedOrganisation ?? (await getOrganisationById(user.organisation_id as ObjectId));
           done(null, user);
         } catch (err) {

--- a/server/src/http/routes/user.routes/auth.routes.ts
+++ b/server/src/http/routes/user.routes/auth.routes.ts
@@ -3,7 +3,7 @@ import express from "express";
 import Joi from "joi";
 
 import { login } from "@/common/actions/account.actions";
-import { removeJwt } from "@/common/actions/sessions.actions";
+import { removeSession } from "@/common/actions/sessions.actions";
 import { COOKIE_NAME } from "@/common/constants/cookieName";
 import { responseWithCookie } from "@/common/utils/httpUtils";
 import { validateFullObjectSchema } from "@/common/utils/validationUtils";
@@ -30,7 +30,7 @@ export default () => {
       if (!req.cookies[COOKIE_NAME]) {
         throw Boom.unauthorized("invalid jwt");
       }
-      await removeJwt(req.cookies[COOKIE_NAME]);
+      await removeSession(req.cookies[COOKIE_NAME]);
       res.clearCookie(COOKIE_NAME);
     })
   );

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -65,6 +65,7 @@ import {
   verifyOrganismeAPIKeyToUser,
 } from "@/common/actions/organismes/organismes.actions";
 import { searchOrganismesFormations } from "@/common/actions/organismes/organismes.formations.actions";
+import { createSession } from "@/common/actions/sessions.actions";
 import { generateSifa } from "@/common/actions/sifa.actions/sifa.actions";
 import { changePassword, updateUserProfile } from "@/common/actions/users.actions";
 import { TETE_DE_RESEAUX } from "@/common/constants/networks";
@@ -73,6 +74,7 @@ import { Organisme } from "@/common/model/@types";
 import { jobEventsDb } from "@/common/model/collections";
 import { apiRoles } from "@/common/roles";
 import { packageJson } from "@/common/utils/esmUtils";
+import { responseWithCookie } from "@/common/utils/httpUtils";
 import { createUserToken } from "@/common/utils/jwtUtils";
 import { passwordSchema, validateFullObjectSchema, validateFullZodObjectSchema } from "@/common/utils/validationUtils";
 import { SReqPostDossiers, SReqPostVerifyUser } from "@/common/validation/ApiERPSchema";
@@ -676,6 +678,19 @@ function setupRoutes(app: Application) {
   /********************************
    * API droits administrateurs   *
    ********************************/
+
+  authRouter.delete(
+    "/api/v1/admin/impersonate",
+    returnResult(async (req, res) => {
+      if (!req.user.impersonating) {
+        throw Boom.forbidden("Permissions invalides");
+      }
+      // génère une session classique pour retrouver les permissions admin
+      const sessionToken = await createSession(req.user.email);
+      responseWithCookie(res, sessionToken);
+    })
+  );
+
   authRouter.use(
     "/api/v1/admin",
     express
@@ -686,6 +701,16 @@ function setupRoutes(app: Application) {
       .use("/effectifs", effectifsAdmin())
       .use("/stats", statsAdmin())
       .use("/maintenanceMessages", maintenancesAdmin())
+      .post(
+        "/impersonate",
+        returnResult(async (req, res) => {
+          const organisation = await registrationSchema.organisation.parseAsync(req.body);
+
+          // génère une nouvelle session avec l'organisation usurpée
+          const sessionToken = await createSession(req.user.email, { impersonatedOrganisation: organisation });
+          responseWithCookie(res, sessionToken);
+        })
+      )
   );
 
   app.use(authRouter);

--- a/server/tests/integration/http/impersonation.routes.test.ts
+++ b/server/tests/integration/http/impersonation.routes.test.ts
@@ -142,6 +142,8 @@ it("End to end - imposture d'organisation", async () => {
     password_updated_at: expect.any(String),
     impersonating: true,
     organisation: {
+      _id: expect.any(String),
+      created_at: expect.any(String),
       code_region: "53",
       type: "DREETS",
     },

--- a/server/tests/integration/http/impersonation.routes.test.ts
+++ b/server/tests/integration/http/impersonation.routes.test.ts
@@ -1,0 +1,178 @@
+import { AxiosInstance } from "axiosist";
+
+import logger from "@/common/logger";
+import { PermissionsTestConfig, testPermissions } from "@tests/utils/permissions";
+import { RequestAsOrganisationFunc, expectUnauthorizedError, initTestApp } from "@tests/utils/testUtils";
+
+let app: Awaited<ReturnType<typeof initTestApp>>;
+let httpClient: AxiosInstance;
+let requestAsOrganisation: RequestAsOrganisationFunc;
+
+beforeEach(async () => {
+  app = await initTestApp();
+  httpClient = app.httpClient;
+  requestAsOrganisation = app.requestAsOrganisation;
+});
+
+describe("POST /api/v1/admin/impersonate - démarre une imposture d'organisation", () => {
+  it("Vérifie qu'on ne peut pas accéder à la route sans être authentifié", async () => {
+    const response = await httpClient.post("/api/v1/admin/impersonate", {
+      type: "DREETS",
+      code_region: "53",
+    });
+    expectUnauthorizedError(response);
+  });
+
+  describe("Permissions", () => {
+    const accesOrganisme: PermissionsTestConfig<boolean> = {
+      "OFF lié": false,
+      "OFF non lié": false,
+      "OFR lié": false,
+      "OFR responsable": false,
+      "OFR non lié": false,
+      "OFRF lié": false,
+      "OFRF responsable": false,
+      "OFRF non lié": false,
+      "Tête de réseau": false,
+      "Tête de réseau non liée": false,
+      "DREETS même région": false,
+      "DREETS autre région": false,
+      "DDETS même département": false,
+      "DDETS autre département": false,
+      "ACADEMIE même académie": false,
+      "ACADEMIE autre académie": false,
+      "Opérateur public national": false,
+      Administrateur: true,
+    };
+    testPermissions(accesOrganisme, async (organisation, allowed) => {
+      const response = await requestAsOrganisation(organisation, "post", "/api/v1/admin/impersonate", {
+        type: "DREETS",
+        code_region: "53",
+      });
+
+      expect(response.status).toStrictEqual(allowed ? 200 : 403);
+      expect(response.headers["set-cookie"]).toStrictEqual(
+        allowed ? [expect.stringMatching("flux-retour-cfas-local-jwt=eyJh.*")] : undefined
+      );
+    });
+  });
+});
+
+describe("DELETE /api/v1/admin/impersonate - arrête l'imposture d'organisation", () => {
+  it("Vérifie qu'on ne peut pas accéder à la route sans être authentifié", async () => {
+    const response = await httpClient.delete("/api/v1/admin/impersonate");
+    expectUnauthorizedError(response);
+  });
+
+  describe("Permissions", () => {
+    const accesOrganisme: PermissionsTestConfig<boolean> = {
+      "OFF lié": false,
+      "OFF non lié": false,
+      "OFR lié": false,
+      "OFR responsable": false,
+      "OFR non lié": false,
+      "OFRF lié": false,
+      "OFRF responsable": false,
+      "OFRF non lié": false,
+      "Tête de réseau": false,
+      "Tête de réseau non liée": false,
+      "DREETS même région": false,
+      "DREETS autre région": false,
+      "DDETS même département": false,
+      "DDETS autre département": false,
+      "ACADEMIE même académie": false,
+      "ACADEMIE autre académie": false,
+      "Opérateur public national": false,
+      Administrateur: true,
+    };
+    testPermissions(accesOrganisme, async (organisation, allowed) => {
+      if (allowed) {
+        let response = await requestAsOrganisation(organisation, "post", "/api/v1/admin/impersonate", {
+          type: "DREETS",
+          code_region: "53",
+        });
+        expect(response.status).toStrictEqual(200);
+        const cookie = response.headers["set-cookie"]?.[0];
+
+        response = await httpClient.delete("/api/v1/admin/impersonate", { headers: { cookie } });
+        expect(response.status).toStrictEqual(200);
+        expect(response.headers["set-cookie"]).toStrictEqual([
+          expect.stringMatching("flux-retour-cfas-local-jwt=eyJh.*"),
+        ]);
+      } else {
+        const response = await requestAsOrganisation(organisation, "delete", "/api/v1/admin/impersonate");
+
+        expect(response.status).toStrictEqual(403);
+        expect(response.headers["set-cookie"]).toStrictEqual(undefined);
+      }
+    });
+  });
+});
+
+it("End to end - imposture d'organisation", async () => {
+  logger.level("error");
+  let response = await requestAsOrganisation(
+    {
+      type: "ADMINISTRATEUR",
+    },
+    "post",
+    "/api/v1/admin/impersonate",
+    {
+      type: "DREETS",
+      code_region: "53",
+    }
+  );
+  expect(response.status).toStrictEqual(200);
+  let cookie = response.headers["set-cookie"]?.[0];
+
+  // vérifie que l'organisation a changé
+  response = await httpClient.get("/api/v1/session", { headers: { cookie } });
+  expect(response.data).toStrictEqual({
+    _id: expect.any(String),
+    account_status: "CONFIRMED",
+    civility: "Madame",
+    nom: "Dupont",
+    prenom: "Jean",
+    email: "Administrateur@test.local",
+    fonction: "Responsable administratif",
+    has_accept_cgu_version: "v0.1",
+    telephone: "",
+    invalided_token: false,
+    created_at: expect.any(String),
+    password_updated_at: expect.any(String),
+    impersonating: true,
+    organisation: {
+      code_region: "53",
+      type: "DREETS",
+    },
+    organisation_id: expect.any(String),
+  });
+
+  response = await httpClient.delete("/api/v1/admin/impersonate", { headers: { cookie } });
+  expect(response.status).toStrictEqual(200);
+  cookie = response.headers["set-cookie"]?.[0];
+
+  // vérifie que l'organisation est revenue à la normale
+  response = await httpClient.get("/api/v1/session", { headers: { cookie } });
+  expect(response.status).toStrictEqual(200);
+  expect(response.data).toStrictEqual({
+    _id: expect.any(String),
+    account_status: "CONFIRMED",
+    civility: "Madame",
+    nom: "Dupont",
+    prenom: "Jean",
+    email: "Administrateur@test.local",
+    fonction: "Responsable administratif",
+    has_accept_cgu_version: "v0.1",
+    telephone: "",
+    invalided_token: false,
+    created_at: expect.any(String),
+    password_updated_at: expect.any(String),
+    organisation: {
+      _id: expect.any(String),
+      created_at: expect.any(String),
+      type: "ADMINISTRATEUR",
+    },
+    organisation_id: expect.any(String),
+  });
+});

--- a/ui/common/httpClient.ts
+++ b/ui/common/httpClient.ts
@@ -88,14 +88,18 @@ export const _getBlob = async (path: string, options?: AxiosRequestConfig<any>) 
   return handleResponse(path, response);
 };
 
-export const _post = async (path: string, body?: any, options?: AxiosRequestConfig<any>) => {
+export const _post = async <RequestBody = any, ResponseBody = any>(
+  path: string,
+  body?: RequestBody,
+  options?: AxiosRequestConfig<any>
+): Promise<ResponseBody> => {
   const response = await axios.post(path, body, {
     headers: getHeaders(),
     validateStatus: () => true,
     httpsAgent: getHttpsAgent(),
     ...options,
   });
-  return handleResponse(path, response);
+  return handleResponse<ResponseBody>(path, response);
 };
 
 export const _postFile = async (path: string, data, options?: AxiosRequestConfig<any>) => {

--- a/ui/common/internal/AuthContext.ts
+++ b/ui/common/internal/AuthContext.ts
@@ -16,6 +16,9 @@ export interface AuthContext<IOrganisation = Organisation> {
 
   // legacy field used for ERPs
   username: string;
+
+  // only admins can impersonate organisations
+  impersonating?: boolean;
 }
 
 // contexte côté UI

--- a/ui/components/Page/components/Header.tsx
+++ b/ui/components/Page/components/Header.tsx
@@ -26,6 +26,7 @@ import { AccountFill } from "@/theme/components/icons/AccountFill";
 import { AccountUnfill } from "@/theme/components/icons/AccountUnfill";
 import { ExitIcon } from "@/theme/components/icons/ExitIcon";
 import { Parametre } from "@/theme/components/icons/Parametre";
+import { SpyLineIcon } from "@/theme/components/icons/SpyLine";
 
 const UserMenu = () => {
   const { auth, organisationType } = useAuth();
@@ -88,7 +89,7 @@ const UserMenu = () => {
                   <MenuItem href="/admin/maintenance" icon={<Parametre boxSize={4} />}>
                     Message de maintenance
                   </MenuItem>
-                  <MenuItem href="/admin/impostures" icon={<Parametre boxSize={4} />}>
+                  <MenuItem href="/admin/impostures" icon={<SpyLineIcon boxSize={4} />}>
                     Impostures
                   </MenuItem>
                 </MenuGroup>

--- a/ui/components/Page/components/Header.tsx
+++ b/ui/components/Page/components/Header.tsx
@@ -17,13 +17,14 @@ import {
 } from "@chakra-ui/react";
 
 import { PRODUCT_NAME_TITLE } from "@/common/constants/product";
-import { _post } from "@/common/httpClient";
+import { _delete, _post } from "@/common/httpClient";
 import Link from "@/components/Links/Link";
 import MenuItem from "@/components/Links/MenuItem";
 import useAuth from "@/hooks/useAuth";
 import { Settings4Fill, UserFill } from "@/theme/components/icons";
 import { AccountFill } from "@/theme/components/icons/AccountFill";
 import { AccountUnfill } from "@/theme/components/icons/AccountUnfill";
+import { ExitIcon } from "@/theme/components/icons/ExitIcon";
 import { Parametre } from "@/theme/components/icons/Parametre";
 
 const UserMenu = () => {
@@ -87,6 +88,9 @@ const UserMenu = () => {
                   <MenuItem href="/admin/maintenance" icon={<Parametre boxSize={4} />}>
                     Message de maintenance
                   </MenuItem>
+                  <MenuItem href="/admin/impostures" icon={<Parametre boxSize={4} />}>
+                    Impostures
+                  </MenuItem>
                 </MenuGroup>
               )}
               <MenuDivider />
@@ -100,6 +104,8 @@ const UserMenu = () => {
 };
 
 const Header = () => {
+  const { auth } = useAuth();
+
   return (
     <Container maxW={"full"} borderBottom={"1px solid"} borderColor={"grey.400"} px={[0, 4]} as="header">
       <Container maxW="xl" py={[0, 2]} px={[0, 4]}>
@@ -120,6 +126,22 @@ const Header = () => {
             </Heading>
           </Box>
 
+          {auth?.impersonating && (
+            <Button
+              leftIcon={<ExitIcon />}
+              size="sm"
+              colorScheme="red"
+              px={4}
+              mt={["2w", "2w", "2w", "0"]}
+              mx={["0", "0", "2w", "2w"]}
+              onClick={async () => {
+                await _delete("/api/v1/admin/impersonate");
+                location.href = "/";
+              }}
+            >
+              Imposture en cours
+            </Button>
+          )}
           <Flex
             maxWidth="380px"
             h="42px"

--- a/ui/pages/admin/impostures.tsx
+++ b/ui/pages/admin/impostures.tsx
@@ -48,7 +48,7 @@ function ImposturesPage() {
         <Heading as="h2" color="#465F9D" fontSize="gamma" fontWeight="700" mt={10} mb={3}>
           Organisme de formation
         </Heading>
-        Pour connaître des sirets, voir le{" "}
+        Pour connaître des SIRET d’OFA, voir le{" "}
         <Link
           href="https://referentiel.apprentissage.onisep.fr/organismes?uais=true"
           color="action-high-blue-france"

--- a/ui/pages/admin/impostures.tsx
+++ b/ui/pages/admin/impostures.tsx
@@ -1,14 +1,28 @@
-import { Heading, Container, Text, Button, Flex } from "@chakra-ui/react";
+import { Heading, Container, Text } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
 
 import { _post, _put, _delete } from "@/common/httpClient";
 import { getAuthServerSideProps } from "@/common/SSR/getAuthServerSideProps";
+import Link from "@/components/Links/Link";
 import SimplePage from "@/components/Page/SimplePage";
 import withAuth from "@/components/withAuth";
 import { NewOrganisation } from "@/modules/auth/inscription/common";
+import SearchBySIRETForm from "@/modules/auth/inscription/components/SearchBySIRETForm";
+import { InscriptionOperateurPublic } from "@/modules/auth/inscription/InscriptionOperateurPublic";
+import { InscriptionTeteDeReseau } from "@/modules/auth/inscription/InscriptionTeteDeReseau";
+import { ExternalLinkLine } from "@/theme/components/icons";
 
 export const getServerSideProps = async (context) => ({ props: { ...(await getAuthServerSideProps(context)) } });
 
 function ImposturesPage() {
+  const [organisation, setOrganisation] = useState<NewOrganisation | null>(null);
+
+  useEffect(() => {
+    if (organisation) {
+      void impersonate(organisation);
+    }
+  }, [organisation]);
+
   async function impersonate(organisation: NewOrganisation) {
     await _post<NewOrganisation>("/api/v1/admin/impersonate", organisation);
     location.href = "/";
@@ -23,50 +37,29 @@ function ImposturesPage() {
         <Text>
           Cette page permet de vous faire passer pour un membre d’une organisation quelconque à des fins de test.
         </Text>
-        <Flex gap={8} py={8} wrap="wrap" justifyContent="center">
-          <Button
-            variant="outline"
-            onClick={() =>
-              impersonate({
-                type: "OPERATEUR_PUBLIC_NATIONAL",
-                nom: "Ministère de l’Éducation nationale et de la Jeunesse",
-              })
-            }
-          >
-            Ministère de l’Éducation nationale et de la Jeunesse
-          </Button>
-          <Button variant="outline" onClick={() => impersonate({ type: "DREETS", code_region: "53" })}>
-            DREETS Bretagne
-          </Button>
-          <Button variant="outline" onClick={() => impersonate({ type: "DRAAF", code_region: "53" })}>
-            DRAAF Bretagne
-          </Button>
-          <Button variant="outline" onClick={() => impersonate({ type: "CONSEIL_REGIONAL", code_region: "53" })}>
-            Conseil régional Bretagne
-          </Button>
-          <Button variant="outline" onClick={() => impersonate({ type: "ACADEMIE", code_academie: "14" })}>
-            Académie Rennes
-          </Button>
-          <Button variant="outline" onClick={() => impersonate({ type: "DDETS", code_departement: "56" })}>
-            DDETS Morbihan (56)
-          </Button>
-          <Button variant="outline" onClick={() => impersonate({ type: "TETE_DE_RESEAU", reseau: "CCI" })}>
-            Réseau CCI
-          </Button>
-          <Button variant="outline" onClick={() => impersonate({ type: "TETE_DE_RESEAU", reseau: "CMA" })}>
-            Réseau CMA
-          </Button>
-          <Button
-            variant="outline"
-            onClick={() =>
-              impersonate({ type: "ORGANISME_FORMATION_FORMATEUR", siret: "51400512300013", uai: "0130239P" })
-            }
-          >
-            Kedge 51400512300013/0130239P
-          </Button>
-        </Flex>
-
-        {/* TODO pouvoir choisir l’organisation manuellement */}
+        <Heading as="h2" color="#465F9D" fontSize="gamma" fontWeight="700" mt={10} mb={3}>
+          Opérateur publique
+        </Heading>
+        <InscriptionOperateurPublic setOrganisation={setOrganisation} />
+        <Heading as="h2" color="#465F9D" fontSize="gamma" fontWeight="700" mt={10} mb={3}>
+          Tête de réseau
+        </Heading>
+        <InscriptionTeteDeReseau setOrganisation={setOrganisation} />
+        <Heading as="h2" color="#465F9D" fontSize="gamma" fontWeight="700" mt={10} mb={3}>
+          Organisme de formation
+        </Heading>
+        Pour connaître des sirets, voir le{" "}
+        <Link
+          href="https://referentiel.apprentissage.onisep.fr/organismes?uais=true"
+          color="action-high-blue-france"
+          isExternal
+          borderBottom="1px"
+        >
+          catalogue
+          <ExternalLinkLine w={".7em"} h={".7em"} ml={1} />
+        </Link>
+        .
+        <SearchBySIRETForm organisation={organisation} setOrganisation={setOrganisation} />
       </Container>
     </SimplePage>
   );

--- a/ui/pages/admin/impostures.tsx
+++ b/ui/pages/admin/impostures.tsx
@@ -1,4 +1,4 @@
-import { Heading, Container, Text } from "@chakra-ui/react";
+import { Heading, Container, Text, Box } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 
 import { _post, _put, _delete } from "@/common/httpClient";
@@ -34,32 +34,36 @@ function ImposturesPage() {
         <Heading as="h1" color="#465F9D" fontSize="beta" fontWeight="700" mb={3}>
           Impostures
         </Heading>
+
         <Text>
           Cette page permet de vous faire passer pour un membre d’une organisation quelconque à des fins de test.
         </Text>
-        <Heading as="h2" color="#465F9D" fontSize="gamma" fontWeight="700" mt={10} mb={3}>
-          Opérateur publique
-        </Heading>
-        <InscriptionOperateurPublic setOrganisation={setOrganisation} />
-        <Heading as="h2" color="#465F9D" fontSize="gamma" fontWeight="700" mt={10} mb={3}>
-          Tête de réseau
-        </Heading>
-        <InscriptionTeteDeReseau setOrganisation={setOrganisation} />
-        <Heading as="h2" color="#465F9D" fontSize="gamma" fontWeight="700" mt={10} mb={3}>
-          Organisme de formation
-        </Heading>
-        Pour connaître des SIRET d’OFA, voir le{" "}
-        <Link
-          href="https://referentiel.apprentissage.onisep.fr/organismes?uais=true"
-          color="action-high-blue-france"
-          isExternal
-          borderBottom="1px"
-        >
-          catalogue
-          <ExternalLinkLine w={".7em"} h={".7em"} ml={1} />
-        </Link>
-        .
-        <SearchBySIRETForm organisation={organisation} setOrganisation={setOrganisation} />
+
+        <Box maxW="fit-content">
+          <Heading as="h2" color="#465F9D" fontSize="gamma" fontWeight="700" mt={10} mb={3}>
+            Opérateur publique
+          </Heading>
+          <InscriptionOperateurPublic setOrganisation={setOrganisation} />
+          <Heading as="h2" color="#465F9D" fontSize="gamma" fontWeight="700" mt={10} mb={3}>
+            Tête de réseau
+          </Heading>
+          <InscriptionTeteDeReseau setOrganisation={setOrganisation} />
+          <Heading as="h2" color="#465F9D" fontSize="gamma" fontWeight="700" mt={10} mb={3}>
+            Organisme de formation
+          </Heading>
+          Pour connaître des SIRET d’OFA, voir le{" "}
+          <Link
+            href="https://referentiel.apprentissage.onisep.fr/organismes?uais=true"
+            color="action-high-blue-france"
+            isExternal
+            borderBottom="1px"
+          >
+            catalogue
+            <ExternalLinkLine w={".7em"} h={".7em"} ml={1} />
+          </Link>
+          .
+          <SearchBySIRETForm organisation={organisation} setOrganisation={setOrganisation} />
+        </Box>
       </Container>
     </SimplePage>
   );

--- a/ui/pages/admin/impostures.tsx
+++ b/ui/pages/admin/impostures.tsx
@@ -1,0 +1,74 @@
+import { Heading, Container, Text, Button, Flex } from "@chakra-ui/react";
+
+import { _post, _put, _delete } from "@/common/httpClient";
+import { getAuthServerSideProps } from "@/common/SSR/getAuthServerSideProps";
+import SimplePage from "@/components/Page/SimplePage";
+import withAuth from "@/components/withAuth";
+import { NewOrganisation } from "@/modules/auth/inscription/common";
+
+export const getServerSideProps = async (context) => ({ props: { ...(await getAuthServerSideProps(context)) } });
+
+function ImposturesPage() {
+  async function impersonate(organisation: NewOrganisation) {
+    await _post<NewOrganisation>("/api/v1/admin/impersonate", organisation);
+    location.href = "/";
+  }
+
+  return (
+    <SimplePage title="Imposture">
+      <Container maxW="xl" p="8">
+        <Heading as="h1" color="#465F9D" fontSize="beta" fontWeight="700" mb={3}>
+          Impostures
+        </Heading>
+        <Text>
+          Cette page permet de vous faire passer pour un membre d’une organisation quelconque à des fins de test.
+        </Text>
+        <Flex gap={8} py={8} wrap="wrap" justifyContent="center">
+          <Button
+            variant="outline"
+            onClick={() =>
+              impersonate({
+                type: "OPERATEUR_PUBLIC_NATIONAL",
+                nom: "Ministère de l’Éducation nationale et de la Jeunesse",
+              })
+            }
+          >
+            Ministère de l’Éducation nationale et de la Jeunesse
+          </Button>
+          <Button variant="outline" onClick={() => impersonate({ type: "DREETS", code_region: "53" })}>
+            DREETS Bretagne
+          </Button>
+          <Button variant="outline" onClick={() => impersonate({ type: "DRAAF", code_region: "53" })}>
+            DRAAF Bretagne
+          </Button>
+          <Button variant="outline" onClick={() => impersonate({ type: "CONSEIL_REGIONAL", code_region: "53" })}>
+            Conseil régional Bretagne
+          </Button>
+          <Button variant="outline" onClick={() => impersonate({ type: "ACADEMIE", code_academie: "14" })}>
+            Académie Rennes
+          </Button>
+          <Button variant="outline" onClick={() => impersonate({ type: "DDETS", code_departement: "56" })}>
+            DDETS Morbihan (56)
+          </Button>
+          <Button variant="outline" onClick={() => impersonate({ type: "TETE_DE_RESEAU", reseau: "CCI" })}>
+            Réseau CCI
+          </Button>
+          <Button variant="outline" onClick={() => impersonate({ type: "TETE_DE_RESEAU", reseau: "CMA" })}>
+            Réseau CMA
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() =>
+              impersonate({ type: "ORGANISME_FORMATION_FORMATEUR", siret: "51400512300013", uai: "0130239P" })
+            }
+          >
+            Kedge 51400512300013/0130239P
+          </Button>
+        </Flex>
+
+        {/* TODO pouvoir choisir l’organisation manuellement */}
+      </Container>
+    </SimplePage>
+  );
+}
+export default withAuth(ImposturesPage, ["ADMINISTRATEUR"]);

--- a/ui/theme/components/icons/ExitIcon.tsx
+++ b/ui/theme/components/icons/ExitIcon.tsx
@@ -1,0 +1,13 @@
+import { Icon, SystemProps } from "@chakra-ui/react";
+
+// dsfr fr-icon-logout-box-r-line
+export function ExitIcon(props?: SystemProps) {
+  return (
+    <Icon viewBox="0 0 24 24" w="20px" h="20px" {...props}>
+      <path
+        d="M19 2a1 1 0 0 1 1 1v3h-2V4H6v16h12v-2h2v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1h14Zm-1 6 5 4-5 4v-3h-7v-2h7V8Z"
+        fill="currentColor"
+      />
+    </Icon>
+  );
+}

--- a/ui/theme/components/icons/SpyLine.tsx
+++ b/ui/theme/components/icons/SpyLine.tsx
@@ -1,0 +1,10 @@
+import { Icon, SystemProps } from "@chakra-ui/react";
+
+// dsfr ri-spy-line
+export function SpyLineIcon(props?: SystemProps) {
+  return (
+    <Icon viewBox="0 0 24 24" w="24px" h="24px" {...props}>
+      <path d="M17 13a4 4 0 1 1-4 4h-2a4 4 0 1 1-.535-2h3.07A3.998 3.998 0 0 1 17 13ZM7 15a2 2 0 1 0 0 4 2 2 0 0 0 0-4Zm10 0a2 2 0 1 0 0 4 2 2 0 0 0 0-4ZM16 3a4 4 0 0 1 4 4v3h2v2H2v-2h2V7a4 4 0 0 1 4-4h8Zm0 2H8c-1.054 0-2 .95-2 2v3h12V7c0-1.054-.95-2-2-2Z" />
+    </Icon>
+  );
+}


### PR DESCRIPTION
Pour remédier à la problématique de comptes de test (recette et prod) qui impactent les autres utilisateurs.

- nouvelle entrée dans le menu utilisateur
- nouvelle page impostures, avec des boutons prédéfinis pour changer ton organisation
- des petites retouches au niveau des jwt qui font office de token de session (en moins bien...)

Notes :
- [x] Il faudrait sans doute rendre configurable les uai / sirets, idem réseaux. Ou bien mettre un raccourci dans chaque page organisme de l'admin (mais on aura toujours pas les organisations).
- Je n'ai pas pu tester par manque de temps les fonctionnalités avancées en tant qu'OF...
- [x] seul l'organisation (du authcontext) a été mise à jour, il faudrait sans doute mettre ctx.organisation_id aussi et donc créer au préalable l'organisation en base. A priori c'est juste la gestion des membres qui est lié à ce champ côté serveur.
