### PR TITLE
chore: suppression du test coverage & utilise de jest-mongodb

### DIFF
--- a/jest-mongodb-config.js
+++ b/jest-mongodb-config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  mongodbMemoryServerOptions: {
+    binary: {
+      version: "6.0.2",
+    },
+    autoStart: false,
+    instance: {},
+  },
+  useSharedDBForAllJestWorkers: false,
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -33,16 +33,6 @@ const config = async () => {
   })();
 
   return {
-    collectCoverageFrom: ["<rootDir>/server/src/**/*.{js,ts}"],
-    coverageProvider: "v8",
-    coverageThreshold: {
-      global: {
-        branches: 73,
-        functions: 40,
-        lines: 47,
-        statements: -14000,
-      },
-    },
     projects: [
       {
         ...preset.defaultsESM,

--- a/jest.config.js
+++ b/jest.config.js
@@ -37,18 +37,15 @@ const config = async () => {
       {
         ...preset.defaultsESM,
         displayName: "server",
-        globalSetup: "<rootDir>/server/tests/jest/globalSetup.ts",
-        globalTeardown: "<rootDir>/server/tests/jest/globalTeardown.ts",
         modulePathIgnorePatterns: ["<rootDir>/server/dist/", "<rootDir>/ui/.next/"],
         moduleFileExtensions: ["js", "jsx", "ts", "tsx", "json", "node"],
         moduleNameMapper: {
           "^@/(.*)$": "<rootDir>/server/src/$1",
           "^@tests/(.*)$": "<rootDir>/server/tests/$1",
         },
-        preset: "ts-jest",
+        preset: "@shelf/jest-mongodb",
         setupFiles: ["<rootDir>/server/tests/jest/setupFiles.ts"],
         setupFilesAfterEnv: ["<rootDir>/server/tests/jest/setupFileAfterEnv.ts"],
-        testEnvironment: "node",
         testMatch: ["<rootDir>/server/**/?(*.)+(spec|test).[tj]s?(x)"],
         transform: {
           "^.+\\.tsx?$": [

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@commitlint/config-conventional": "^17.7.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^6.0.3",
+    "@shelf/jest-mongodb": "^4.1.7",
     "@typescript-eslint/eslint-plugin": "^6.4.1",
     "@typescript-eslint/parser": "^6.4.1",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepare": "husky install",
     "talisman:add-exception": "yarn node-talisman --githook pre-commit -i",
     "test": "cross-env NODE_NO_WARNINGS=1 NODE_OPTIONS=--experimental-vm-modules jest",
-    "test:ci": "yarn test --coverage --ci -w 2",
+    "test:ci": "yarn test --ci -w 2",
     "test:watch": "yarn test --watch",
     "typecheck": "yarn foreach:parallel run typecheck",
     "typecheck:ci": "yarn foreach:ci run typecheck",

--- a/server/package.json
+++ b/server/package.json
@@ -125,7 +125,6 @@
     "jest": "^29.5.0",
     "jest-date-mock": "^1.0.8",
     "json-schema-traverse": "1.0.0",
-    "mongodb-memory-server": "8.13.0",
     "nock": "13.2.4",
     "sentry-testkit": "^5.0.5",
     "ts-jest": "^29.1.0",

--- a/server/tests/jest/globalSetup.ts
+++ b/server/tests/jest/globalSetup.ts
@@ -1,3 +1,0 @@
-export default async function globalSetup() {
-  // nothing here because the typescript aliases are not yet loaded
-}

--- a/server/tests/jest/globalTeardown.ts
+++ b/server/tests/jest/globalTeardown.ts
@@ -1,3 +1,0 @@
-export default async function globalTeardown() {
-  // nothing here because the typescript aliases are not yet loaded
-}

--- a/server/tests/utils/mongoUtils.ts
+++ b/server/tests/utils/mongoUtils.ts
@@ -1,20 +1,9 @@
-import { MongoMemoryServer } from "mongodb-memory-server";
-
 import { connectToMongodb, closeMongodbConnection } from "@/common/mongodb";
 
-let mongoInMemory;
-
 export const startAndConnectMongodb = async () => {
-  mongoInMemory = await MongoMemoryServer.create({
-    binary: {
-      version: "6.0.2",
-    },
-  });
-  const uri = mongoInMemory.getUri();
-  await connectToMongodb(uri);
+  await connectToMongodb(globalThis.__MONGO_URI__);
 };
 
 export const stopMongodb = async () => {
   await closeMongodbConnection();
-  await mongoInMemory.stop();
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6456,6 +6456,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@shelf/jest-mongodb@npm:^4.1.7":
+  version: 4.1.7
+  resolution: "@shelf/jest-mongodb@npm:4.1.7"
+  dependencies:
+    debug: 4.3.4
+    mongodb-memory-server: 8.11.5
+  peerDependencies:
+    jest-environment-node: 27.x.x || 28.x || 29.x
+    mongodb: 3.x.x || 4.x || 5.x
+  checksum: b42bf476fa4e76f25a9c53c0648a0698f00b42335a65fa744b533963be11b5479e810f4ed239260657f2fa3ed3656cc242b507f0109934300f3fc1e16a0bd89b
+  languageName: node
+  linkType: hard
+
 "@sideway/address@npm:^4.1.3":
   version: 4.1.4
   resolution: "@sideway/address@npm:4.1.4"
@@ -8986,6 +8999,13 @@ __metadata:
   version: 2.0.1
   resolution: "@types/stack-utils@npm:2.0.1"
   checksum: 205fdbe3326b7046d7eaf5e494d8084f2659086a266f3f9cf00bccc549c8e36e407f88168ad4383c8b07099957ad669f75f2532ed4bc70be2b037330f7bae019
+  languageName: node
+  linkType: hard
+
+"@types/tmp@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "@types/tmp@npm:0.2.3"
+  checksum: 0ca45e99b3b3c6959d5c4f4555f73c8007db540cfb0fbbb9373217f9ab85e67eef75193f51a1d6564b0ee6c6f5ffa259d1034d7f7530a5b7ce80acb94cfc4daa
   languageName: node
   linkType: hard
 
@@ -20246,6 +20266,7 @@ md5@latest:
     "@commitlint/config-conventional": ^17.7.0
     "@semantic-release/changelog": ^6.0.3
     "@semantic-release/exec": ^6.0.3
+    "@shelf/jest-mongodb": ^4.1.7
     "@typescript-eslint/eslint-plugin": ^6.4.1
     "@typescript-eslint/parser": ^6.4.1
     cross-env: ^7.0.3
@@ -20340,10 +20361,11 @@ md5@latest:
   languageName: node
   linkType: hard
 
-"mongodb-memory-server-core@npm:8.13.0":
-  version: 8.13.0
-  resolution: "mongodb-memory-server-core@npm:8.13.0"
+"mongodb-memory-server-core@npm:8.11.5":
+  version: 8.11.5
+  resolution: "mongodb-memory-server-core@npm:8.11.5"
   dependencies:
+    "@types/tmp": ^0.2.3
     async-mutex: ^0.3.2
     camelcase: ^6.3.0
     debug: ^4.3.4
@@ -20351,24 +20373,25 @@ md5@latest:
     get-port: ^5.1.1
     https-proxy-agent: ^5.0.1
     md5-file: ^5.0.0
-    mongodb: ^4.16.0
+    mongodb: ^4.13.0
     new-find-package-json: ^2.0.0
-    semver: ^7.5.1
+    semver: ^7.3.8
     tar-stream: ^2.1.4
-    tslib: ^2.5.3
+    tmp: ^0.2.1
+    tslib: ^2.4.1
     uuid: ^9.0.0
     yauzl: ^2.10.0
-  checksum: 05ee432d70acf4779b8d3aee63d76216d3e0fc92ab81f1588ad323d58d6372603b1a6d15dc57c066a3ca7d78c993019f4c337a995d3222ffad25534278119c45
+  checksum: aac6b091eb0c8198501967571bb04a20ae84572754c635dddc0fc7c61bd635090e24faa465c32162049393d56417cae527751d16c921e4c782402cd3634c108d
   languageName: node
   linkType: hard
 
-"mongodb-memory-server@npm:8.13.0":
-  version: 8.13.0
-  resolution: "mongodb-memory-server@npm:8.13.0"
+"mongodb-memory-server@npm:8.11.5":
+  version: 8.11.5
+  resolution: "mongodb-memory-server@npm:8.11.5"
   dependencies:
-    mongodb-memory-server-core: 8.13.0
-    tslib: ^2.5.3
-  checksum: 93bc1f40dbf7330a009fb9a6ffab84b151a1f5ced3614f22028139447249cb821c638b61d085eb7c4a68d00f4de836bb444e52fcd32e426a890cfe685d3d8211
+    mongodb-memory-server-core: 8.11.5
+    tslib: ^2.4.1
+  checksum: 90b50c42a24e016463741b1ba193f69bc7f4e2ab8f4cade776a02980abff43a5257025572e52ce5a0acb4803eae63107cc92d74c7c8beff2eeff0ca321b16585
   languageName: node
   linkType: hard
 
@@ -20434,7 +20457,7 @@ md5@latest:
   languageName: node
   linkType: hard
 
-"mongodb@npm:^4.16.0":
+"mongodb@npm:^4.13.0":
   version: 4.17.1
   resolution: "mongodb@npm:4.17.1"
   dependencies:
@@ -23884,7 +23907,7 @@ request-debug@latest:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^3.0.2":
+"rimraf@npm:^3.0.0, rimraf@npm:^3.0.2":
   version: 3.0.2
   resolution: "rimraf@npm:3.0.2"
   dependencies:
@@ -24214,7 +24237,7 @@ request-debug@latest:
   languageName: node
   linkType: hard
 
-"semver@npm:7.5.4, semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.1, semver@npm:^7.5.3, semver@npm:^7.5.4":
+"semver@npm:7.5.4, semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.1.2, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:
@@ -24381,7 +24404,6 @@ request-debug@latest:
     migrate-mongo: 10.0.0
     mjml: 4.11.0
     mongodb: 5.7.0
-    mongodb-memory-server: 8.13.0
     multiparty: 4.2.3
     nock: 13.2.4
     node-ovh-objectstorage: 2.0.5
@@ -25659,6 +25681,15 @@ request-debug@latest:
   languageName: node
   linkType: hard
 
+"tmp@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "tmp@npm:0.2.1"
+  dependencies:
+    rimraf: ^3.0.0
+  checksum: 8b1214654182575124498c87ca986ac53dc76ff36e8f0e0b67139a8d221eaecfdec108c0e6ec54d76f49f1f72ab9325500b246f562b926f85bcdfca8bf35df9e
+  languageName: node
+  linkType: hard
+
 "tmpl@npm:1.0.5":
   version: 1.0.5
   resolution: "tmpl@npm:1.0.5"
@@ -25967,7 +25998,7 @@ request-debug@latest:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.4.1 || ^1.9.3, tslib@npm:^2.5.0, tslib@npm:^2.5.3":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.4.1, tslib@npm:^2.4.1 || ^1.9.3, tslib@npm:^2.5.0":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad


### PR DESCRIPTION
Il me semble qu'il y a des soucis lors du téléchargement de la mongo memory serveur alétoirement. 
![image](https://github.com/mission-apprentissage/flux-retour-cfas/assets/4658821/4dc77aca-dc5b-4461-8044-49861010ac7b)


Je penses que comme c'est fait en parallel et ça overwrite le fichier cible ça crée des conflits. La lib recommandé par jest est un wrapper qui va géré le DL au `globalSetup`.

