### PR TITLE
chore(server): suppression des organismes absents du referentiel n'ayant jamais transmis + fix organismes fiables

### DIFF
--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -273,6 +273,15 @@ program
   .action(createJobAction("tmp:patches:update-lastTransmissionDate-organismes"));
 
 /**
+ * Job (temporaire) de suppression des organismes absents du référentiel n'ayant jamais transmis
+ */
+program
+  .command("tmp:patches:remove-organismes-absentsReferentiel-sansTransmission")
+  .description("[TEMPORAIRE] Suppression des organismes absents du référentiel n'ayant jamais transmis")
+  .option("-q, --queued", "Run job asynchronously", false)
+  .action(createJobAction("tmp:patches:remove-organismes-absentsReferentiel-sansTransmission"));
+
+/**
  * Job d'initialisation de données de test
  */
 program.command("seed:sample").description("Seed sample data").action(createJobAction("seed:sample"));

--- a/server/src/jobs/hydrate/organismes/hydrate-organismes.ts
+++ b/server/src/jobs/hydrate/organismes/hydrate-organismes.ts
@@ -6,6 +6,7 @@ import {
   findOrganismeByUaiAndSiret,
   updateOrganisme,
 } from "@/common/actions/organismes/organismes.actions";
+import { STATUT_FIABILISATION_ORGANISME } from "@/common/constants/fiabilisation";
 import { STATUT_PRESENCE_REFERENTIEL } from "@/common/constants/organisme";
 import logger from "@/common/logger";
 import { organismesDb, organismesReferentielDb } from "@/common/model/collections";
@@ -77,6 +78,8 @@ const insertOrUpdateOrganisme = async (organismeFromReferentiel) => {
         adresse: adresseFormatted,
         ferme: isFerme,
         qualiopi: qualiopi || false,
+        fiabilisation_statut:
+          !isFerme && uai ? STATUT_FIABILISATION_ORGANISME.FIABLE : STATUT_FIABILISATION_ORGANISME.INCONNU,
         est_dans_le_referentiel: uaiMultiplesInTdb
           ? STATUT_PRESENCE_REFERENTIEL.PRESENT_UAI_MULTIPLES_TDB
           : STATUT_PRESENCE_REFERENTIEL.PRESENT,
@@ -102,6 +105,8 @@ const insertOrUpdateOrganisme = async (organismeFromReferentiel) => {
       adresse: adresseFormatted,
       ferme: isFerme,
       qualiopi: qualiopi || false,
+      fiabilisation_statut:
+        !isFerme && uai ? STATUT_FIABILISATION_ORGANISME.FIABLE : STATUT_FIABILISATION_ORGANISME.INCONNU,
       est_dans_le_referentiel: uaiMultiplesInTdb
         ? STATUT_PRESENCE_REFERENTIEL.PRESENT_UAI_MULTIPLES_TDB
         : STATUT_PRESENCE_REFERENTIEL.PRESENT,

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -33,6 +33,7 @@ import { removeDuplicatesEffectifsQueue } from "./ingestion/process-effectifs-qu
 import { processEffectifQueueById, processEffectifsQueue } from "./ingestion/process-ingestion";
 import { addJob, executeJob } from "./jobs_actions";
 import { removeOrganismeAndEffectifs } from "./patches/remove-organisme-effectifs-dossiersApprenants";
+import { removeOrganismesAbsentsReferentielSansTransmission } from "./patches/remove-organismes-absentReferentiel-sansTransmission";
 import { removeOrganismesSansSiretSansEffectifs } from "./patches/remove-organismes-sansSiret-sansEffectifs";
 import { updateLastTransmissionDateForOrganismes } from "./patches/update-lastTransmissionDates";
 import { clearSeedAssets } from "./seed/clearAssets";
@@ -210,6 +211,8 @@ export async function runJob(job: IJob): Promise<number> {
         return removeOrganismesSansSiretSansEffectifs();
       case "tmp:patches:remove-organisme-effectifs":
         return removeOrganismeAndEffectifs(job.payload as any);
+      case "tmp:patches:remove-organismes-absentsReferentiel-sansTransmission":
+        return removeOrganismesAbsentsReferentielSansTransmission();
       case "process:effectifs-queue:remove-duplicates":
         return removeDuplicatesEffectifsQueue();
       case "process:effectifs-queue:single":

--- a/server/src/jobs/patches/remove-organismes-absentReferentiel-sansTransmission/index.ts
+++ b/server/src/jobs/patches/remove-organismes-absentReferentiel-sansTransmission/index.ts
@@ -1,0 +1,17 @@
+import { STATUT_PRESENCE_REFERENTIEL } from "@/common/constants/organisme";
+import logger from "@/common/logger";
+import { organismesDb } from "@/common/model/collections";
+
+/**
+ * Fonction "patch" de suppression des organismes n'ayant jamais transmis et n'étant pas présents dans le référentiel
+ */
+export const removeOrganismesAbsentsReferentielSansTransmission = async () => {
+  logger.info("Suppression des organismes absents du référentiel et n'ayant jamais transmis ... ");
+
+  const { deletedCount } = await organismesDb().deleteMany({
+    est_dans_le_referentiel: STATUT_PRESENCE_REFERENTIEL.ABSENT,
+    $or: [{ first_transmission_date: { $exists: false } }, { first_transmission_date: undefined }],
+  });
+
+  logger.info(`${deletedCount} organismes supprimés avec succès !`);
+};


### PR DESCRIPTION
2 correctifs : 

- Un script de suppression des organismes non fiables (absent du référentiel) n'ayant jamais transmis, ce sont des organismes reliquats de l'ancienne version du TDB (Janvier 2023), il n'ont pas d'utilité.

- Un fix dans l'hydrate des organismes, pour marquer comme FIABLE les organismes présents dans le référentiel, ayant une UAI et encore ouverts. 
Vu que le script de fiabilisation se base sur la liste des organismes liés à des effectifs, les organismes ne transmettant pas mais étant fiables n'avait jamais de statut de fiabilisation mis à jour. 
