### PR TITLE
chore: retrait des valeurs nulles de la validation Excel pour être cohérent avec l'import réel

### DIFF
--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -484,7 +484,9 @@ function setupRoutes(app: Application) {
             returnResult(async (req) => {
               const data = await z
                 .array(dossierApprenantSchemaV3WithMoreRequiredFields())
-                .safeParseAsync((req.body || []).map((e) => stripNullProperties(e)));
+                .safeParseAsync(
+                  Array.isArray(req.body) ? req.body.map((dossier) => stripNullProperties(dossier)) : req.body
+                );
               return data;
             })
           )

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -83,6 +83,7 @@ import { initSentryExpress } from "@/common/services/sentry/sentry";
 import { __dirname } from "@/common/utils/esmUtils";
 import { responseWithCookie } from "@/common/utils/httpUtils";
 import { createUserToken } from "@/common/utils/jwtUtils";
+import stripNullProperties from "@/common/utils/stripNullProperties";
 import { passwordSchema, validateFullObjectSchema, validateFullZodObjectSchema } from "@/common/utils/validationUtils";
 import { SReqPostVerifyUser } from "@/common/validation/ApiERPSchema";
 import { configurationERPSchema } from "@/common/validation/configurationERPSchema";
@@ -481,7 +482,9 @@ function setupRoutes(app: Application) {
           .post(
             "/validate",
             returnResult(async (req) => {
-              const data = await z.array(dossierApprenantSchemaV3WithMoreRequiredFields()).safeParseAsync(req.body);
+              const data = await z
+                .array(dossierApprenantSchemaV3WithMoreRequiredFields())
+                .safeParseAsync((req.body || []).map((e) => stripNullProperties(e)));
               return data;
             })
           )


### PR DESCRIPTION
Contexte : On retire les valeurs nulles dans l'import API v3/v2 pour ne pas avoir de bugs quand les ERPs envoient une donnée null juste pour pas l'envoyer (vu en direct avec SCForm qui fonctionne comme ça).

Maintenant on fait la même chose pour la validation de l'import excel sinon c'est incohérent. Et surtout parce que des valeurs nulles peuvent arriver !