### PR TITLE
fix(ui): affichage des effectifs quand ils ont été importés au moins une fois (tm-29)

### DIFF
--- a/ui/modules/mon-espace/effectifs/EffectifsBanner.tsx
+++ b/ui/modules/mon-espace/effectifs/EffectifsBanner.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import { ERPS } from "@/common/constants/erps";
 import { Organisme } from "@/common/internal/Organisme";
+import { prettyPrintDate } from "@/common/utils/dateUtils";
 import Section from "@/components/Section/Section";
 
 type EffectifsBannerProps = {
@@ -15,6 +16,8 @@ const EffectifsBanner = ({ organisme, isMine }: EffectifsBannerProps) => {
   const mode_de_transmission = organisme.mode_de_transmission;
   const erpName = ERPS.find((erp) => erp.id === erpId?.toUpperCase())?.name;
   const prefixOrganismeText = isMine ? "Votre" : "Cet";
+  // Legacy: pas de mode de transmission connu ni d'ERP configuré, mais une date de transmission.
+  const legacy = !mode_de_transmission && !erpName && organisme.last_transmission_date;
 
   return (
     <Section
@@ -28,6 +31,7 @@ const EffectifsBanner = ({ organisme, isMine }: EffectifsBannerProps) => {
       <HStack justifyContent="space-between">
         <VStack alignItems="baseline" gap={4}>
           <Heading as="h2" fontSize="gamma" color="blue_cumulus_main">
+            {legacy && `${prefixOrganismeText} organisme transmet ses effectifs`}
             {erpName && `${prefixOrganismeText} organisme transmet ses effectifs via ${erpName}`}
             {mode_de_transmission === "MANUEL" &&
               `${prefixOrganismeText} organisme transmet ses effectifs manuellement`}
@@ -35,8 +39,11 @@ const EffectifsBanner = ({ organisme, isMine }: EffectifsBannerProps) => {
           <Text>
             {erpName &&
               `Dernière transmission de données par ${erpName} ${
-                organisme.last_transmission_date || "[en cours d'importation]"
+                organisme.last_transmission_date
+                  ? `le ${prettyPrintDate(organisme.last_transmission_date)}`
+                  : "[en cours d'importation]"
               }.`}
+            {legacy && `Dernière transmission de données le ${prettyPrintDate(organisme.last_transmission_date)}.`}
           </Text>
         </VStack>
         <Image src="/images/computer-woman.svg" alt="" />

--- a/ui/modules/mon-espace/effectifs/EffectifsPage.tsx
+++ b/ui/modules/mon-espace/effectifs/EffectifsPage.tsx
@@ -70,7 +70,7 @@ const EffectifsPage = ({ isMine, organisme }: EffectifsPageProps) => {
   }
 
   let MainComponent;
-  if (!organisme.mode_de_transmission) {
+  if (!organisme.mode_de_transmission && !organisme.last_transmission_date) {
     MainComponent = <ChoixTransmission organismeId={organisme._id} />;
   } else if (organisme.mode_de_transmission === "API") {
     if (organisme.erps?.length === 0 && !organisme.first_transmission_date) {
@@ -86,7 +86,7 @@ const EffectifsPage = ({ isMine, organisme }: EffectifsPageProps) => {
 
   return (
     <>
-      {organisme.mode_de_transmission ? (
+      {organisme.mode_de_transmission || organisme.last_transmission_date ? (
         <EffectifsBanner organisme={organisme} isMine={isMine} />
       ) : (
         <EffectifsBannerERPNotConfigured isMine={isMine} />


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/TM-29

 - En local je n'ai pas d'effectifs, donc c'est très mal testé
 - J'espère avoir bien compris le pb. L'idée c'est : j'affiche les effectifs même si je n'ai pas les infos de mode de transmission à partir du moment où j'ai transmission.