### PR TITLE
fix: remove null properties before zod validation and sending to queue

### DIFF
--- a/server/src/common/utils/stripNullProperties.ts
+++ b/server/src/common/utils/stripNullProperties.ts
@@ -1,0 +1,9 @@
+export default function stripNullProperties<T>(obj: T): T {
+  const result: Partial<T> = {};
+  for (const key in obj) {
+    if (obj[key] !== null) {
+      result[key] = obj[key];
+    }
+  }
+  return result as T;
+}

--- a/server/src/http/routes/specific.routes/dossiers-apprenants.routes.ts
+++ b/server/src/http/routes/specific.routes/dossiers-apprenants.routes.ts
@@ -5,6 +5,7 @@ import logger from "@/common/logger";
 import { effectifsQueueDb } from "@/common/model/collections";
 import { defaultValuesEffectifQueue } from "@/common/model/effectifsQueue.model";
 import { formatError } from "@/common/utils/errorUtils";
+import stripNullProperties from "@/common/utils/stripNullProperties";
 import dossierApprenantSchemaV1V2 from "@/common/validation/dossierApprenantSchemaV1V2";
 import dossierApprenantSchemaV3 from "@/common/validation/dossierApprenantSchemaV3";
 
@@ -19,10 +20,9 @@ export default () => {
    * Une validation plus complete est effectuée lors du traitement des données par process-effectifs-queue
    */
   router.post("/", async ({ user, body, originalUrl }, res) => {
-    const bodyItems = await Joi.array()
-      .max(POST_DOSSIERS_APPRENANTS_MAX_INPUT_LENGTH)
-      .validateAsync(body, { abortEarly: false });
-
+    const bodyItems = (
+      await Joi.array().max(POST_DOSSIERS_APPRENANTS_MAX_INPUT_LENGTH).validateAsync(body, { abortEarly: false })
+    ).map((e) => stripNullProperties(e));
     const isV3 = originalUrl.includes("/v3");
     const validationSchema = isV3 ? dossierApprenantSchemaV3() : dossierApprenantSchemaV1V2();
 

--- a/server/tests/data/randomizedSample.ts
+++ b/server/tests/data/randomizedSample.ts
@@ -115,7 +115,7 @@ export const createRandomDossierApprenantApiInput = (
     statut_apprenant: getRandomStatutApprenant(),
     date_metier_mise_a_jour_statut: faker.date.past().toISOString(),
     annee_formation: formation.annee,
-    periode_formation: isStudentPresent ? formation.periode.join("-") : null,
+    periode_formation: isStudentPresent ? formation.periode.join("-") : undefined,
     annee_scolaire,
     id_erp_apprenant: faker.datatype.uuid(),
     tel_apprenant: faker.helpers.arrayElement([faker.phone.number(), undefined]),


### PR DESCRIPTION
Suite à discussion avec SCForm : 

Ils envoient tous leurs objets formatés pareil, avec des null quand ils n'ont pas la valeur.

Pour éviter de péter une erreur Zod dans l'envoi en queue on va "simplement" stripper tous les champs null avant d'envoyer.

La prise de risque parait faible, le seul cas serait une réinitialisation de données voulue.

Si les tests passent je pense qu'on peut dire que c'est bon