### PR TITLE
chore(server): ajout de migration pour correction des effectifs

### DIFF
--- a/server/migrations/20230727114445-fix-effectifs-contrats.js
+++ b/server/migrations/20230727114445-fix-effectifs-contrats.js
@@ -1,0 +1,4 @@
+export const up = async (db) => {
+  const collection = db.collection("effectifs");
+  await collection.updateMany({ contrats: null }, { $set: { contrats: [] } }, { bypassDocumentValidation: true });
+};

--- a/server/migrations/20230727114600-fix-effectifs-annee-formation.js
+++ b/server/migrations/20230727114600-fix-effectifs-annee-formation.js
@@ -1,0 +1,6 @@
+export const up = async (db) => {
+  const collection = db.collection("effectifs");
+  await collection.updateMany({ "formation.annee": "1" }, { $set: { "formation.annee": 1 } });
+  await collection.updateMany({ "formation.annee": "2" }, { $set: { "formation.annee": 2 } });
+  await collection.updateMany({ "formation.annee": "3" }, { $set: { "formation.annee": 3 } });
+};


### PR DESCRIPTION
Ajout de 2 migrations pour correction du format des effectifs sur des cas que j'ai identifiés : 

- champ contrat null au lieu de []
- annee de la formation en string