### PR TITLE
chore: incrementation de la limite d'envoi json pour l'API en restant raisonnable quand même

### DIFF
--- a/server/.env.test
+++ b/server/.env.test
@@ -4,6 +4,7 @@
 FLUX_RETOUR_CFAS_ENV=local
 FLUX_RETOUR_CFAS_PUBLIC_URL=test
 FLUX_RETOUR_CFAS_MONGODB_URI=mongodb://[user]:[password]@mongodb:27017/[db]?authSource=admin&retryWrites=true&w=majority
+FLUX_RETOUR_CFAS_BODY_PARSER_LIMIT=100kb
 
 ## LOG VARIABLES
 FLUX_RETOUR_CFAS_LOG_LEVEL=fatal

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -6,6 +6,7 @@ const config = {
   appName: env.get("FLUX_RETOUR_CFAS_NAME").default("Flux Retour Cfas").asString(),
   env: env.get("FLUX_RETOUR_CFAS_ENV").required().asString(),
   publicUrl: env.get("FLUX_RETOUR_CFAS_PUBLIC_URL").required().asString(),
+  bodyParserLimit: env.get("FLUX_RETOUR_CFAS_BODY_PARSER_LIMIT").default("10mb").asString(),
   mongodb: {
     uri: env.get("FLUX_RETOUR_CFAS_MONGODB_URI").required().asString(),
   },

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -145,7 +145,7 @@ export default async function createServer(): Promise<Application> {
   // TracingHandler creates a trace for every incoming request
   app.use(Sentry.Handlers.tracingHandler());
 
-  app.use(bodyParser.json({ limit: "10mb" }));
+  app.use(bodyParser.json({ limit: config.bodyParserLimit }));
   app.use(logMiddleware);
   app.use(cookieParser());
   app.use(passport.initialize());

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -145,7 +145,7 @@ export default async function createServer(): Promise<Application> {
   // TracingHandler creates a trace for every incoming request
   app.use(Sentry.Handlers.tracingHandler());
 
-  app.use(bodyParser.json());
+  app.use(bodyParser.json({ limit: "10mb" }));
   app.use(logMiddleware);
   app.use(cookieParser());
   app.use(passport.initialize());


### PR DESCRIPTION
L'idée c'est que si on envoie 50 apprenants ça fait un payload too high
D'ailleurs ça m'étonne que ça marchait pour tout le monde avec 100kb c'est vite atteint non @totakoko & @sbenfares ?