### PR TITLE
Ameliorations page organismes

### DIFF
--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -634,7 +634,9 @@ export async function findUserOrganismes(ctx: AuthContext) {
           enseigne: 1,
           raison_sociale: 1,
           ferme: 1,
-          nature: 1,
+          nature: {
+            $ifNull: ["$nature", "inconnue"], // On devrait plutôt remplir automatiquement la nature
+          },
           adresse: 1,
           siret: 1,
           uai: 1,

--- a/ui/hooks/organismes.ts
+++ b/ui/hooks/organismes.ts
@@ -64,13 +64,6 @@ export function useOrganisationOrganismes() {
     error,
   } = useQuery<Organisme[], any>(["organisation/organismes"], () => _get("/api/v1/organisation/organismes"), {});
 
-  // corrige les natures null en attendant une correction des données
-  organismes?.forEach((organisme) => {
-    if (!organisme.nature) {
-      organisme.nature = "inconnue";
-    }
-  });
-
   return {
     organismes,
     isLoading,

--- a/ui/hooks/organismes.ts
+++ b/ui/hooks/organismes.ts
@@ -64,6 +64,13 @@ export function useOrganisationOrganismes() {
     error,
   } = useQuery<Organisme[], any>(["organisation/organismes"], () => _get("/api/v1/organisation/organismes"), {});
 
+  // corrige les natures null en attendant une correction des données
+  organismes?.forEach((organisme) => {
+    if (!organisme.nature) {
+      organisme.nature = "inconnue";
+    }
+  });
+
   return {
     organismes,
     isLoading,

--- a/ui/modules/organismes/OrganismesTable.tsx
+++ b/ui/modules/organismes/OrganismesTable.tsx
@@ -38,7 +38,13 @@ const organismesTableColumnsDefs: AccessorKeyColumnDef<OrganismeNormalized, any>
           {row.original.nom ?? "Organisme inconnu"}
         </Link>
         <Text fontSize="xs" pt={2} color="#777777" whiteSpace="nowrap">
-          UAI&nbsp;: {(row.original as any).uai} - SIRET&nbsp;: {(row.original as any).siret}
+          UAI&nbsp;:{" "}
+          {(row.original as any).uai ?? (
+            <Text as="span" color="error">
+              INCONNUE
+            </Text>
+          )}{" "}
+          - SIRET&nbsp;: {(row.original as any).siret}
         </Text>
       </>
     ),

--- a/ui/modules/organismes/OrganismesTable.tsx
+++ b/ui/modules/organismes/OrganismesTable.tsx
@@ -51,6 +51,12 @@ const organismesTableColumnsDefs: AccessorKeyColumnDef<OrganismeNormalized, any>
   },
   {
     accessorKey: "nature",
+    sortingFn: (a, b) => {
+      // déplace la nature inconnue en premier dans la liste
+      const natureA = a.original.nature === "inconnue" ? " " : a.original.nature;
+      const natureB = b.original.nature === "inconnue" ? " " : b.original.nature;
+      return natureA.localeCompare(natureB);
+    },
     header: () => (
       <>
         Nature


### PR DESCRIPTION
- Complète la nature des organismes côté UI (300 organismes concernés), pour que nature INCONNUE se comporte de la même façon que nature null. Idéalement, ça serait à faire dans une migration pour corriger les données, mais je n'ai aucune assurance qu'il n'y a pas un bout de code quelque part qui ne crée pas des organismes sans nature. (je pense notamment à l'inscription avec une organisme de l'api entreprise uniquement)
- Ajoute une mention INCONNUE en rouge en face d'un UAI manquant dans la liste des organismes.
- ~En attente Nadine au cas où il faille trier différemment la colonne nature pour mettre les inconnues en début ou fin de liste plutôt qu'au milieu.~ => j'ai pris l'initiative de déplacer les natures inconnues en début de liste en cas de tri