### PR TITLE
chore: upgrade metabase 0.46.6.4

### DIFF
--- a/.infra/ansible/roles/setup/files/app/.overrides/common/docker-compose.common.yml
+++ b/.infra/ansible/roles/setup/files/app/.overrides/common/docker-compose.common.yml
@@ -27,7 +27,7 @@ services:
     #   - "127.0.0.1:27017:27017"
 
   metabase:
-    image: metabase/metabase:v0.46.6.1
+    image: metabase/metabase:v0.46.6.4
     mem_limit: 2g
     container_name: flux_retour_cfas_metabase
     volumes:


### PR DESCRIPTION
cf. https://www.metabase.com/blog/security-advisory-h2