### PR TITLE
fix: correction d'un test flaky (mauvais siret)

### DIFF
--- a/server/tests/data/sampleEtablissements.ts
+++ b/server/tests/data/sampleEtablissements.ts
@@ -21,7 +21,7 @@ export default {
   },
   19040492100017: {
     uai: "0040533H",
-    siret: "1904049210001",
+    siret: "19040492100017",
     nom: "LYCEE POLYVALENT TEST",
     nature: NATURE_ORGANISME_DE_FORMATION.FORMATEUR,
     adresse: {


### PR DESCRIPTION
Idéalement, il faudrait supprimer tout random des tests pour être sûr de ce qu'on teste.
