### PR TITLE
fix: suppression des relations non présentes dans le référentiel

### DIFF
--- a/server/src/jobs/hydrate/organismes/hydrate-organismes-relations.ts
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes-relations.ts
@@ -11,7 +11,7 @@ const logger = parentLogger.child({
 });
 
 interface OrganismeInfos {
-  _id: ObjectId;
+  _id?: ObjectId;
   enseigne?: string;
   raison_sociale?: string;
   commune?: string;
@@ -125,8 +125,12 @@ export const hydrateOrganismesRelations = async () => {
         { _id: organisme._id },
         {
           $set: {
-            organismesFormateurs: organismesFormateurs.map((organisme) => addOrganismesInfos(organisme)),
-            organismesResponsables: organismesResponsables.map((organisme) => addOrganismesInfos(organisme)),
+            organismesFormateurs: organismesFormateurs
+              .map((organisme) => addOrganismesInfos(organisme))
+              .filter((organisme) => organisme._id !== undefined),
+            organismesResponsables: organismesResponsables
+              .map((organisme) => addOrganismesInfos(organisme))
+              .filter((organisme) => organisme._id !== undefined),
             updated_at: new Date(),
           },
         }


### PR DESCRIPTION
Certains organismes, comme https://referentiel.apprentissage.onisep.fr/organismes/19400019600015/relations ont des relations définies avec des organismes qui sont absent du référentiel. Donc on ne les gère pas et on supprime ces relations.

Les requêtes suivantes renvoyaient des résultats, maintenant 0.
```
db.getCollection("organismes").find({
    "organismesResponsables.0": {
        $exists :true
    },
    "organismesResponsables._id": null
})
db.getCollection("organismes").find({
    "organismesFormateurs.0": {
        $exists :true
    },
    "organismesFormateurs._id": null
})
```