### PR TITLE
fix(server): correction du passage de la liste des couples du TDB vs couples Queue + Tdb

### DIFF
--- a/server/src/jobs/fiabilisation/uai-siret/build.ts
+++ b/server/src/jobs/fiabilisation/uai-siret/build.ts
@@ -228,11 +228,8 @@ const getAllCouplesUaiSiretTdbInReferentiel = async () => {
           pipeline: [
             {
               $match: {
-                $expr: {
-                  $or: [
-                    { $eq: ["$est_dans_le_referentiel", STATUT_PRESENCE_REFERENTIEL.PRESENT] },
-                    { $eq: ["$est_dans_le_referentiel", STATUT_PRESENCE_REFERENTIEL.PRESENT_UAI_MULTIPLES_TDB] },
-                  ],
+                est_dans_le_referentiel: {
+                  $in: [STATUT_PRESENCE_REFERENTIEL.PRESENT, STATUT_PRESENCE_REFERENTIEL.PRESENT_UAI_MULTIPLES_TDB],
                 },
               },
             },

--- a/server/src/jobs/fiabilisation/uai-siret/build.ts
+++ b/server/src/jobs/fiabilisation/uai-siret/build.ts
@@ -33,16 +33,15 @@ export const buildFiabilisationUaiSiret = async () => {
   await fiabilisationUaiSiretDb().deleteMany({});
 
   logger.info("> Execution du script de fiabilisation sur tous les couples UAI-SIRET...");
-  const organismesFromReferentiel = await organismesReferentielDb().find().toArray();
-  const uniqueCouplesUaiSiretToCheck = await getAllUniqueCouplesUaiSiretToFiabilise();
+  const [organismesFromReferentiel, allCouplesUaiSiretTdb, uniqueCouplesUaiSiretToCheck] = await Promise.all([
+    organismesReferentielDb().find().toArray(),
+    getAllCouplesUaiSiretTdb(),
+    getAllUniqueCouplesUaiSiretToFiabilise(),
+  ]);
 
   // Traitement // sur tous les couples identifiés
   await PromisePool.for(uniqueCouplesUaiSiretToCheck).process(async (coupleUaiSiretTdb) => {
-    await buildFiabilisationCoupleForTdbCouple(
-      coupleUaiSiretTdb,
-      uniqueCouplesUaiSiretToCheck,
-      organismesFromReferentiel
-    );
+    await buildFiabilisationCoupleForTdbCouple(coupleUaiSiretTdb, allCouplesUaiSiretTdb, organismesFromReferentiel);
   });
 
   // Ajout de fiabilisation manuelles

--- a/server/src/jobs/fiabilisation/uai-siret/build.ts
+++ b/server/src/jobs/fiabilisation/uai-siret/build.ts
@@ -1,6 +1,7 @@
 import { PromisePool } from "@supercharge/promise-pool";
 
 import { STATUT_FIABILISATION_COUPLES_UAI_SIRET } from "@/common/constants/fiabilisation";
+import { STATUT_PRESENCE_REFERENTIEL } from "@/common/constants/organisme";
 import logger from "@/common/logger";
 import {
   effectifsDb,
@@ -33,15 +34,20 @@ export const buildFiabilisationUaiSiret = async () => {
   await fiabilisationUaiSiretDb().deleteMany({});
 
   logger.info("> Execution du script de fiabilisation sur tous les couples UAI-SIRET...");
-  const [organismesFromReferentiel, allCouplesUaiSiretTdb, uniqueCouplesUaiSiretToCheck] = await Promise.all([
-    organismesReferentielDb().find().toArray(),
-    getAllCouplesUaiSiretTdb(),
-    getAllUniqueCouplesUaiSiretToFiabilise(),
-  ]);
+  const [organismesFromReferentiel, allCouplesUaiSiretTdbInReferentiel, uniqueCouplesUaiSiretToCheck] =
+    await Promise.all([
+      organismesReferentielDb().find().toArray(),
+      getAllCouplesUaiSiretTdbInReferentiel(),
+      getAllUniqueCouplesUaiSiretToFiabilise(),
+    ]);
 
   // Traitement // sur tous les couples identifiés
   await PromisePool.for(uniqueCouplesUaiSiretToCheck).process(async (coupleUaiSiretTdb) => {
-    await buildFiabilisationCoupleForTdbCouple(coupleUaiSiretTdb, allCouplesUaiSiretTdb, organismesFromReferentiel);
+    await buildFiabilisationCoupleForTdbCouple(
+      coupleUaiSiretTdb,
+      allCouplesUaiSiretTdbInReferentiel,
+      organismesFromReferentiel
+    );
   });
 
   // Ajout de fiabilisation manuelles
@@ -199,6 +205,38 @@ const getAllCouplesUaiSiretTdb = async () => {
           localField: "organisme_id",
           foreignField: "_id",
           as: "organismes_info",
+        },
+      },
+      { $unwind: "$organismes_info" },
+      { $project: { organisme_uai: "$organismes_info.uai", organisme_siret: "$organismes_info.siret" } },
+      { $group: { _id: { uai: "$organisme_uai", siret: "$organisme_siret" } } },
+      { $project: { _id: 0, uai: "$_id.uai", siret: "$_id.siret" } },
+    ])
+    .toArray();
+};
+
+const getAllCouplesUaiSiretTdbInReferentiel = async () => {
+  return await effectifsDb()
+    .aggregate([
+      { $match: filters },
+      {
+        $lookup: {
+          from: "organismes",
+          localField: "organisme_id",
+          foreignField: "_id",
+          as: "organismes_info",
+          pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $or: [
+                    { $eq: ["$est_dans_le_referentiel", STATUT_PRESENCE_REFERENTIEL.PRESENT] },
+                    { $eq: ["$est_dans_le_referentiel", STATUT_PRESENCE_REFERENTIEL.PRESENT_UAI_MULTIPLES_TDB] },
+                  ],
+                },
+              },
+            },
+          ],
         },
       },
       { $unwind: "$organismes_info" },


### PR DESCRIPTION
Correctif du script de fiabilisation : on a besoin de passer aux règles de fiab la liste des couples UAI-SIRET présents dans le TdB et dans le référentiel et on lui passait la liste des couples dans le TDB + dans la queue.

Il se peut donc qu'on n'arrive pas à fiabiliser car cette liste était trop grosse et on peut avoir zappé des validation de la regle de siret/uai unique dans le TDB à case de ça.
