### PR TITLE
fix(server): on accepte maintenant le NIR avec 13 ou 15 caractères

### DIFF
--- a/server/src/common/constants/validations.ts
+++ b/server/src/common/constants/validations.ts
@@ -9,6 +9,8 @@ export const CODE_NAF_REGEX_PATTERN = "^[0-9]{4}[A-Z]$";
 export const UAI_REGEX_PATTERN = "^[0-9]{7}[a-zA-Z]$";
 export const YEAR_RANGE_PATTERN = "^[12][0-9]{3}-[12][0-9]{3}$";
 export const NIR_REGEX_PATTERN = "^[0-9]{13}$";
+// Le NIR peut contenir 15 caractères (13 chiffres + 2 chiffres de contrôle)
+export const NIR_LOOSE_REGEX_PATTERN = "^[0-9]{13}([0-9]{2})?$";
 
 // Numero INE (Identifiant National Elève)
 // Le numero INE composé de 11 caractères,
@@ -30,6 +32,7 @@ export const CODE_NAF_REGEX = new RegExp(CODE_NAF_REGEX_PATTERN);
 export const UAI_REGEX = new RegExp(UAI_REGEX_PATTERN);
 export const YEAR_RANGE_REGEX = new RegExp(YEAR_RANGE_PATTERN);
 export const NIR_REGEX = new RegExp(NIR_REGEX_PATTERN);
+export const NIR_LOOSE_REGEX = new RegExp(NIR_LOOSE_REGEX_PATTERN);
 
 export const isValidCFD = (cfd) => typeof cfd === "string" && CFD_REGEX.test(cfd);
 export const isValidINE = (ine) => typeof ine === "string" && INE_REGEX.test(ine);

--- a/server/src/common/validation/utils/zodPrimitives.ts
+++ b/server/src/common/validation/utils/zodPrimitives.ts
@@ -286,6 +286,10 @@ export const primitivesV3 = {
           return value;
         })
         .describe("NIR de l'apprenant")
+        .openapi({
+          example: "1234567890123",
+          type: "string",
+        })
     ),
     adresse: z.string().trim().describe("Adresse de l'apprenant"),
     code_postal: z.preprocess(

--- a/server/src/common/validation/utils/zodPrimitives.ts
+++ b/server/src/common/validation/utils/zodPrimitives.ts
@@ -11,8 +11,8 @@ import {
   SIRET_REGEX,
   UAI_REGEX,
   YEAR_RANGE_REGEX,
-  NIR_REGEX,
   INE_REGEX,
+  NIR_LOOSE_REGEX,
 } from "@/common/constants/validations";
 
 import { telephoneConverter } from "./frenchTelephoneNumber";
@@ -277,8 +277,14 @@ export const primitivesV3 = {
       z
         .string()
         .trim()
-        .toUpperCase()
-        .regex(NIR_REGEX, "NIR invalide (13 chiffres attendus)")
+        // On indique juste "13 chiffres attendus", car ça ne devrait pas être 15 (on répare silencieusement quand même à la ligne suivante)
+        .regex(NIR_LOOSE_REGEX, "NIR invalide (13 chiffres attendus)")
+        .transform((value) => {
+          if (value.length === 15) {
+            return value.slice(0, -2);
+          }
+          return value;
+        })
         .describe("NIR de l'apprenant")
     ),
     adresse: z.string().trim().describe("Adresse de l'apprenant"),


### PR DESCRIPTION
Un ERP et un téléversement manuel ont fait l'erreur d'envoyer la clé dans le NIR donc on se dit qu'on peut réparer silencieusement (donc on accepte 15 caractères aussi et on retire les deux derniers)