### PR TITLE
fix(server): fiabilisation effectifQueue sans filtre sur validation

### DIFF
--- a/server/src/jobs/fiabilisation/uai-siret/build.ts
+++ b/server/src/jobs/fiabilisation/uai-siret/build.ts
@@ -218,7 +218,7 @@ const getAllCouplesUaiSiretTdbInQueue = async () => {
   //
   return await effectifsQueueDb()
     .aggregate([
-      { $match: { validation_errors: [], ...filters } },
+      { $match: { ...filters } },
       { $group: { _id: { uai: "$uai_etablissement", siret: "$siret_etablissement" } } },
       { $project: { _id: 0, uai: "$_id.uai", siret: "$_id.siret" } },
     ])


### PR DESCRIPTION
Petit (mais important) fix sur la requête de récupération des couples de la queue pour la fiabilisation.

Le filtre sur validationErrors empéchait d'avoir dans la liste des couples à fiabiliser (vu qu'ils ont une erreur ils ne remontent pas et ne peuvent pas donc être fiabilisés hors c'est ce qu'on souhaite)