### PR TITLE
chore(server): transformation du champ est_dans_referentiel

### DIFF
--- a/server/migrations/20230720093700-update-est-dans-referentiel-flag.js
+++ b/server/migrations/20230720093700-update-est-dans-referentiel-flag.js
@@ -1,0 +1,20 @@
+export const up = async (db) => {
+  // cette migration MAJ le champ est_dans_le_referentiel avec le nouveau format
+  await db
+    .collection("organismes")
+    .updateMany(
+      { est_dans_le_referentiel: true },
+      { $set: { est_dans_le_referentiel: "present" } },
+      { bypassDocumentValidation: true }
+    );
+
+  await db
+    .collection("organismes")
+    .updateMany(
+      { est_dans_le_referentiel: false },
+      { $set: { est_dans_le_referentiel: "absent" } },
+      { bypassDocumentValidation: true }
+    );
+};
+
+export const down = async () => {};

--- a/server/src/common/constants/organisme.ts
+++ b/server/src/common/constants/organisme.ts
@@ -5,3 +5,9 @@ export const NATURE_ORGANISME_DE_FORMATION = {
   LIEU: "lieu_formation",
   INCONNUE: "inconnue",
 } as const;
+
+export const STATUT_PRESENCE_REFERENTIEL = {
+  ABSENT: "absent",
+  PRESENT: "present",
+  PRESENT_UAI_MULTIPLES: "present_uai_multiples",
+} as const;

--- a/server/src/common/constants/organisme.ts
+++ b/server/src/common/constants/organisme.ts
@@ -9,5 +9,5 @@ export const NATURE_ORGANISME_DE_FORMATION = {
 export const STATUT_PRESENCE_REFERENTIEL = {
   ABSENT: "absent",
   PRESENT: "present",
-  PRESENT_UAI_MULTIPLES: "present_uai_multiples",
+  PRESENT_UAI_MULTIPLES_TDB: "present_uai_multiples_dans_tdb",
 } as const;

--- a/server/src/common/model/@types/Organisme.ts
+++ b/server/src/common/model/@types/Organisme.ts
@@ -955,7 +955,7 @@ export interface Organisme {
   /**
    * Est dans le referentiel ONISEP des organismes
    */
-  est_dans_le_referentiel?: "absent" | "present" | "present_uai_multiples";
+  est_dans_le_referentiel?: "absent" | "present" | "present_uai_multiples_dans_tdb";
   /**
    * Le siret est fermé
    */

--- a/server/src/common/model/@types/Organisme.ts
+++ b/server/src/common/model/@types/Organisme.ts
@@ -953,9 +953,9 @@ export interface Organisme {
    */
   last_transmission_date?: Date;
   /**
-   * Est dans le referentiel onisep des organismes
+   * Est dans le referentiel ONISEP des organismes
    */
-  est_dans_le_referentiel?: boolean;
+  est_dans_le_referentiel?: "absent" | "present" | "present_uai_multiples";
   /**
    * Le siret est fermé
    */

--- a/server/src/common/model/organismes.model.ts
+++ b/server/src/common/model/organismes.model.ts
@@ -1,10 +1,11 @@
+import { number } from "joi";
 import { CreateIndexesOptions, IndexSpecification } from "mongodb";
 
 import { STATUT_CREATION_ORGANISME, STATUT_FIABILISATION_ORGANISME } from "@/common/constants/fiabilisation";
 import { TETE_DE_RESEAUX } from "@/common/constants/networks";
 import { SIRET_REGEX_PATTERN, UAI_REGEX_PATTERN } from "@/common/constants/validations";
 
-import { NATURE_ORGANISME_DE_FORMATION } from "../constants/organisme";
+import { NATURE_ORGANISME_DE_FORMATION, STATUT_PRESENCE_REFERENTIEL } from "../constants/organisme";
 
 import { adresseSchema } from "./json-schema/adresseSchema";
 import {
@@ -158,7 +159,10 @@ const schema = object(
     metiers: arrayOf(string(), { description: "Les domaines métiers rattachés à l'établissement" }),
     first_transmission_date: date({ description: "Date de la première transmission de données" }),
     last_transmission_date: date({ description: "Date de la dernière transmission de données" }),
-    est_dans_le_referentiel: boolean({ description: "Est dans le referentiel onisep des organismes" }),
+    est_dans_le_referentiel: string({
+      enum: Object.values(STATUT_PRESENCE_REFERENTIEL),
+      description: "Présence dans le referentiel ONISEP des organismes",
+    }),
     ferme: boolean({ description: "Le siret est fermé" }),
     qualiopi: boolean({ description: "a la certification Qualiopi" }),
 

--- a/server/src/common/model/organismes.model.ts
+++ b/server/src/common/model/organismes.model.ts
@@ -1,4 +1,3 @@
-import { number } from "joi";
 import { CreateIndexesOptions, IndexSpecification } from "mongodb";
 
 import { STATUT_CREATION_ORGANISME, STATUT_FIABILISATION_ORGANISME } from "@/common/constants/fiabilisation";

--- a/server/src/jobs/fiabilisation/uai-siret/update.ts
+++ b/server/src/jobs/fiabilisation/uai-siret/update.ts
@@ -11,6 +11,7 @@ import {
   STATUT_FIABILISATION_COUPLES_UAI_SIRET,
   STATUT_FIABILISATION_ORGANISME,
 } from "@/common/constants/fiabilisation";
+import { STATUT_PRESENCE_REFERENTIEL } from "@/common/constants/organisme";
 import logger from "@/common/logger";
 import { Organisme } from "@/common/model/@types";
 import {
@@ -84,7 +85,7 @@ export const updateOrganismesFiabilisationUaiSiret = async () => {
  */
 const updateOrganismesReferentielFiables = async () => {
   const { modifiedCount } = await organismesDb().updateMany(
-    { uai: { $exists: true }, est_dans_le_referentiel: true, ferme: false },
+    { uai: { $exists: true }, est_dans_le_referentiel: STATUT_PRESENCE_REFERENTIEL.PRESENT, ferme: false },
     { $set: { fiabilisation_statut: STATUT_FIABILISATION_ORGANISME.FIABLE } }
   );
   nbOrganismesReferentielFiables += modifiedCount;

--- a/server/src/jobs/hydrate/organismes/hydrate-organismes.ts
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes.ts
@@ -7,6 +7,7 @@ import {
   updateOrganisme,
 } from "@/common/actions/organismes/organismes.actions";
 import { STATUT_FIABILISATION_ORGANISME } from "@/common/constants/fiabilisation";
+import { STATUT_PRESENCE_REFERENTIEL } from "@/common/constants/organisme";
 import logger from "@/common/logger";
 import { organismesDb, organismesReferentielDb } from "@/common/model/collections";
 
@@ -56,7 +57,12 @@ const resetOrganismesReferentielPresence = async () => {
   logger.info("Remise à 0 des organismes comme non présents dans le référentiel...");
   await organismesDb().updateMany(
     { siret: { $exists: true } },
-    { $set: { est_dans_le_referentiel: false, fiabilisation_statut: STATUT_FIABILISATION_ORGANISME.INCONNU } }
+    {
+      $set: {
+        est_dans_le_referentiel: STATUT_PRESENCE_REFERENTIEL.ABSENT,
+        fiabilisation_statut: STATUT_FIABILISATION_ORGANISME.INCONNU,
+      },
+    }
   );
 };
 
@@ -87,7 +93,7 @@ const insertOrUpdateOrganisme = async (organismeFromReferentiel) => {
         adresse: adresseFormatted,
         ferme: isFerme,
         qualiopi: qualiopi || false,
-        est_dans_le_referentiel: true,
+        est_dans_le_referentiel: STATUT_PRESENCE_REFERENTIEL.PRESENT,
       });
       nbOrganismeCreated++;
     } catch (error) {
@@ -110,7 +116,7 @@ const insertOrUpdateOrganisme = async (organismeFromReferentiel) => {
       adresse: adresseFormatted,
       ferme: isFerme,
       qualiopi: qualiopi || false,
-      est_dans_le_referentiel: true,
+      est_dans_le_referentiel: STATUT_PRESENCE_REFERENTIEL.PRESENT,
     };
     try {
       await updateOrganisme(organismeInTdb._id, updatedOrganisme);

--- a/server/src/jobs/hydrate/organismes/hydrate-organismes.ts
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes.ts
@@ -79,6 +79,7 @@ const insertOrUpdateOrganisme = async (organismeFromReferentiel) => {
 
   // Recherche de l'organisme via le couple UAI - SIRET
   const organismeInTdb = await findOrganismeByUaiAndSiret(uai, siret);
+  const multipleOrganismesInReferentielWithSameSiret = (await organismesReferentielDb().countDocuments({ siret })) > 1;
 
   // Ajout de l'organisme sans appels API si non existant dans le tdb
   if (!organismeInTdb) {
@@ -93,7 +94,9 @@ const insertOrUpdateOrganisme = async (organismeFromReferentiel) => {
         adresse: adresseFormatted,
         ferme: isFerme,
         qualiopi: qualiopi || false,
-        est_dans_le_referentiel: STATUT_PRESENCE_REFERENTIEL.PRESENT,
+        est_dans_le_referentiel: multipleOrganismesInReferentielWithSameSiret
+          ? STATUT_PRESENCE_REFERENTIEL.PRESENT_UAI_MULTIPLES
+          : STATUT_PRESENCE_REFERENTIEL.PRESENT,
       });
       nbOrganismeCreated++;
     } catch (error) {
@@ -116,7 +119,9 @@ const insertOrUpdateOrganisme = async (organismeFromReferentiel) => {
       adresse: adresseFormatted,
       ferme: isFerme,
       qualiopi: qualiopi || false,
-      est_dans_le_referentiel: STATUT_PRESENCE_REFERENTIEL.PRESENT,
+      est_dans_le_referentiel: multipleOrganismesInReferentielWithSameSiret
+        ? STATUT_PRESENCE_REFERENTIEL.PRESENT_UAI_MULTIPLES
+        : STATUT_PRESENCE_REFERENTIEL.PRESENT,
     };
     try {
       await updateOrganisme(organismeInTdb._id, updatedOrganisme);

--- a/server/src/jobs/hydrate/organismes/hydrate-organismes.ts
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes.ts
@@ -79,7 +79,7 @@ const insertOrUpdateOrganisme = async (organismeFromReferentiel) => {
 
   // Recherche de l'organisme via le couple UAI - SIRET
   const organismeInTdb = await findOrganismeByUaiAndSiret(uai, siret);
-  const multipleOrganismesInReferentielWithSameSiret = (await organismesReferentielDb().countDocuments({ siret })) > 1;
+  const uaiMultiplesInTdb = (await organismesDb().countDocuments({ siret })) > 1;
 
   // Ajout de l'organisme sans appels API si non existant dans le tdb
   if (!organismeInTdb) {
@@ -94,8 +94,8 @@ const insertOrUpdateOrganisme = async (organismeFromReferentiel) => {
         adresse: adresseFormatted,
         ferme: isFerme,
         qualiopi: qualiopi || false,
-        est_dans_le_referentiel: multipleOrganismesInReferentielWithSameSiret
-          ? STATUT_PRESENCE_REFERENTIEL.PRESENT_UAI_MULTIPLES
+        est_dans_le_referentiel: uaiMultiplesInTdb
+          ? STATUT_PRESENCE_REFERENTIEL.PRESENT_UAI_MULTIPLES_TDB
           : STATUT_PRESENCE_REFERENTIEL.PRESENT,
       });
       nbOrganismeCreated++;
@@ -119,8 +119,8 @@ const insertOrUpdateOrganisme = async (organismeFromReferentiel) => {
       adresse: adresseFormatted,
       ferme: isFerme,
       qualiopi: qualiopi || false,
-      est_dans_le_referentiel: multipleOrganismesInReferentielWithSameSiret
-        ? STATUT_PRESENCE_REFERENTIEL.PRESENT_UAI_MULTIPLES
+      est_dans_le_referentiel: uaiMultiplesInTdb
+        ? STATUT_PRESENCE_REFERENTIEL.PRESENT_UAI_MULTIPLES_TDB
         : STATUT_PRESENCE_REFERENTIEL.PRESENT,
     };
     try {

--- a/server/src/jobs/hydrate/reseaux/hydrate-reseaux.ts
+++ b/server/src/jobs/hydrate/reseaux/hydrate-reseaux.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { PromisePool } from "@supercharge/promise-pool";
 
 import { findOrganismesBySiret } from "@/common/actions/organismes/organismes.actions";
+import { STATUT_PRESENCE_REFERENTIEL } from "@/common/constants/organisme";
 import logger from "@/common/logger";
 import { organismesDb } from "@/common/model/collections";
 import { __dirname } from "@/common/utils/esmUtils";
@@ -110,7 +111,7 @@ const hydrateReseauFile = async (filename: string) => {
 
     // Recherche des organismes présents dans le référentiel et ayant ce siret
     const organismesForSiret = await findOrganismesBySiret(organismeFromFile.siret, {
-      est_dans_le_referentiel: true,
+      est_dans_le_referentiel: { $ne: STATUT_PRESENCE_REFERENTIEL.ABSENT },
     });
 
     const found = organismesForSiret?.length !== 0;

--- a/server/tests/utils/permissions.ts
+++ b/server/tests/utils/permissions.ts
@@ -1,6 +1,7 @@
 import { ObjectId, WithId } from "mongodb";
 
 import { addEffectifComputedFields } from "@/common/actions/effectifs.actions";
+import { STATUT_PRESENCE_REFERENTIEL } from "@/common/constants/organisme";
 import { Effectif } from "@/common/model/@types/Effectif";
 import { Organisme } from "@/common/model/@types/Organisme";
 import { NewOrganisation } from "@/common/model/organisations.model";
@@ -49,7 +50,7 @@ export const commonOrganismeAttributes: Omit<{ [key in keyof Organisme]: Organis
   organismesResponsables: [],
   created_at: new Date("2023-04-12T18:00:00.000Z"),
   updated_at: new Date("2023-04-12T18:00:00.000Z"),
-  est_dans_le_referentiel: true,
+  est_dans_le_referentiel: STATUT_PRESENCE_REFERENTIEL.PRESENT,
   last_transmission_date: new Date("2023-04-15T18:00:00.000Z"),
 };
 

--- a/ui/common/internal/Organisme.ts
+++ b/ui/common/internal/Organisme.ts
@@ -933,7 +933,7 @@ export interface Organisme {
   /**
    * Est dans le referentiel onisep des organismes
    */
-  est_dans_le_referentiel?: boolean;
+  est_dans_le_referentiel?: "absent" | "present" | "present_uai_multiples_dans_tdb";
   /**
    * Le siret est fermé
    */

--- a/ui/modules/admin/OrganismeDetail.tsx
+++ b/ui/modules/admin/OrganismeDetail.tsx
@@ -164,7 +164,12 @@ const OrganismeDetail = ({ data }) => {
         },
         est_dans_le_referentiel: {
           header: () => "Est dans le Référentiel?",
-          cell: ({ value }) => (value ? <Text color="green">OUI</Text> : <Text color="tomato">NON</Text>),
+          cell: ({ value }) =>
+            value === "present" || value === "present_uai_multiples_dans_tdb" ? (
+              <Text color="green">{value}</Text>
+            ) : (
+              <Text color="tomato">{value}</Text>
+            ),
         },
         last_transmission_date: {
           header: () => "Dernière transmission au tdb",

--- a/ui/modules/admin/OrganismesList.tsx
+++ b/ui/modules/admin/OrganismesList.tsx
@@ -95,7 +95,7 @@ const OrganismesList = ({ data, pagination, sorting, searchValue, highlight }: a
                 ? { as: Link, href: { query: { ...router.query, est_dans_le_referentiel: getValue() } } }
                 : {})}
             >
-              {getValue() ? "OUI" : "NON"}
+              {getValue() || ""}
             </Text>
           ),
         },


### PR DESCRIPTION
Objectif : identifier les organismes du référentiel avec uai multiples dans le TdB.

- [x] Transformation du champ **est_dans_le_referentiel** en string avec 3 valeurs possibles.
- [x] Ajout d'une migration pour update les valeurs existantes.
- [x] Ajout d'une nouvelle règle de gestion (vu avec Anne) dans le script hydrate organismes
- [x] ⚠️ Attention au rebase / conflit avec la PR : https://github.com/mission-apprentissage/flux-retour-cfas/pull/3107 (done here 👉🏼https://github.com/mission-apprentissage/flux-retour-cfas/pull/3099/commits/b039d679c1cc5daa045d0a8386caad47f875ad46)