### PR TITLE
fix: correction condition liste des organismes liés

### DIFF
--- a/server/src/common/actions/helpers/permissions.ts
+++ b/server/src/common/actions/helpers/permissions.ts
@@ -181,7 +181,7 @@ export async function findOrganismesAccessiblesByOrganisation(ctx: AuthContext<O
   const organisation = ctx.organisation;
   const userOrganisme = await organismesDb().findOne({
     siret: organisation.siret,
-    ...(organisation.uai ? { uai: organisation.uai } : {}),
+    uai: organisation.uai as string,
   });
   if (!userOrganisme) {
     logger.error({ siret: organisation.siret, uai: organisation.uai }, "organisme de l'organisation non trouvé");
@@ -205,12 +205,11 @@ export async function findOFLinkedOrganismesIds(userOrganisme: Organisme) {
         if (
           subOrganismeCatalog.nature !== NATURE_ORGANISME_DE_FORMATION.LIEU &&
           subOrganismeCatalog.nature !== NATURE_ORGANISME_DE_FORMATION.INCONNUE &&
-          userOrganisme.siret !== subOrganismeCatalog.siret &&
-          userOrganisme.uai !== subOrganismeCatalog.uai
+          !(userOrganisme.siret === subOrganismeCatalog.siret && userOrganisme.uai === subOrganismeCatalog.uai)
         ) {
           const subOrganisme = await organismesDb().findOne({
-            siret: subOrganismeCatalog.siret as string,
-            uai: subOrganismeCatalog.uai as string,
+            siret: subOrganismeCatalog.siret,
+            uai: subOrganismeCatalog.uai,
           });
           if (!subOrganisme) {
             logger.error(


### PR DESCRIPTION
- En regardant les relations entre OF via les formations, je suis retombé sur la fonction `findOFLinkedOrganismesIds` (qu'on devrait sans doute mettre à jour au passage pour s'assurer qu'on ne liste que les organismes formateurs).
J'avais fait une modificaiton il y a quelque temps pour rechercher sur le couple UAI + SIRET (clé d'unicité), plutôt que juste sur le SIRET. mais en relisant, je pense avoir foiré la condition car elle exclue les organismes avec même UAI ou même SIRET... Cette PR corrige ça.

- Et aussi une recherche d'un organisme avec les infos de l'organisation. Idem il faut utiliser le siret et l'uai (même s'il n'est pas défini = null)



En bonus, est-ce que ça ne vaudrait pas le coup de définir plus spécifiquement ce qu'on recherche ? Cad ici les organismes qui dispensent des formations comme indiquées dans le référentiel ?