### PR TITLE
fix: suppression de la dépendance à l'api entreprise step 1

### DIFF
--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -608,17 +608,6 @@ export async function findOrganismesByUAI(uai: string): Promise<Organisme[]> {
   return organismes;
 }
 
-export async function getOrganismeByUAIAndSIRETOrFallbackAPIEntreprise(
-  uai: string | null,
-  siret: string
-): Promise<Organisme> {
-  try {
-    return await getOrganismeByUAIAndSIRET(uai, siret);
-  } catch (err) {
-    return fetchFromAPIEntreprise(siret);
-  }
-}
-
 export async function getOrganismeByUAIAndSIRET(uai: string | null, siret: string): Promise<Organisme> {
   const organisme = await organismesDb().findOne({
     uai: uai as any,
@@ -628,27 +617,6 @@ export async function getOrganismeByUAIAndSIRET(uai: string | null, siret: strin
     throw Boom.badRequest("Aucun organisme trouvé");
   }
   return organisme;
-}
-
-/**
- * Renvoie les données principales d'un établissement de l'API Entreprise
- * Sert pour afficher sur l'UI à l'inscription
- */
-async function fetchFromAPIEntreprise(siret: string): Promise<any> {
-  const result: InfoSiret = await findDataFromSiret(siret);
-  if (result.messages.api_entreprise_status !== "OK") {
-    logger.warn({ module: "inscription", siret }, "aucun organisme trouvé sur api entreprise");
-    throw Boom.badRequest("Aucun organisme trouvé");
-  }
-  return {
-    uai: null,
-    siret: result.result.siret,
-    ferme: result.result.ferme,
-    raison_sociale: result.result.raison_sociale,
-    adresse: {
-      complete: result.result.adresse,
-    },
-  };
 }
 
 async function canConfigureOrganismeERP(ctx: AuthContext, organismeId: ObjectId): Promise<boolean> {

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -63,12 +63,12 @@ import {
   generateApiKeyForOrg,
   getOrganismeByAPIKey,
   getOrganismeById,
-  getOrganismeByUAIAndSIRETOrFallbackAPIEntreprise,
   getOrganismeDetails,
   listContactsOrganisme,
   listOrganismesFormateurs,
   searchOrganismes,
   verifyOrganismeAPIKeyToUser,
+  getOrganismeByUAIAndSIRET,
 } from "@/common/actions/organismes/organismes.actions";
 import { searchOrganismesFormations } from "@/common/actions/organismes/organismes.formations.actions";
 import { createSession } from "@/common/actions/sessions.actions";
@@ -215,7 +215,7 @@ function setupRoutes(app: Application) {
           uai: z.string().nullable(),
           siret: z.string(),
         });
-        return await getOrganismeByUAIAndSIRETOrFallbackAPIEntreprise(uai, siret);
+        return await getOrganismeByUAIAndSIRET(uai, siret);
       })
     )
     .use("/api/emails", emails()) // No versionning to be sure emails links are always working


### PR DESCRIPTION
Comme dit en IRL, seul le référentiel compte, et on ne doit pas chercher d'info via l'API entreprise.

Cependant, il y a plusieurs appels un peu partout, alors je propose de détricoter au fur et à mesure.
Première étape qui me parait pas trop risquée, faire sauter `getOrganismeByUAIAndSIRETOrFallbackAPIEntreprise` (et ses dépendances) vu que le nom est suffisamment explicite.

@sbenfares et @totakoko je vous ai mis tous les deux en relecteurs comme c'est un sujet dont on a parlé tous les 3.