### PR TITLE
chore: utiliser les données validées plutôt que les données d'entrée pour effectifQueue

### DIFF
--- a/server/src/common/model/json-schema/jsonSchemaTypes.ts
+++ b/server/src/common/model/json-schema/jsonSchemaTypes.ts
@@ -94,7 +94,7 @@ export function objectOrNull(properties, custom = {}) {
 export function any(custom: { description?: string } = {}) {
   return {
     ...custom,
-    bsonType: ["number", "string", "bool", "object", "array", "null"],
+    bsonType: ["number", "string", "bool", "object", "array", "null", "objectId", "date"],
     additionalProperties: true,
   };
 }

--- a/server/src/http/routes/specific.routes/dossiers-apprenants.routes.ts
+++ b/server/src/http/routes/specific.routes/dossiers-apprenants.routes.ts
@@ -37,7 +37,7 @@ export default () => {
         : result.error.issues.map(({ path, message }) => ({ message, path }));
 
       return {
-        ...dossierApprenant,
+        ...(result.success ? result.data : dossierApprenant),
         ...defaultValuesEffectifQueue(),
         ...(prettyValidationError ? { processed_at: new Date() } : {}),
         validation_errors: prettyValidationError || [],


### PR DESCRIPTION
Suite à cette discussion. Si la CI passe, je pense que c'est bon.
Pour info, `result.data` existe uniquement si `result.success`

https://mission-apprentissage.slack.com/archives/C02G31Y8WKH/p1689929686365259

EDIT: Du coup j'ai dû modifier le type en entrée pour accepter les dates car notre validateur convertit en date.
Ça n'a pas l'air d'avoir d'impact négatif