### PR TITLE
fix: corrections configuration erp + scform (clé d'api)

### DIFF
--- a/server/src/common/actions/organisations.actions.ts
+++ b/server/src/common/actions/organisations.actions.ts
@@ -225,7 +225,13 @@ export async function getOrganisationOrganisme(ctx: AuthContext): Promise<WithId
       uai: organisationOF.uai as string,
     },
     {
-      projection: getOrganismeProjection(true),
+      projection: getOrganismeProjection({
+        viewContacts: true,
+        infoTransmissionEffectifs: true,
+        indicateursEffectifs: true,
+        effectifsNominatifs: true,
+        manageEffectifs: true,
+      }),
     }
   );
   if (!organisme) {

--- a/ui/modules/mon-espace/effectifs/ChoixERP.tsx
+++ b/ui/modules/mon-espace/effectifs/ChoixERP.tsx
@@ -20,11 +20,20 @@ const ChoixERP = ({ organisme, isMine }) => {
       erp: Yup.string().required("Requis"),
     }),
     onSubmit: async (submittedValues) => {
-      router.push(
-        isMine
-          ? `/effectifs/aide-configuration-erp?erp=${submittedValues.erp}`
-          : `/organismes/${organisme._id}/effectifs/aide-configuration-erp?erp=${submittedValues.erp}`
-      );
+      if (submittedValues.erp === "SCFORM") {
+        await configureOrganismeERP(organisme._id, {
+          erps: ["SCFORM"],
+          setup_step_courante: "COMPLETE",
+          mode_de_transmission: "API",
+        });
+        router.push("/mon-compte/erp");
+      } else {
+        router.push(
+          isMine
+            ? `/effectifs/aide-configuration-erp?erp=${submittedValues.erp}`
+            : `/organismes/${organisme._id}/effectifs/aide-configuration-erp?erp=${submittedValues.erp}`
+        );
+      }
     },
   });
   return (

--- a/ui/modules/mon-espace/effectifs/ChoixTransmission.tsx
+++ b/ui/modules/mon-espace/effectifs/ChoixTransmission.tsx
@@ -43,12 +43,8 @@ const ChoixTransmission = ({ organismeId, isMine = false }: ChoixTransmissionPro
             <Center h="10%">
               <Button
                 onClick={async () => {
-                  if (isMine) {
-                    router.push("/mon-compte/erp");
-                  } else {
-                    await configureOrganismeERP(organismeId, { mode_de_transmission: "API" });
-                    router.reload();
-                  }
+                  await configureOrganismeERP(organismeId, { mode_de_transmission: "API" });
+                  router.reload();
                 }}
                 size={"md"}
                 variant={"secondary"}

--- a/ui/modules/mon-espace/effectifs/EffectifsPage.tsx
+++ b/ui/modules/mon-espace/effectifs/EffectifsPage.tsx
@@ -80,10 +80,14 @@ const EffectifsPage = ({ isMine, organisme }: EffectifsPageProps) => {
     MainComponent = (
       <Effectifs nbDuplicates={duplicates?.length || 0} isMine={isMine} organismesEffectifs={organismesEffectifs} />
     );
-  } else if (organisme.mode_de_transmission === "API" && !organisme.erps?.length) {
+  } else if (!organisme.mode_de_transmission) {
+    MainComponent = <ChoixTransmission organismeId={organisme._id} isMine={isMine} />;
+  } else if (!organisme.erps?.length) {
     MainComponent = <ChoixERP isMine={isMine} organisme={organisme} />;
   } else {
-    MainComponent = <ChoixTransmission organismeId={organisme._id} isMine={isMine} />;
+    MainComponent = (
+      <Effectifs nbDuplicates={duplicates?.length || 0} isMine={isMine} organismesEffectifs={organismesEffectifs} />
+    );
   }
 
   return (


### PR DESCRIPTION
Remet en place le processus classique de configuration de l'ERP, sauf pour SCForm qui redirige l'utilisateur vers la configuration de la clé d'API.
Les changements d'état de configuration ne fonctionnaient pas à cause des derniers changements sur les permissions qui ne renvoie pas toujours toutes les informations de l'organisme.

Il y a un atelier prévu demain après-midi pour repenser le workflow de configuration ERP.