### PR TITLE
feat: sauvegarde de l'ERP à la connexion API

### DIFF
--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -707,6 +707,9 @@ export async function verifyOrganismeAPIKeyToUser(
         api_siret: verif.siret,
         api_configuration_date: new Date(),
       },
+      $addToSet: {
+        erps: verif.erp,
+      },
     }
   );
 


### PR DESCRIPTION
A la confirmation de configuration de clé d'API à l'URL `/connexion-api?siret=XXXXX&uai=YYYYY&erp=ZZZZ&api_key=TTTTT`, l'ERP est enregistré et ajouté dans la liste des ERP de l'organisme.