### PR TITLE
feat: affichage des effectifs par formation

### DIFF
--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -390,10 +390,10 @@ program
  * Job de remplissage des formations du catalogue
  */
 program
-  .command("hydrate:rncp-rome")
+  .command("hydrate:rncp")
   .description("Remplissage du RNCP")
   .option("-q, --queued", "Run job asynchronously", false)
-  .action(createJobAction("hydrate:rncp-romes"));
+  .action(createJobAction("hydrate:rncp"));
 
 program
   .command("hydrate:organismes-formations")

--- a/server/src/common/actions/indicateurs/indicateurs.actions.ts
+++ b/server/src/common/actions/indicateurs/indicateurs.actions.ts
@@ -615,6 +615,13 @@ export async function getOrganismeIndicateursEffectifsParFormation(
           localField: "rncp_code",
           foreignField: "rncp",
           as: "rncp",
+          pipeline: [
+            {
+              $project: {
+                _id: 0,
+              },
+            },
+          ],
         },
       },
       {

--- a/server/src/common/actions/indicateurs/indicateurs.ts
+++ b/server/src/common/actions/indicateurs/indicateurs.ts
@@ -1,3 +1,5 @@
+import { Rncp } from "@/common/model/@types/Rncp";
+
 export interface IndicateursEffectifs {
   apprenants: number;
   apprentis: number;
@@ -14,6 +16,11 @@ export type IndicateursEffectifsAvecOrganisme = IndicateursEffectifs & {
   nature: string;
   siret: string;
   uai: string;
+};
+
+export type IndicateursEffectifsAvecFormation = IndicateursEffectifs & {
+  rncp_code: string | null;
+  rncp: Rncp | null;
 };
 
 export interface IndicateursOrganismes {

--- a/server/src/common/actions/rncp.actions.ts
+++ b/server/src/common/actions/rncp.actions.ts
@@ -1,0 +1,5 @@
+import { rncpDb } from "@/common/model/collections";
+
+export const getFicheRNCP = async (code_rncp: string) => {
+  return await rncpDb().findOne({ rncp: code_rncp });
+};

--- a/server/src/common/model/@types/Rncp.ts
+++ b/server/src/common/model/@types/Rncp.ts
@@ -2,5 +2,10 @@
 
 export interface Rncp {
   rncp: string;
+  nouveaux_rncp?: string[];
+  intitule: string;
+  niveau?: number;
+  etat_fiche: string;
+  actif: boolean;
   romes: string[];
 }

--- a/server/src/common/model/rncp.model.ts
+++ b/server/src/common/model/rncp.model.ts
@@ -1,6 +1,6 @@
 import { CreateIndexesOptions, IndexSpecification } from "mongodb";
 
-import { arrayOf, object, objectId, string } from "./json-schema/jsonSchemaTypes";
+import { arrayOf, boolean, number, object, objectId, string } from "./json-schema/jsonSchemaTypes";
 
 const collectionName = "rncp";
 
@@ -10,9 +10,14 @@ const schema = object(
   {
     _id: objectId(),
     rncp: string(),
+    nouveaux_rncp: arrayOf(string()),
+    intitule: string(),
+    niveau: number(),
+    etat_fiche: string(),
+    actif: boolean(),
     romes: arrayOf(string()),
   },
-  { required: ["rncp", "romes"], additionalProperties: false }
+  { required: ["rncp", "intitule", "etat_fiche", "actif", "romes"], additionalProperties: false }
 );
 
 export default { schema, indexes, collectionName };

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -71,6 +71,7 @@ import {
   getInvalidUaisFromDossierApprenant,
 } from "@/common/actions/organismes/organismes.actions";
 import { searchOrganismesFormations } from "@/common/actions/organismes/organismes.formations.actions";
+import { getFicheRNCP } from "@/common/actions/rncp.actions";
 import { createSession } from "@/common/actions/sessions.actions";
 import { generateSifa } from "@/common/actions/sifa.actions/sifa.actions";
 import { changePassword, updateUserProfile } from "@/common/actions/users.actions";
@@ -579,6 +580,13 @@ function setupRoutes(app: Application) {
         return await searchOrganismesFormations(searchTerm);
       })
     );
+
+  authRouter.get(
+    "/api/v1/rncp/:code_rncp",
+    returnResult(async (req) => {
+      return await getFicheRNCP(req.params.code_rncp);
+    })
+  );
 
   // LEGACY écrans indicateurs
   authRouter

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -33,6 +33,7 @@ import {
   getIndicateursEffectifsParOrganisme,
   getIndicateursOrganismesParDepartement,
   getOrganismeIndicateursEffectifs,
+  getOrganismeIndicateursEffectifsParFormation,
   getOrganismeIndicateursOrganismes,
   typesEffectifNominatif,
 } from "@/common/actions/indicateurs/indicateurs.actions";
@@ -400,6 +401,14 @@ function setupRoutes(app: Application) {
         returnResult(async (req, res) => {
           const filters = await validateFullZodObjectSchema(req.query, fullEffectifsFiltersSchema);
           return await getIndicateursEffectifsParOrganisme(req.user, filters, res.locals.organismeId);
+        })
+      )
+      .get(
+        "/indicateurs/effectifs/par-formation",
+        requireOrganismePermission("indicateursEffectifs"),
+        returnResult(async (req, res) => {
+          const filters = await validateFullZodObjectSchema(req.query, fullEffectifsFiltersSchema);
+          return await getOrganismeIndicateursEffectifsParFormation(req.user, filters, res.locals.organismeId);
         })
       )
       .get(

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -18,7 +18,7 @@ import { hydrateDeca } from "./hydrate/deca/hydrate-deca";
 import { hydrateEffectifsComputed } from "./hydrate/effectifs/hydrate-effectifs-computed";
 import { hydrateEffectifsFormationsNiveaux } from "./hydrate/effectifs/hydrate-effectifs-formations-niveaux";
 import { hydrateFormationsCatalogue } from "./hydrate/hydrate-formations-catalogue";
-import { hydrateRNCPRomes } from "./hydrate/hydrate-rncp-romes";
+import { hydrateRNCP } from "./hydrate/hydrate-rncp";
 import { hydrateOpenApi } from "./hydrate/open-api/hydrate-open-api";
 import { hydrateOrganismesEffectifsCount } from "./hydrate/organismes/hydrate-effectifs_count";
 import { hydrateOrganismesFromReferentiel } from "./hydrate/organismes/hydrate-organismes";
@@ -156,8 +156,8 @@ export async function runJob(job: IJob): Promise<number> {
         return hydrateFromReferentiel();
       case "hydrate:formations-catalogue":
         return hydrateFormationsCatalogue();
-      case "hydrate:rncp-romes":
-        return hydrateRNCPRomes();
+      case "hydrate:rncp":
+        return hydrateRNCP();
       case "hydrate:organismes-formations":
         return hydrateOrganismesFormations();
       case "hydrate:organismes-relations":

--- a/server/tests/integration/http/indicateurs.route.test.ts
+++ b/server/tests/integration/http/indicateurs.route.test.ts
@@ -1,5 +1,6 @@
 import { AxiosInstance } from "axiosist";
 
+import { IndicateursEffectifsAvecOrganisme } from "@/common/actions/indicateurs/indicateurs";
 import { Effectif } from "@/common/model/@types";
 import { effectifsDb, organismesDb } from "@/common/model/collections";
 import { historySequenceApprentiToAbandon, historySequenceInscritToApprenti } from "@tests/data/historySequenceSamples";
@@ -225,7 +226,7 @@ describe("Route indicateurs", () => {
                   inscritsSansContrat: 0,
                   rupturants: 0,
                   abandons: 0,
-                },
+                } satisfies IndicateursEffectifsAvecOrganisme,
               ]
             : []
         );

--- a/server/tests/integration/http/rncp.routes.test.ts
+++ b/server/tests/integration/http/rncp.routes.test.ts
@@ -1,0 +1,80 @@
+import { AxiosInstance } from "axiosist";
+
+import { Rncp } from "@/common/model/@types/Rncp";
+import { organismesDb, rncpDb } from "@/common/model/collections";
+import { useMongo } from "@tests/jest/setupMongo";
+import { organismes, testPermissions } from "@tests/utils/permissions";
+import { RequestAsOrganisationFunc, expectUnauthorizedError, initTestApp } from "@tests/utils/testUtils";
+
+// FIXME route authentifiée
+
+let app: Awaited<ReturnType<typeof initTestApp>>;
+let httpClient: AxiosInstance;
+let requestAsOrganisation: RequestAsOrganisationFunc;
+
+describe("GET /api/v1/rncp/:code_rncp - retourne une fiche RNCP", () => {
+  useMongo();
+
+  const ficheRNCP: Rncp = {
+    rncp: "RNCP34956",
+    actif: true,
+    etat_fiche: "Publiée",
+    intitule: "Arts de la cuisine",
+    niveau: 4,
+    romes: ["G1602"],
+  };
+
+  beforeEach(async () => {
+    app = await initTestApp();
+    httpClient = app.httpClient;
+    requestAsOrganisation = app.requestAsOrganisation;
+  });
+  beforeEach(async () => {
+    await Promise.all([
+      organismesDb().insertMany(organismes),
+      rncpDb().insertOne({ ...ficheRNCP }), // la copie par destructuring évite à insertOne d'ajouter _id à l'objet
+    ]);
+  });
+
+  it("Vérifie qu'on ne peut pas accéder à la route sans être authentifié", async () => {
+    const response = await httpClient.get(`/api/v1/rncp/${ficheRNCP.rncp}`);
+    expectUnauthorizedError(response);
+  });
+
+  describe("Permissions", () => {
+    testPermissions(
+      {
+        "OF cible": true,
+        "OF non lié": true,
+        "OF formateur": true,
+        "OF responsable": true,
+        "Tête de réseau même réseau": true,
+        "Tête de réseau autre réseau": true,
+        "DREETS même région": true,
+        "DREETS autre région": true,
+        "DRAAF même région": true,
+        "DRAAF autre région": true,
+        "Conseil Régional même région": true,
+        "Conseil Régional autre région": true,
+        "CARIF OREF régional même région": true,
+        "CARIF OREF régional autre région": true,
+        "DDETS même département": true,
+        "DDETS autre département": true,
+        "Académie même académie": true,
+        "Académie autre académie": true,
+        "Opérateur public national": true,
+        "CARIF OREF national": true,
+        Administrateur: true,
+      },
+      async (organisation, allowed) => {
+        const response = await requestAsOrganisation(organisation, "get", `/api/v1/rncp/${ficheRNCP.rncp}`);
+
+        expect(response.status).toStrictEqual(allowed ? 200 : 403);
+        expect(response.data).toStrictEqual({
+          _id: expect.any(String),
+          ...ficheRNCP,
+        });
+      }
+    );
+  });
+});

--- a/ui/modules/dashboard/DashboardOrganisme.tsx
+++ b/ui/modules/dashboard/DashboardOrganisme.tsx
@@ -37,7 +37,8 @@ import { DashboardWelcome } from "@/theme/components/icons/DashboardWelcome";
 
 import { ExternalLinks } from "../admin/OrganismeDetail";
 import { NewOrganisation } from "../auth/inscription/common";
-import { IndicateursEffectifs, IndicateursOrganismes } from "../models/indicateurs";
+import { IndicateursEffectifs, IndicateursEffectifsAvecFormation, IndicateursOrganismes } from "../models/indicateurs";
+import IndicateursEffectifsParFormationTable from "../organismes/IndicateursEffectifsParFormationTable";
 import InfoTransmissionDonnees from "../organismes/InfoTransmissionDonnees";
 
 import ContactsModal from "./ContactsModal";
@@ -84,6 +85,19 @@ const DashboardOrganisme = ({ organisme, modePublique }: Props) => {
     () => _get(`/api/v1/organismes/${organisme._id}/indicateurs/organismes`),
     {
       enabled: !!organisme?._id,
+    }
+  );
+
+  const { data: formationsAvecIndicateurs } = useQuery<IndicateursEffectifsAvecFormation[]>(
+    ["organismes", organisme?._id, "indicateurs/effectifs/par-formation"],
+    async () =>
+      _get(`/api/v1/organismes/${organisme._id}/indicateurs/effectifs/par-formation`, {
+        params: {
+          date: new Date(),
+        },
+      }),
+    {
+      enabled: !!organisme?._id && organisme?.permissions?.indicateursEffectifs,
     }
   );
 
@@ -689,6 +703,18 @@ const DashboardOrganisme = ({ organisme, modePublique }: Props) => {
                 </Flex>
               </>
             )}
+
+            {organisme?.permissions?.indicateursEffectifs &&
+              formationsAvecIndicateurs &&
+              formationsAvecIndicateurs.length > 0 && (
+                <>
+                  <Divider size="md" my={8} />
+                  <Heading as="h1" color="#465F9D" fontSize="beta" fontWeight="700" mb={8}>
+                    Répartition des effectifs par niveau et formations
+                  </Heading>
+                  <IndicateursEffectifsParFormationTable formations={formationsAvecIndicateurs} />
+                </>
+              )}
           </>
         ) : (
           <Ribbons variant="warning" mt="0.5rem">

--- a/ui/modules/indicateurs/filters/FiltreFormationNiveau.tsx
+++ b/ui/modules/indicateurs/filters/FiltreFormationNiveau.tsx
@@ -31,6 +31,11 @@ const niveaux: NiveauFormation[] = [
   },
 ];
 
+export const niveauFormationByNiveau = niveaux.reduce((acc, n) => {
+  acc[n.key] = n.label;
+  return acc;
+}, {});
+
 interface FiltreFormationNiveauProps {
   value: string[];
   onChange: (value: string[]) => void;

--- a/ui/modules/models/indicateurs.ts
+++ b/ui/modules/models/indicateurs.ts
@@ -16,6 +16,11 @@ export type IndicateursEffectifsAvecOrganisme = IndicateursEffectifs & {
   uai: string;
 };
 
+export type IndicateursEffectifsAvecFormation = IndicateursEffectifs & {
+  rncp_code: string | null;
+  rncp: Record<any, any> | null;
+}; // FIXME importer le modèle complet
+
 export interface IndicateursOrganismes {
   tauxCouverture: number;
   totalOrganismes: number;

--- a/ui/modules/organismes/IndicateursEffectifsParFormationTable.tsx
+++ b/ui/modules/organismes/IndicateursEffectifsParFormationTable.tsx
@@ -109,7 +109,6 @@ function IndicateursEffectifsParFormationTable(props: IndicateursEffectifsParFor
       return {};
     }
   });
-  console.log("ficheRNCP", ficheRNCP);
   const [expandedNiveaux, setExpandedNiveaux] = useState<{ [niveau: string]: boolean }>({});
 
   function toggleExpand(niveau: string) {
@@ -207,7 +206,14 @@ function IndicateursEffectifsParFormationTable(props: IndicateursEffectifsParFor
       </Table>
 
       {ficheRNCP && (
-        <Modal isOpen={isOpen} onClose={onClose} size="3xl">
+        <Modal
+          isOpen={isOpen}
+          onClose={() => {
+            onClose();
+            setSelectedCodeRNCP(null);
+          }}
+          size="3xl"
+        >
           <ModalOverlay />
           <ModalContent borderRadius="0" p="2w" pb="4w">
             <ModalHeader display="flex" alignItems="center" fontSize="24px" pl="0">
@@ -224,7 +230,6 @@ function IndicateursEffectifsParFormationTable(props: IndicateursEffectifsParFor
                   variant="whiteBg"
                   href={`https://www.francecompetences.fr/recherche/rncp/${ficheRNCP.rncp?.substring(4)}`}
                   isExternal
-                  borderBottom="1px"
                   ml="auto !important"
                 >
                   Consulter la fiche

--- a/ui/modules/organismes/IndicateursEffectifsParFormationTable.tsx
+++ b/ui/modules/organismes/IndicateursEffectifsParFormationTable.tsx
@@ -1,0 +1,172 @@
+import { ChevronDownIcon } from "@chakra-ui/icons";
+import { Table, Tbody, Td, Text, Th, Thead, Tr } from "@chakra-ui/react";
+import { Fragment, useMemo, useState } from "react";
+
+import { _get } from "@/common/httpClient";
+
+import { AbandonsIcon, ApprentisIcon, InscritsSansContratsIcon, RupturantsIcon } from "../dashboard/icons";
+import { niveauFormationByNiveau } from "../indicateurs/filters/FiltreFormationNiveau";
+import { IndicateursEffectifsAvecFormation } from "../models/indicateurs";
+
+interface CustomColumnDef {
+  accessorKey: string;
+  header: () => string | JSX.Element;
+  style?: any;
+}
+
+const formationsTableColumnsDefs: CustomColumnDef[] = [
+  {
+    accessorKey: "intitule_long",
+    header: () => "Niveau et intitulé de la formation",
+    style: {
+      width: "100%",
+    },
+  },
+  {
+    accessorKey: "apprentis",
+    header: () => (
+      <>
+        <ApprentisIcon w="16px" />
+        <Text as="span" ml={2} fontSize="sm">
+          Apprentis
+        </Text>
+      </>
+    ),
+  },
+  {
+    accessorKey: "inscritsSansContrat",
+    header: () => (
+      <>
+        <InscritsSansContratsIcon w="16px" />
+        <Text as="span" ml={2} fontSize="sm">
+          Sans contrat
+        </Text>
+      </>
+    ),
+  },
+  {
+    accessorKey: "rupturants",
+    header: () => (
+      <>
+        <RupturantsIcon w="16px" />
+        <Text as="span" ml={2} fontSize="sm">
+          Ruptures
+        </Text>
+      </>
+    ),
+  },
+  {
+    accessorKey: "abandons",
+    header: () => (
+      <>
+        <AbandonsIcon w="16px" />
+        <Text as="span" ml={2} fontSize="sm">
+          Sorties
+        </Text>
+      </>
+    ),
+  },
+];
+
+interface NiveauAvecFormations {
+  niveau: string;
+  label: string;
+  formations: IndicateursEffectifsAvecFormation[];
+}
+
+interface IndicateursEffectifsParFormationTableProps {
+  formations: IndicateursEffectifsAvecFormation[];
+}
+function IndicateursEffectifsParFormationTable(props: IndicateursEffectifsParFormationTableProps) {
+  const [expandedNiveaux, setExpandedNiveaux] = useState<{ [niveau: string]: boolean }>({});
+
+  function toggleExpand(niveau: string) {
+    expandedNiveaux[niveau] = !expandedNiveaux[niveau];
+    setExpandedNiveaux({ ...expandedNiveaux });
+  }
+
+  const niveauxAvecFormations = useMemo(() => {
+    return Object.values(
+      props.formations.reduce<{ [key: string]: NiveauAvecFormations }>((acc, formation) => {
+        let formationsNiveau = acc[formation.rncp?.niveau];
+        if (!formationsNiveau) {
+          formationsNiveau = acc[formation.rncp?.niveau] = {
+            niveau: formation.rncp?.niveau,
+            label: niveauFormationByNiveau[formation.rncp?.niveau] ?? "Sans niveau",
+            formations: [],
+          };
+        }
+        formationsNiveau.formations.push(formation);
+        return acc;
+      }, {})
+    ).sort((a, b) => (a.niveau < b.niveau ? -1 : 1));
+  }, [props.formations]);
+
+  return (
+    <>
+      <Table className="stripped-bgcolor-even" variant="primary">
+        <Thead position="sticky" top="0" zIndex="1" background="#ffffff">
+          <Tr>
+            {formationsTableColumnsDefs.map((columnDef) => (
+              <Th key={columnDef.accessorKey} {...columnDef?.style}>
+                {columnDef.header()}
+              </Th>
+            ))}
+          </Tr>
+        </Thead>
+        <Tbody fontSize="zeta">
+          {niveauxAvecFormations.map((niveauAvecFormations) => (
+            <Fragment key={niveauAvecFormations.niveau}>
+              <Tr key={niveauAvecFormations.niveau}>
+                <Td
+                  background="#F5F5FE"
+                  color="bluefrance"
+                  fontWeight="bold"
+                  fontSize="zeta"
+                  colSpan={100}
+                  cursor="pointer"
+                  title="Cliquer pour afficher/masquer le détail"
+                  lineHeight="3em"
+                  borderBottom=".5px solid bluefrance"
+                  onClick={() => toggleExpand(niveauAvecFormations.niveau)}
+                >
+                  <ChevronDownIcon
+                    boxSize="6"
+                    transform={expandedNiveaux[niveauAvecFormations.niveau] ? "rotate(-180deg)" : ""}
+                    transition=".3s"
+                  />
+                  {niveauAvecFormations.label}
+                </Td>
+              </Tr>
+
+              {expandedNiveaux[niveauAvecFormations.niveau] &&
+                niveauAvecFormations.formations.map((formation) => (
+                  <Tr key={formation.rncp_code}>
+                    <Td>
+                      <Text>{formation.rncp?.intitule ?? "Fiche non trouvée"}</Text>
+                      <Text mt={2} color="#3A3A3A" fontSize="omega">
+                        RNCP&nbsp;:{" "}
+                        {formation.rncp_code ? (
+                          formation.rncp_code
+                        ) : (
+                          <Text as="span" color="red">
+                            INCONNU
+                          </Text>
+                        )}
+                      </Text>
+                    </Td>
+                    <Td>{formation.apprentis}</Td>
+                    <Td>{formation.inscritsSansContrat}</Td>
+                    <Td>{formation.rupturants}</Td>
+                    <Td>{formation.abandons}</Td>
+                  </Tr>
+                ))}
+            </Fragment>
+          ))}
+        </Tbody>
+      </Table>
+    </>
+  );
+}
+
+export default IndicateursEffectifsParFormationTable;


### PR DESCRIPTION
- Sur le dashboard d'un organisme, nouvelle section quand il y a des effectifs avec un tableau des effectifs par niveau et formation (RNCP)
- Maj du job RNCP pour ajouter plus d'informations. car c'est utilisé pour afficher le libellé pour un code RNCP notamment.

~Va rester en preview en attendant des feedbacks.~

En fonction des retours, il faudra :
- [x] ajouter quelques tests automatisés sur les nouvelles routes