### PR TITLE
chore: supprime les crons pour l'env de dev

### DIFF
--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -15,10 +15,12 @@ import { updateUserPassword } from "./jobs/users/update-user-password";
 
 async function startJobProcessor(signal: AbortSignal) {
   logger.info(`Process jobs queue - start`);
-  await addJob({
-    name: "crons:init",
-    queued: true,
-  });
+  if (config.env !== "local") {
+    await addJob({
+      name: "crons:init",
+      queued: true,
+    });
+  }
 
   await processor(signal);
   logger.info(`Processor shut down`);


### PR DESCRIPTION
Empêche le serveur de dev de démarrer le processor, qui démarre tous les jobs du cron daily, tous les jours alors qu'on en veut pas.