### PR TITLE
fix: maj first_transmission_date en même temps que last_transmission_date

### DIFF
--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -196,11 +196,14 @@ export const updateOrganismeFromApis = async (organisme: WithId<Organisme>) => {
 };
 
 /**
- * Méthode de maj des dates de transmission d'un organisme
- * @deprecated Utiliser updateOrganismeLastTransmissionDate
+ * Met à jour les dates de transmission d'un organisme.
+ * - first_transmission_date : si pas déjà présent
+ * - last_transmission_date : dans tous les cas
  */
-export const setOrganismeTransmissionDates = async (organisme: WithId<Organisme>) => {
-  const updated = await organismesDb().findOneAndUpdate(
+export const updateOrganismeTransmissionDates = async (
+  organisme: Pick<WithId<Organisme>, "_id" | "first_transmission_date">
+) => {
+  const modifyResult = await organismesDb().findOneAndUpdate(
     { _id: organisme._id },
     {
       $set: {
@@ -208,32 +211,12 @@ export const setOrganismeTransmissionDates = async (organisme: WithId<Organisme>
         last_transmission_date: new Date(),
         updated_at: new Date(),
       },
-    },
-    { returnDocument: "after" }
-  );
-  if (!updated.value) {
-    throw new Error(`Could not set organisme transmission dates on organisme ${organisme._id.toString()}`);
-  }
-  return updated.value as WithId<Organisme>;
-};
-
-/**
- * Met à jour la date de dernière transmission d'un organisme.
- */
-export async function updateOrganismeLastTransmissionDate(organismeId: ObjectId) {
-  const modifyResult = await organismesDb().findOneAndUpdate(
-    { _id: organismeId },
-    {
-      $set: {
-        last_transmission_date: new Date(),
-        updated_at: new Date(),
-      },
     }
   );
-  if (!modifyResult.ok) {
-    throw new Error(`Could not set organisme last transmission date on organisme ${organismeId.toString()}`);
+  if (!modifyResult.value) {
+    throw new Error(`Could not set organisme transmission dates on organisme ${organisme._id.toString()}`);
   }
-}
+};
 
 /**
  * Returns sous-établissements by siret for an uai

--- a/server/src/http/routes/specific.routes/upload.routes.ts
+++ b/server/src/http/routes/specific.routes/upload.routes.ts
@@ -18,7 +18,7 @@ import {
 } from "@/common/actions/effectifs.actions";
 import { checkIfEffectifExists } from "@/common/actions/engine/engine.actions";
 import { getFormationWithCfd, getFormationWithRNCP } from "@/common/actions/formations.actions";
-import { findOrganismeById, setOrganismeTransmissionDates } from "@/common/actions/organismes/organismes.actions";
+import { findOrganismeById, updateOrganismeTransmissionDates } from "@/common/actions/organismes/organismes.actions";
 import {
   addDocument,
   getDocument,
@@ -630,7 +630,7 @@ export default {
     }
 
     if (uploads.last_snapshot_effectifs.length > 0) {
-      await setOrganismeTransmissionDates(organisme);
+      await updateOrganismeTransmissionDates(organisme);
     }
 
     return {};

--- a/server/src/jobs/ingestion/process-ingestion.ts
+++ b/server/src/jobs/ingestion/process-ingestion.ts
@@ -12,7 +12,7 @@ import {
 } from "@/common/actions/engine/engine.actions";
 import {
   findOrganismeByUaiAndSiret,
-  updateOrganismeLastTransmissionDate,
+  updateOrganismeTransmissionDates,
 } from "@/common/actions/organismes/organismes.actions";
 import parentLogger from "@/common/logger";
 import { Effectif, FiabilisationUaiSiret, Organisme } from "@/common/model/@types";
@@ -129,7 +129,7 @@ async function processEffectifQueueItem(effectifQueue: WithId<EffectifsQueue>): 
       // création ou mise à jour de l'effectif
       const [{ effectifId, itemProcessingInfos }] = await Promise.all([
         createOrUpdateEffectif(effectif),
-        updateOrganismeLastTransmissionDate(organisme._id),
+        updateOrganismeTransmissionDates(organisme),
       ]);
 
       // ajout des informations sur le traitement au logger

--- a/server/tests/integration/common/actions/organismes.actions.test.ts
+++ b/server/tests/integration/common/actions/organismes.actions.test.ts
@@ -7,7 +7,7 @@ import {
   createOrganisme,
   findOrganismeById,
   getOrganismeInfosFromSiret,
-  setOrganismeTransmissionDates,
+  updateOrganismeTransmissionDates,
   updateOrganisme,
   updateOrganismeFromApis,
 } from "@/common/actions/organismes/organismes.actions";
@@ -249,7 +249,7 @@ describe("Test des actions Organismes", () => {
     });
   });
 
-  describe("setOrganismeTransmissionDates", () => {
+  describe("updateOrganismeTransmissionDates", () => {
     it("mets à jour les dates first_transmission_date et last_transmission_date pour un organisme sans first_transmission_date", async () => {
       const { _id } = await createOrganisme(sampleOrganismeWithUAI);
 
@@ -259,7 +259,7 @@ describe("Test des actions Organismes", () => {
       assert.deepStrictEqual(created.first_transmission_date, undefined);
 
       // MAJ de l'organisme et vérification de l'ajout de first_transmission_date
-      await setOrganismeTransmissionDates(created);
+      await updateOrganismeTransmissionDates(created);
       const updated = await findOrganismeById(_id);
       assert.notDeepStrictEqual(updated?.first_transmission_date, undefined);
       assert.notDeepStrictEqual(updated?.last_transmission_date, undefined);
@@ -276,7 +276,7 @@ describe("Test des actions Organismes", () => {
       assert.deepStrictEqual(created.first_transmission_date, first_transmission_date);
 
       // MAJ de l'organisme et vérification de l'ajout de last_transmission_date
-      await setOrganismeTransmissionDates(created);
+      await updateOrganismeTransmissionDates(created);
       const updated = await findOrganismeById(_id);
       assert.deepStrictEqual(updated?.first_transmission_date, first_transmission_date);
       assert.notDeepStrictEqual(updated?.last_transmission_date, undefined);


### PR DESCRIPTION
Suite au refactor de l'ingestion + monitoring, j'avais modifié cette partie pour ne mettre à jour que la date de dernière transmission.

Ici je rétablis aussi celle de 1ère tranmission, qui est potentiellement utilisée mais jamais affichée.
Selon moi, last_transmission_date est beaucoup plus intéressant que first_transmission_date pour connaître si un organisme a transmis des effectifs.