### PR TITLE
fix: maj metabase vers v0.46.6

### DIFF
--- a/.infra/ansible/roles/setup/files/app/.overrides/common/docker-compose.common.yml
+++ b/.infra/ansible/roles/setup/files/app/.overrides/common/docker-compose.common.yml
@@ -27,7 +27,7 @@ services:
     #   - "127.0.0.1:27017:27017"
 
   metabase:
-    image: metabase/metabase:v0.45.3
+    image: metabase/metabase:v0.46.6
     mem_limit: 2g
     container_name: flux_retour_cfas_metabase
     volumes:


### PR DESCRIPTION
corrige un bug lié aux dashboard avec paramètres

Dans la [doc de metabase](https://www.metabase.com/docs/latest/installation-and-operation/upgrading-metabase), il est indiqué qu'on peut (va ?) perdre les données comme on a pas de production database.

A priori, comme on a un volume monté sur `/metabase-data` je dirais que tout va bien. :)