### PR TITLE
chore(ui): harmonisation de la taille dans la subnavbar

### DIFF
--- a/ui/components/Page/components/NavigationMenu.tsx
+++ b/ui/components/Page/components/NavigationMenu.tsx
@@ -154,7 +154,7 @@ function NavBarAutreOrganisme({ organismeId }: { organismeId: string }): ReactEl
 
   return (
     <Container maxW="xl">
-      <Flex as="nav" align="center" wrap="wrap" w="100%">
+      <Flex as="nav" align="center" wrap="wrap" w="100%" fontSize="zeta">
         <Box p={4} bg={"transparent"}>
           <ParentGroupIcon mt="-0.3rem" boxSize={4} color="dsfr_lightprimary.bluefrance_850" />
         </Box>


### PR DESCRIPTION
Catherine trouvait la police de la deuxième trop grosse et elle n'a pas tort, voilà j'ai mis la même taille partout

<img width="769" alt="Capture d’écran 2023-08-11 à 09 33 02" src="https://github.com/mission-apprentissage/flux-retour-cfas/assets/1575946/5c919f52-fded-4772-8765-bee15183cba6">
