### PR TITLE
fix(server): correction de l'ingestion et des scripts de fiabilisation

### DIFF
--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -24,6 +24,7 @@ import { buildAdresseFromUai, getDepartementCodeFromUai } from "@/common/utils/u
 import { IReqPostVerifyUser } from "@/common/validation/ApiERPSchema";
 import { ConfigurationERP } from "@/common/validation/configurationERPSchema";
 
+import { mapFiabilizedOrganismeUaiSiretCouple } from "../engine/engine.organismes.utils";
 import { InfoSiret } from "../infoSiret.actions-struct";
 
 import { getFormationsTreeForOrganisme } from "./organismes.formations.actions";
@@ -178,6 +179,24 @@ export const findOrganismeByUaiAndSiret = async (uai?: string, siret?: string, p
     throw new Error("missing parameter `uai` or `siret`");
   }
   return await organismesDb().findOne({ uai, siret } as any, { projection });
+};
+
+/**
+ * Méthode de récupération d'un organisme fiable depuis un UAI et un SIRET
+ * @param {string} uai
+ * @param {string} siret
+ * @param {*} projection
+ * @returns
+ */
+export const findOrganismeFiableByUaiAndSiret = async (uai?: string, siret?: string, projection = {}) => {
+  if (!uai && !siret) {
+    throw new Error("missing parameter `uai` or `siret`");
+  }
+
+  // Récupération du couple fiable depuis l'UAI / SIRET
+  const { cleanUai, cleanSiret } = await mapFiabilizedOrganismeUaiSiretCouple({ uai, siret });
+
+  return await organismesDb().findOne({ uai: cleanUai, siret: cleanSiret } as any, { projection });
 };
 
 /**

--- a/server/src/jobs/fiabilisation/uai-siret/build.ts
+++ b/server/src/jobs/fiabilisation/uai-siret/build.ts
@@ -2,7 +2,12 @@ import { PromisePool } from "@supercharge/promise-pool";
 
 import { STATUT_FIABILISATION_COUPLES_UAI_SIRET } from "@/common/constants/fiabilisation";
 import logger from "@/common/logger";
-import { effectifsDb, fiabilisationUaiSiretDb, organismesReferentielDb } from "@/common/model/collections";
+import {
+  effectifsDb,
+  effectifsQueueDb,
+  fiabilisationUaiSiretDb,
+  organismesReferentielDb,
+} from "@/common/model/collections";
 import { getPercentage } from "@/common/utils/miscUtils";
 
 import { addFiabilisationsManuelles } from "./build.manual";
@@ -30,31 +35,15 @@ export const buildFiabilisationUaiSiret = async () => {
   logger.info("> Execution du script de fiabilisation sur tous les couples UAI-SIRET...");
 
   const organismesFromReferentiel = await organismesReferentielDb().find().toArray();
-
-  // on récupère tous les couples UAI/SIRET depuis les effectifs en faisant un lookup effectifs - organismes
-  const allCouplesUaiSiretTdb = await effectifsDb()
-    .aggregate([
-      { $match: filters },
-      {
-        $lookup: {
-          from: "organismes",
-          localField: "organisme_id",
-          foreignField: "_id",
-          as: "organismes_info",
-        },
-      },
-      { $unwind: "$organismes_info" },
-      { $project: { organisme_uai: "$organismes_info.uai", organisme_siret: "$organismes_info.siret" } },
-      { $group: { _id: { uai: "$organisme_uai", siret: "$organisme_siret" } } },
-      { $project: { _id: 0, uai: "$_id.uai", siret: "$_id.siret" } },
-    ])
-    .toArray();
-
-  logger.info(">", allCouplesUaiSiretTdb.length, "couples UAI/SIRET trouvés en db");
+  const uniqueCouplesUaiSiretToCheck = await getAllUniqueCouplesUaiSiretToFiabilise();
 
   // Traitement // sur tous les couples identifiés
-  await PromisePool.for(allCouplesUaiSiretTdb).process(async (coupleUaiSiretTdb) => {
-    await buildFiabilisationCoupleForTdbCouple(coupleUaiSiretTdb, allCouplesUaiSiretTdb, organismesFromReferentiel);
+  await PromisePool.for(uniqueCouplesUaiSiretToCheck).process(async (coupleUaiSiretTdb) => {
+    await buildFiabilisationCoupleForTdbCouple(
+      coupleUaiSiretTdb,
+      uniqueCouplesUaiSiretToCheck,
+      organismesFromReferentiel
+    );
   });
 
   // Ajout de fiabilisation manuelles
@@ -80,13 +69,13 @@ export const buildFiabilisationUaiSiret = async () => {
     type: STATUT_FIABILISATION_COUPLES_UAI_SIRET.NON_FIABILISABLE_INEXISTANT,
   });
 
-  let percentageCouplesFiables = getPercentage(nbCouplesFiablesFound, allCouplesUaiSiretTdb.length);
+  let percentageCouplesFiables = getPercentage(nbCouplesFiablesFound, uniqueCouplesUaiSiretToCheck.length);
   let nbCouplesNonFiabilisables =
     nbCouplesNonFiabilisablesUaiNonValidee +
     nbCouplesNonFiabilisablesUaiValidee +
     nbCouplesNonFiabilisablesPbCollecte +
     nbCouplesNonFiabilisablesInexistants;
-  let percentageCouplesNonFiabilisables = getPercentage(nbCouplesNonFiabilisables, allCouplesUaiSiretTdb.length);
+  let percentageCouplesNonFiabilisables = getPercentage(nbCouplesNonFiabilisables, uniqueCouplesUaiSiretToCheck.length);
 
   logger.info(` -> ${nbCouplesFiablesFound} couples déjà fiables (${percentageCouplesFiables}%)`);
   logger.info(` -> ${nbCouplesAFiabiliser} nouveaux couples à fiabiliser`);
@@ -107,6 +96,53 @@ export const buildFiabilisationUaiSiret = async () => {
     nbCouplesNonFiabilisablesPbCollecte,
     nbCouplesNonFiabilisablesInexistants,
   };
+};
+
+/**
+ * Fonction de récupération de la liste des couples UAI SIRET uniques à fiabiliser
+ * Cette liste est construire à partir de tous les couples UAI SIRET lié à des effectifs du TDB + tous les couples
+ * liés à des données valides et sans erreurs dans la file d'attente
+ * @returns
+ */
+export const getAllUniqueCouplesUaiSiretToFiabilise = async () => {
+  // on récupère tous les couples UAI/SIRET depuis les effectifs en faisant un lookup effectifs - organismes
+  const allCouplesUaiSiretTdb = await effectifsDb()
+    .aggregate([
+      { $match: filters },
+      {
+        $lookup: {
+          from: "organismes",
+          localField: "organisme_id",
+          foreignField: "_id",
+          as: "organismes_info",
+        },
+      },
+      { $unwind: "$organismes_info" },
+      { $project: { organisme_uai: "$organismes_info.uai", organisme_siret: "$organismes_info.siret" } },
+      { $group: { _id: { uai: "$organisme_uai", siret: "$organisme_siret" } } },
+      { $project: { _id: 0, uai: "$_id.uai", siret: "$_id.siret" } },
+    ])
+    .toArray();
+  logger.info(" >>", allCouplesUaiSiretTdb.length, "couples UAI/SIRET trouvés en db");
+
+  // on récupère tous les couples UAI/SIRET depuis la file d'attente effectifsQueue sans erreurs de validation
+  const allCouplesUaiSiretTdbInQueue = await effectifsQueueDb()
+    .aggregate([
+      { $match: { validation_errors: [], ...filters } },
+      { $group: { _id: { uai: "$uai_etablissement", siret: "$siret_etablissement" } } },
+      { $project: { _id: 0, uai: "$_id.uai", siret: "$_id.siret" } },
+    ])
+    .toArray();
+  logger.info(" >>", allCouplesUaiSiretTdbInQueue.length, "couples UAI/SIRET trouvés dans la file d'attente");
+
+  // On récupère la liste dédoublonnée des couples depuis les 2 sous ensembles tdb + queue
+  const couplesUaiSiret = [...allCouplesUaiSiretTdb, ...allCouplesUaiSiretTdbInQueue];
+  const uniqueCouplesUaiSiretToCheck = couplesUaiSiret.filter(
+    (obj, index) => couplesUaiSiret.findIndex((item) => item.uai === obj.uai && item.siret === obj.siret) === index
+  );
+
+  logger.info(">", uniqueCouplesUaiSiretToCheck.length, "couples UAI/SIRET uniques à traiter");
+  return uniqueCouplesUaiSiretToCheck;
 };
 
 /**

--- a/server/src/jobs/ingestion/process-ingestion.ts
+++ b/server/src/jobs/ingestion/process-ingestion.ts
@@ -17,7 +17,7 @@ import {
   checkIfEffectifExists,
 } from "@/common/actions/engine/engine.actions";
 import {
-  findOrganismeByUaiAndSiret,
+  findOrganismeFiableByUaiAndSiret,
   setOrganismeTransmissionDates,
 } from "@/common/actions/organismes/organismes.actions";
 import logger from "@/common/logger";
@@ -168,18 +168,18 @@ const transformEffectifQueueItem = async (
           effectif: await pPipe(mapEffectifQueueToEffectif, mergeEffectifWithDefaults, completeEffectifAddress)(data),
           organisme: await pPipe(
             () =>
-              findOrganismeByUaiAndSiret(
+              findOrganismeFiableByUaiAndSiret(
                 effectifQueued?.etablissement_lieu_de_formation_uai,
                 effectifQueued?.etablissement_lieu_de_formation_siret
               ),
             setOrganismeTransmissionDates
           )(data),
-          organisme_formateur: await findOrganismeByUaiAndSiret(
+          organisme_formateur: await findOrganismeFiableByUaiAndSiret(
             effectifQueued?.etablissement_formateur_uai,
             effectifQueued?.etablissement_formateur_siret,
             { _id: 1 }
           ),
-          organisme_responsable: await findOrganismeByUaiAndSiret(
+          organisme_responsable: await findOrganismeFiableByUaiAndSiret(
             effectifQueued?.etablissement_responsable_uai,
             effectifQueued?.etablissement_responsable_siret,
             { _id: 1 }
@@ -191,7 +191,8 @@ const transformEffectifQueueItem = async (
         .transform(async (data) => ({
           effectif: await pPipe(mapEffectifQueueToEffectif, mergeEffectifWithDefaults, completeEffectifAddress)(data),
           organisme: await pPipe(
-            () => findOrganismeByUaiAndSiret(effectifQueued?.uai_etablissement, effectifQueued?.siret_etablissement),
+            () =>
+              findOrganismeFiableByUaiAndSiret(effectifQueued?.uai_etablissement, effectifQueued?.siret_etablissement),
             setOrganismeTransmissionDates
           )(data),
         }))


### PR DESCRIPTION
- Dans l'ingestion prise en compte de la récupération des couples fiabilisés par le scripts de fiabilisation.
- Dans le script de fiabilisation, on récupère désormais tous les couples du TDB ainsi que les couples valides dans la queue.

Pour les exemples AFTRAL qui ne transmettent plus, ce correctif va en 3 temps : 

- Ingérer la donnée, ne pas trouver d'organisme fiable lié donc conserver dans la queue la donnée en erreur
- Au lancement du script de fiab, on va désormais prendre le couple AFTRAL qui est dans la queue en erreur, et le fiabiliser avec le référentiel -> l'ajouter à la collection fiabilisationUaiSiret
- A la prochaine ingestion, vu que le couple est à fiabiliser dans fiabilisationUaiSiret, on va désormais pouvoir le trouver et donc intégrer la donnée au tdb ✅ 