### PR TITLE
chore: suppression de siret_regex qui semble obsolete et utilisé à un seul endroit

### DIFF
--- a/ui/common/domain/siret.ts
+++ b/ui/common/domain/siret.ts
@@ -1,6 +1,3 @@
 export const siretRegex = /^[0-9]{14}$/;
 
-//TODO merge with siretRegex
-export const SIRET_REGEX = new RegExp("^([0-9]{14}|[0-9]{9} [0-9]{4})$");
-
 export const validateSiret = (siret) => Boolean(siret) && siretRegex.test(siret);

--- a/ui/modules/auth/inscription/components/SearchBySIRETForm.tsx
+++ b/ui/modules/auth/inscription/components/SearchBySIRETForm.tsx
@@ -18,7 +18,7 @@ import { Field, Form, Formik } from "formik";
 import { useState } from "react";
 import * as Yup from "yup";
 
-import { SIRET_REGEX } from "@/common/domain/siret";
+import { siretRegex } from "@/common/domain/siret";
 import { _post } from "@/common/httpClient";
 import { sleep } from "@/common/utils/misc";
 import Link from "@/components/Links/Link";
@@ -34,7 +34,7 @@ export default function SearchBySIRETForm({ organisation, setOrganisation }: Ins
       initialValues={{ siret: "" }}
       validateOnBlur={false}
       validationSchema={Yup.object().shape({
-        siret: Yup.string().required("Le SIRET est obligatoire").matches(SIRET_REGEX, {
+        siret: Yup.string().required("Le SIRET est obligatoire").matches(siretRegex, {
           message: "SIRET invalide",
         }),
       })}


### PR DESCRIPTION
Selon le commentaire, on cherchait à se débarasser de cette regex.
J'ai vu qu'elle était utilisée à un seul endroit dans un formik (side note : je déteste formik, chaud pour en parler !) et que c'était pour rechercher donc on s'en fiche du changement très léger de fonctionnement