### PR TITLE
fix: retourne api_key & cie selon les droits

### DIFF
--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -574,6 +574,12 @@ export async function getOrganismeDetails(ctx: AuthContext, organismeId: ObjectI
         last_transmission_date: permissionsOrganisme.infoTransmissionEffectifs,
         mode_de_transmission: permissionsOrganisme.infoTransmissionEffectifs,
         setup_step_courante: permissionsOrganisme.infoTransmissionEffectifs,
+
+        // configuration API
+        api_key: permissionsOrganisme.manageEffectifs,
+        api_configuration_date: permissionsOrganisme.manageEffectifs,
+        api_siret: permissionsOrganisme.manageEffectifs,
+        api_uai: permissionsOrganisme.manageEffectifs,
       }),
     }
   );


### PR DESCRIPTION
Corrige le problème remonté par Raph / Antoine concernant l'api key.
Celle-ci n'était plus retournée côté UI suite aux modifications des permissions (pour éviter que tout le monde n'ait accès à ces infos sensible).

Problème initial :
> Tu te connectes en tant que quelqu’un (n’importe qui) et tu vas sur “mon compte” => “paramétrage ERP” et là ya le bouton qui apparait et ça devrait t’envoyer sur la page en question et si tu clique sur “générer la clé” tu as rien alors que tu avais quelque chose

Par contre en regardant le code, j'ai vu plusieurs problèmes :
- Déjà l'onglet paramétrage ERP est dans mon-compte, et devrait être au niveau de l'organisme. Le problème est qu'un utilisateur non OF peut accéder à cette page et obtient une page blanche comme il n'a pas d'organisme...
- Il y a une condition pour n'afficher cet onglet seulement pour les environnements recette et dev... donc rien en prod.