### PR TITLE
fix(ui): correctifs page des doublons

### DIFF
--- a/ui/modules/mon-espace/effectifs/doublons/EffectifDoublonDeleteAlertDialog.tsx
+++ b/ui/modules/mon-espace/effectifs/doublons/EffectifDoublonDeleteAlertDialog.tsx
@@ -34,7 +34,7 @@ const EffectifDoublonDeleteAlertDialog = ({
       <AlertDialogOverlay>
         <AlertDialogContent>
           <AlertDialogHeader fontSize="lg" fontWeight="bold">
-            Suppression du duplicat d&apos;apprenant <b>{apprenantNomPrenom}</b> (<i>{effectifId}</i>)
+            Suppression du duplicat d&apos;apprenant <b>{apprenantNomPrenom}</b>
           </AlertDialogHeader>
 
           <AlertDialogBody>

--- a/ui/modules/mon-espace/effectifs/doublons/EffectifDoublonDeleteAlertDialog.tsx
+++ b/ui/modules/mon-espace/effectifs/doublons/EffectifDoublonDeleteAlertDialog.tsx
@@ -58,6 +58,7 @@ const EffectifDoublonDeleteAlertDialog = ({
               colorScheme="red"
               onClick={() => {
                 _delete(`/api/v1/effectif/${effectifId}`);
+                router.push(window.location.href); // Try to fix reload in prod
                 router.reload();
               }}
               ml={3}

--- a/ui/modules/mon-espace/effectifs/doublons/EffectifsDoublonsList.tsx
+++ b/ui/modules/mon-espace/effectifs/doublons/EffectifsDoublonsList.tsx
@@ -38,6 +38,7 @@ const EffectifsDoublonsList = ({ data }) => {
               {row.original?._id?.annee_scolaire}
             </Text>
           ),
+          enableSorting: false,
         },
         {
           header: () => "Nom de l'apprenant",
@@ -47,6 +48,7 @@ const EffectifsDoublonsList = ({ data }) => {
               {transformNomPrenomToPascalCase(row)}
             </Text>
           ),
+          enableSorting: false,
         },
         {
           header: () => "Né.e le",
@@ -56,6 +58,7 @@ const EffectifsDoublonsList = ({ data }) => {
               {`Né.e le ${formatDateDayMonthYear(row.original?._id?.date_de_naissance_apprenant)}`}
             </Text>
           ),
+          enableSorting: false,
         },
         {
           header: () => "Code formation diplôme",
@@ -65,6 +68,7 @@ const EffectifsDoublonsList = ({ data }) => {
               {`CFD : ${row.original?._id?.formation_cfd}`}
             </Text>
           ),
+          enableSorting: false,
         },
         {
           header: () => "Nombre d'occurences",
@@ -77,6 +81,7 @@ const EffectifsDoublonsList = ({ data }) => {
               </Text>
             </HStack>
           ),
+          enableSorting: false,
         },
       ]}
     />

--- a/ui/modules/mon-espace/effectifs/doublons/EffectifsDoublonsPage.tsx
+++ b/ui/modules/mon-espace/effectifs/doublons/EffectifsDoublonsPage.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, Flex, HStack, Heading, Spinner, Text, Stack, Divider, Button } from "@chakra-ui/react";
+import { Box, Center, Flex, HStack, Heading, Spinner, Text, Stack, Divider } from "@chakra-ui/react";
 import { useQuery } from "@tanstack/react-query";
 import React from "react";
 import { useRecoilValue } from "recoil";

--- a/ui/modules/mon-espace/effectifs/doublons/EffectifsDoublonsPage.tsx
+++ b/ui/modules/mon-espace/effectifs/doublons/EffectifsDoublonsPage.tsx
@@ -55,12 +55,6 @@ const EffectifsDoublonsPage = ({ isMine }) => {
           </Text>
 
           <EffectifsDoublonsList data={duplicates || []} />
-
-          <Flex flexDir="row-reverse">
-            <Button mr={6} size="md" variant="primary">
-              <Text as="span">Valider</Text>
-            </Button>
-          </Flex>
         </Stack>
 
         <Divider mt={6} mb={4} />


### PR DESCRIPTION
Quelques correctifs sur la page des doublons : 

- Suppression d'un id inutile
- Désactivation du tri
- Suppression d'un bouton inutile

Autre souci bizarre en prod le reload ne se fait pas.