### PR TITLE
chore(server): move reset statut fiab

### DIFF
--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -13,6 +13,7 @@ import { recreateIndexes } from "./jobs/db/recreateIndexes";
 import { removeInscritsSansContratsDepuis, transformRupturantsToAbandonsDepuis } from "./jobs/fiabilisation/effectifs";
 import { getStats } from "./jobs/fiabilisation/stats";
 import { buildFiabilisationUaiSiret } from "./jobs/fiabilisation/uai-siret/build";
+import { resetOrganismesFiabilisationStatut } from "./jobs/fiabilisation/uai-siret/build.utils";
 import { updateOrganismesFiabilisationUaiSiret } from "./jobs/fiabilisation/uai-siret/update";
 import { hydrateEffectifsComputed } from "./jobs/hydrate/effectifs/hydrate-effectifs-computed";
 import { hydrateEffectifsFormationsNiveaux } from "./jobs/hydrate/effectifs/hydrate-effectifs-formations-niveaux";
@@ -551,6 +552,9 @@ program
   .description("Lancement des scripts de fiabilisation des couples UAI SIRET")
   .action(
     runJob(async () => {
+      // On reset le statut de fiabilisation de tous les organismes
+      await resetOrganismesFiabilisationStatut();
+
       // On lance séquentiellement 2 fois de suite la construction (build) de la collection fiabilisation suivi de la MAJ des données liées (apply)
       // Nécessaire pour le bon fonctionnement de l'algo
       await buildFiabilisationUaiSiret();

--- a/server/src/jobs/fiabilisation/uai-siret/build.ts
+++ b/server/src/jobs/fiabilisation/uai-siret/build.ts
@@ -1,8 +1,17 @@
 import { PromisePool } from "@supercharge/promise-pool";
 
-import { STATUT_FIABILISATION_COUPLES_UAI_SIRET } from "@/common/constants/fiabilisation";
+import {
+  STATUT_FIABILISATION_COUPLES_UAI_SIRET,
+  STATUT_FIABILISATION_ORGANISME,
+} from "@/common/constants/fiabilisation";
+import { STATUT_PRESENCE_REFERENTIEL } from "@/common/constants/organisme";
 import logger from "@/common/logger";
-import { effectifsDb, fiabilisationUaiSiretDb, organismesReferentielDb } from "@/common/model/collections";
+import {
+  effectifsDb,
+  fiabilisationUaiSiretDb,
+  organismesDb,
+  organismesReferentielDb,
+} from "@/common/model/collections";
 import { getPercentage } from "@/common/utils/miscUtils";
 
 import { addFiabilisationsManuelles } from "./build.manual";
@@ -26,6 +35,9 @@ const filters = { annee_scolaire: { $in: ["2022-2022", "2022-2023", "2023-2023"]
  */
 export const buildFiabilisationUaiSiret = async () => {
   await fiabilisationUaiSiretDb().deleteMany({});
+
+  // On remet à 0 l'information de présence dans le référentiel
+  await resetOrganismesReferentielPresence();
 
   logger.info("> Execution du script de fiabilisation sur tous les couples UAI-SIRET...");
 
@@ -171,4 +183,20 @@ export const buildFiabilisationCoupleForTdbCouple = async (
 
   // Règle n°9 on vérifie les couples non fiabilisables, si l'UAI est validée cotée référentiel
   if (await checkCoupleNonFiabilisable(coupleUaiSiretTdbToCheck)) return;
+};
+
+/**
+ * Reset du flag est_dans_le_referentiel pour tous les organismes ayant au moins un siret
+ */
+const resetOrganismesReferentielPresence = async () => {
+  logger.info("Remise à 0 des organismes comme non présents dans le référentiel...");
+  await organismesDb().updateMany(
+    { siret: { $exists: true } },
+    {
+      $set: {
+        est_dans_le_referentiel: STATUT_PRESENCE_REFERENTIEL.ABSENT,
+        fiabilisation_statut: STATUT_FIABILISATION_ORGANISME.INCONNU,
+      },
+    }
+  );
 };

--- a/server/src/jobs/fiabilisation/uai-siret/build.ts
+++ b/server/src/jobs/fiabilisation/uai-siret/build.ts
@@ -191,7 +191,7 @@ export const buildFiabilisationCoupleForTdbCouple = async (
 const resetOrganismesReferentielPresence = async () => {
   logger.info("Remise à 0 des organismes comme non présents dans le référentiel...");
   await organismesDb().updateMany(
-    { siret: { $exists: true } },
+    {},
     {
       $set: {
         est_dans_le_referentiel: STATUT_PRESENCE_REFERENTIEL.ABSENT,

--- a/server/src/jobs/fiabilisation/uai-siret/build.utils.ts
+++ b/server/src/jobs/fiabilisation/uai-siret/build.utils.ts
@@ -1,0 +1,11 @@
+import { STATUT_FIABILISATION_ORGANISME } from "@/common/constants/fiabilisation";
+import logger from "@/common/logger";
+import { organismesDb } from "@/common/model/collections";
+
+/**
+ * Reset du flag statut de fiabilisation pour tous les organismes
+ */
+export const resetOrganismesFiabilisationStatut = async () => {
+  logger.info("Remise à 0 des organismes comme ayant une fiabilisation inconnue...");
+  await organismesDb().updateMany({}, { $set: { fiabilisation_statut: STATUT_FIABILISATION_ORGANISME.INCONNU } });
+};

--- a/server/src/jobs/hydrate/organismes/hydrate-organismes.ts
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes.ts
@@ -25,6 +25,9 @@ let nbOrganismeNotUpdated = 0;
  * En cas d'erreurs on log via un createJobEvent()
  */
 export const hydrateOrganismesFromReferentiel = async () => {
+  // On reset tous les organismes comme non présents dans le référentiel
+  await resetOrganismesReferentielPresence();
+
   // On récupère l'intégralité des organismes depuis le référentiel
   const organismesFromReferentiel = await organismesReferentielDb().find().toArray();
   logger.info(`Traitement de ${organismesFromReferentiel.length} organismes provenant du référentiel...`);
@@ -137,4 +140,12 @@ const mapAdresseReferentielToAdresseTdb = (adresseReferentiel) => {
     academie: academie?.code.replace(/^0+/, ""), // Mapping pour coller à notre constante ACADEMIES
     complete: label,
   };
+};
+
+/**
+ * Reset du flag est_dans_le_referentiel pour tous les organismes
+ */
+export const resetOrganismesReferentielPresence = async () => {
+  logger.info("Remise à 0 des organismes comme non présents dans le référentiel...");
+  await organismesDb().updateMany({}, { $set: { est_dans_le_referentiel: STATUT_PRESENCE_REFERENTIEL.ABSENT } });
 };

--- a/server/src/jobs/hydrate/organismes/hydrate-organismes.ts
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes.ts
@@ -6,7 +6,6 @@ import {
   findOrganismeByUaiAndSiret,
   updateOrganisme,
 } from "@/common/actions/organismes/organismes.actions";
-import { STATUT_FIABILISATION_ORGANISME } from "@/common/constants/fiabilisation";
 import { STATUT_PRESENCE_REFERENTIEL } from "@/common/constants/organisme";
 import logger from "@/common/logger";
 import { organismesDb, organismesReferentielDb } from "@/common/model/collections";
@@ -26,9 +25,6 @@ let nbOrganismeNotUpdated = 0;
  * En cas d'erreurs on log via un createJobEvent()
  */
 export const hydrateOrganismesFromReferentiel = async () => {
-  // On remet à 0 l'information de présence dans le référentiel
-  await resetOrganismesReferentielPresence();
-
   // On récupère l'intégralité des organismes depuis le référentiel
   const organismesFromReferentiel = await organismesReferentielDb().find().toArray();
   logger.info(`Traitement de ${organismesFromReferentiel.length} organismes provenant du référentiel...`);
@@ -48,22 +44,6 @@ export const hydrateOrganismesFromReferentiel = async () => {
     nbOrganismesMaj: nbOrganismeUpdated,
     nbOrganismesNonMajErreur: nbOrganismeNotUpdated,
   };
-};
-
-/**
- * Reset du flag est_dans_le_referentiel pour tous les organismes ayant au moins un siret
- */
-const resetOrganismesReferentielPresence = async () => {
-  logger.info("Remise à 0 des organismes comme non présents dans le référentiel...");
-  await organismesDb().updateMany(
-    { siret: { $exists: true } },
-    {
-      $set: {
-        est_dans_le_referentiel: STATUT_PRESENCE_REFERENTIEL.ABSENT,
-        fiabilisation_statut: STATUT_FIABILISATION_ORGANISME.INCONNU,
-      },
-    }
-  );
 };
 
 /**


### PR DESCRIPTION
Déplacement de la fonction de reset des statuts de fiabilisation des organismes dans le job de build de la fiabilisation.