### PR TITLE
chore: plus d'infos quand une erreur arrive côté mongodb

### DIFF
--- a/server/src/http/routes/specific.routes/dossiers-apprenants.routes.ts
+++ b/server/src/http/routes/specific.routes/dossiers-apprenants.routes.ts
@@ -64,9 +64,10 @@ export default () => {
       const err = formatError(e);
       logger.error({ err }, "POST /dossiers-apprenants error");
 
-      res.status(500).json({
+      res.status(400).json({
         status: "ERROR",
         message: err.message,
+        details: err.details,
       });
     }
   });


### PR DESCRIPTION
Actuellement, si l'insertion en db échoue dans effectifsQueue, on renvoie une 500 sans infos:

```
{
    "status": "ERROR",
    "message": "Document failed validation"
}
```

Étant donné qu'on n'est pas encore sûr d'être carré entre nos contrôles côté Zod et nos blocages côté mongodb, j'ai une proposition. Cette PR contient des opinions, tout est discutable : 
 - Etant donné que la seule erreur du try/catch est liée à l'insertion des données qui échoue, je pense qu'on peut balancer une 400 (car elles sont mal formées)
 - Je pense qu'on peut faire suivre l'erreur au client sans risque étant donnée que : 
    1. On est en exploration sur la compréhension de notre modèle
    2. Notre code est open source donc notre modèle est public
    3. On gagne à avoir les infos des erreurs de nos clients direct pour gagner du temps.
 - Je pense que ça vaut le coup de merger ça avant que YMAG et SC-form ne testent au cas où "on n'est pas sec" comme on dit ici, pour éviter de retomber dans ça : https://mission-apprentissage.slack.com/archives/G01LW448XEG/p1686758659857649

```
{
    "status": "ERROR",
    "message": "Document failed validation",
    "details": [
        {
            "operatorName": "properties",
            "propertiesNotSatisfied": [
                {
                    "propertyName": "date_de_naissance_apprenant",
                    "description": "Date de naissance de l'apprenant",
                    "details": [
                        {
                            "operatorName": "bsonType",
                            "specifiedAs": {
                                "bsonType": [
                                    "number",
                                    "string",
                                    "bool",
                                    "object",
                                    "array",
                                    "null"
                                ]
                            },
                            "reason": "type did not match",
                            "consideredValue": "1934-10-28T00:00:00.000Z",
                            "consideredType": "date"
                        }
                    ]
                },
```