### PR TITLE
perf: suppression du count total des effectifs dans la queue

### DIFF
--- a/server/src/jobs/ingestion/process-ingestion.ts
+++ b/server/src/jobs/ingestion/process-ingestion.ts
@@ -73,14 +73,13 @@ export async function processEffectifsQueue(options?: EffectifQueueProcessorOpti
     ...(options?.force ? {} : { processed_at: { $exists: false } }),
     ...(options?.since ? { created_at: { $gt: options.since } } : {}),
   };
-  const total = await effectifsQueueDb().countDocuments(filter);
   const itemsToProcess = await effectifsQueueDb()
     .find(filter)
     .sort({ created_at: 1 })
     .limit(options?.limit ?? 100)
     .toArray();
 
-  logger.info({ filter, count: itemsToProcess.length, total }, "traitement des effectifsQueue");
+  logger.info({ filter, count: itemsToProcess.length }, "traitement des effectifsQueue");
 
   const res = await PromisePool.withConcurrency(10)
     .for(itemsToProcess)


### PR DESCRIPTION
:zap: 

Actuellement si la queue contient 2.5M effectifs à traiter, le count met ~ 10 secondes, donc on le supprime.
(théoriquement, on devrait quand même arriver à traiter les effectifs plus rapidement qu'ils n'entrent...ça n'a pas toujours été le cas !)