### PR TITLE
chore: réduction de la taille du message de branche de prévisualisation

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -55,7 +55,7 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
-            # :rocket: Prévisualisation
-            ## https://${{ github.event.pull_request.number }}.tdb-preview.apprentissage.beta.gouv.fr/
+            ### :rocket: Prévisualisation
+            https://${{ github.event.pull_request.number }}.tdb-preview.apprentissage.beta.gouv.fr/
           comment_tag: execution
           mode: recreate

--- a/server/tests/jest/setupMongo.ts
+++ b/server/tests/jest/setupMongo.ts
@@ -8,7 +8,7 @@ export const useMongo = () => {
     // connect to mongodb and create indexes before running tests
     await startAndConnectMongodb();
     await createIndexes();
-  });
+  }, 10_000);
   afterAll(async () => {
     await stopMongodb();
   });


### PR DESCRIPTION
C'était un peu trop gros, trop d'emphase tue le(s) message(s)