### PR TITLE
chore: add tooltip national

### DIFF
--- a/ui/modules/dashboard/DashboardTransverse.tsx
+++ b/ui/modules/dashboard/DashboardTransverse.tsx
@@ -256,6 +256,27 @@ const DashboardTransverse = () => {
           <GridItem bg="galt" py="8" px="12">
             <Heading as="h3" color="#3558A2" fontSize="gamma" fontWeight="700" mb={3}>
               Répartition des effectifs au national
+              <Tooltip
+                background="bluefrance"
+                color="white"
+                label={
+                  <Box padding="1w">
+                    Répartition du nombre d’apprenants et de sorties d’apprentissage à l’instant T, par départements.
+                    Ces chiffres correspondent aux données à la date du jour, et peuvent varier d’un jour à l’autre
+                    selon les données transmises par les organismes de formation en apprentissage.
+                  </Box>
+                }
+                aria-label="Informations sur la répartition des effectifs au national"
+              >
+                <Box
+                  as="i"
+                  className="ri-information-line"
+                  fontSize="epsilon"
+                  color="grey.500"
+                  marginLeft="1w"
+                  verticalAlign="middle"
+                />
+              </Tooltip>
             </Heading>
             <Divider size="md" my={4} borderBottomWidth="2px" opacity="1" />
 


### PR DESCRIPTION
Source : 

<img width="426" alt="Capture d’écran 2023-08-29 à 14 40 21" src="https://github.com/mission-apprentissage/flux-retour-cfas/assets/1575946/64287aff-00dd-4f1e-8592-866970324435">

Et: https://www.figma.com/file/0mofiw6xvEKFnvdIjl5Whl/DSFR-x-TdB?type=design&node-id=345%3A71736&mode=design&t=iwhKUWG4XsXP0GlH-1