### PR TITLE
fix: typage process effectif avec un id

### DIFF
--- a/server/src/jobs/ingestion/process-ingestion.ts
+++ b/server/src/jobs/ingestion/process-ingestion.ts
@@ -61,7 +61,7 @@ export const processEffectifsQueue = async (options?: Options) => {
 
   const filter: Record<string, any> = force ? {} : { processed_at: { $exists: false } };
   if (id) {
-    filter._id = id;
+    filter._id = new ObjectId(id);
   }
 
   const result = await processItems(filter);


### PR DESCRIPTION
Mini fix quand j'ai voulu debugger, ça ne marchait pas.


Pour plus tard, y'a du ménage à faire dans cette zone, donc on en reparlera. :D
Je verrais bien 2 commandes vraiment séparées :
- commande classique pour lancer le job de traitement des effectifs (qui traite à l'infini)
- commande pour traiter un effectif

Là les 2 sont mélangées, avec deux params id qui se retrouvent dans une boucle plutôt que faire 1 appel de fonction. :thinking: 