### PR TITLE
chore: fix restart policy

### DIFF
--- a/.infra/docker-compose.production.yml
+++ b/.infra/docker-compose.production.yml
@@ -11,7 +11,9 @@ x-deploy-default: &deploy-default
   rollback_config:
     parallelism: 0
   restart_policy:
-    window: 5s
+    window: 360s
+    # Max 24hours
+    max_attempts: 240
 
 x-default: &default
   networks:
@@ -95,7 +97,7 @@ services:
       driver: "fluentd"
       options:
         fluentd-address: localhost:24224
-        tag: docker.json.tdb.{{env_type}}.ui
+        tag: docker.txt.tdb.{{env_type}}.ui
         fluentd-async: "true"
 
   metabase:

--- a/.infra/docker-compose.recette.yml
+++ b/.infra/docker-compose.recette.yml
@@ -11,6 +11,10 @@ services:
         failure_action: rollback
       rollback_config:
         parallelism: 0
+      restart_policy:
+        window: 360s
+        # Max 24hours
+        max_attempts: 240
     ports:
       - 1025:1025
     networks:


### PR DESCRIPTION
**Changements:**
Lors du restart d'un conteneur, on laisse 6 minutes au conteneur pour compléter le restart et éviter d'entrer dans une loop infini de restart. De plus on on limite à 240 attempts (24 heures).