### PR TITLE
refactor: suppression inscription OF non présent dans le référentiel

### DIFF
--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -610,8 +610,7 @@ export async function findOrganismesBySIRET(siret: string): Promise<Organisme[]>
     .toArray();
   if (organismes.length === 0) {
     logger.warn({ module: "inscription", siret }, "aucun organisme trouvé en base");
-    // si pas d'organisme en base (et donc le référentiel), on cherche depuis API entreprise
-    return [await fetchFromAPIEntreprise(siret)];
+    throw Boom.badRequest("Aucun organisme trouvé");
   }
   return organismes;
 }
@@ -642,7 +641,6 @@ export async function getOrganismeByUAIAndSIRETOrFallbackAPIEntreprise(
 }
 
 export async function getOrganismeByUAIAndSIRET(uai: string | null, siret: string): Promise<Organisme> {
-  // FIXME projection à définir
   const organisme = await organismesDb().findOne({
     uai: uai as any,
     siret: siret,

--- a/ui/modules/auth/inscription/components/SearchBySIRETForm.tsx
+++ b/ui/modules/auth/inscription/components/SearchBySIRETForm.tsx
@@ -18,6 +18,7 @@ import { Field, Form, Formik } from "formik";
 import { useState } from "react";
 import * as Yup from "yup";
 
+import { CONTACT_ADDRESS } from "@/common/constants/product";
 import { siretRegex } from "@/common/domain/siret";
 import { _post } from "@/common/httpClient";
 import { sleep } from "@/common/utils/misc";
@@ -78,9 +79,21 @@ export default function SearchBySIRETForm({ organisation, setOrganisation }: Ins
                   {meta.error === "Aucun organisme trouvé" ? (
                     <div>
                       {/* la div supprime le flex parent */}
-                      Ce SIRET n’a pas été identifié. Veuillez vérifier à nouveau ou consulter l’
-                      <Link href={"https://annuaire-entreprises.data.gouv.fr/"} textDecoration={"underline"} isExternal>
-                        annuaire des entreprises
+                      Ce SIRET n’a pas été trouvé dans le{" "}
+                      <Link href="https://referentiel.apprentissage.onisep.fr/" textDecoration="underline" isExternal>
+                        référentiel de l’apprentissage
+                      </Link>
+                      .
+                      <br />
+                      Si vous pensez que c’est une erreur, veuillez nous contacter à{" "}
+                      <Link
+                        href={`mailto:${CONTACT_ADDRESS}`}
+                        target="_blank"
+                        textDecoration="underline"
+                        isExternal
+                        whiteSpace="nowrap"
+                      >
+                        {CONTACT_ADDRESS}
                       </Link>
                       .
                     </div>

--- a/ui/modules/auth/inscription/components/SearchByUAIForm.tsx
+++ b/ui/modules/auth/inscription/components/SearchByUAIForm.tsx
@@ -18,9 +18,11 @@ import { Field, Form, Formik } from "formik";
 import { useState } from "react";
 import * as Yup from "yup";
 
+import { CONTACT_ADDRESS } from "@/common/constants/product";
 import { UAI_REGEX } from "@/common/domain/uai";
 import { _post } from "@/common/httpClient";
 import { sleep } from "@/common/utils/misc";
+import Link from "@/components/Links/Link";
 import { getOrganisationTypeFromNature, InscriptionOrganistionChildProps } from "@/modules/auth/inscription/common";
 
 import OrganismeDetails from "./OrganismeDetails";
@@ -43,10 +45,7 @@ export default function SearchByUAIForm({ organisation, setOrganisation }: Inscr
           await sleep(500); // attente pour ne pas paraitre trop instantané...
           setOrganismes(organismes);
         } catch (err) {
-          let errorMessage: string = err?.json?.data?.message || err.message;
-          if (errorMessage === "Aucun organisme trouvé") {
-            errorMessage = "Ce code UAI n'existe pas. Veuillez vérifier à nouveau";
-          }
+          const errorMessage: string = err?.json?.data?.message || err.message;
           actions.setFieldError("uai", errorMessage);
         } finally {
           actions.setSubmitting(false);
@@ -77,7 +76,32 @@ export default function SearchByUAIForm({ organisation, setOrganisation }: Inscr
                     });
                   }}
                 />
-                <FormErrorMessage>{meta.error}</FormErrorMessage>
+                <FormErrorMessage>
+                  {meta.error === "Aucun organisme trouvé" ? (
+                    <div>
+                      {/* la div supprime le flex parent */}
+                      Ce code UAI n’a pas été trouvé dans le{" "}
+                      <Link href="https://referentiel.apprentissage.onisep.fr/" textDecoration="underline" isExternal>
+                        référentiel de l’apprentissage
+                      </Link>
+                      .
+                      <br />
+                      Si vous pensez que c’est une erreur, veuillez nous contacter à{" "}
+                      <Link
+                        href={`mailto:${CONTACT_ADDRESS}`}
+                        target="_blank"
+                        textDecoration="underline"
+                        isExternal
+                        whiteSpace="nowrap"
+                      >
+                        {CONTACT_ADDRESS}
+                      </Link>
+                      .
+                    </div>
+                  ) : (
+                    meta.error
+                  )}
+                </FormErrorMessage>
               </FormControl>
             )}
           </Field>

--- a/ui/pages/auth/inscription/organisme-inconnu.tsx
+++ b/ui/pages/auth/inscription/organisme-inconnu.tsx
@@ -17,18 +17,9 @@ export default function InscriptionOrganismeInconnu() {
           color="bluefrance"
           whiteSpace="nowrap"
         >
-          Référentiel{" "}
+          référentiel de l’apprentissage
         </Link>
-        de l’apprentissage ou{" "}
-        <Link
-          href={"https://annuaire-entreprises.data.gouv.fr/"}
-          fontWeight={700}
-          color="bluefrance"
-          whiteSpace="nowrap"
-        >
-          l’Annuaire{" "}
-        </Link>
-        des entreprises. Vous pouvez aussi consulter la{" "}
+        . Vous pouvez aussi consulter la{" "}
         <Link
           href={"https://mission-apprentissage.notion.site/Page-d-Aide-FAQ-dbb1eddc954441eaa0ba7f5c6404bdc0"}
           fontWeight={700}


### PR DESCRIPTION
Comme vu à l'IRL (au moins avec Nadine et Antoine), on ne doit pas (plus) laisser s'inscrire des utilisateurs OFA dont l'organisme n'est pas dans le référentiel.

Jusque-là (sans compter l'expiration de la clé d'api entreprise...), on autorisait l'utilisateur avec un SIRET valide à créer un compte.

- [ ] reste des messages d'erreurs à adapter avec @cathbaiona 