### PR TITLE
refactor: simplifications des organisations OFA

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -67,6 +67,8 @@ fileignoreconfig:
   checksum: 71c60b9fc5f4d0308146235adde75e4df34ebac59539cef321403b5966b061ad
 - filename: server/src/jobs/seed/start/index.ts
   checksum: bd018d4dab141be955d6e546f817b0aa58edc733e9e562272765d8211d2f3015
+- filename: server/tests/integration/http/organisme.routes.test.ts
+  checksum: c2769caf07b18b075ef9164b3711b7af46b1fac6de841ba66e377a31bcacf070
 - filename: server/tests/integration/http/password.route.test.ts
   checksum: 5dac6833c2dc7f76b3c8b74c3e102968cfcb69bd1073046bcd434f44717f1384
 - filename: ui/modules/organismes/Televersement.tsx

--- a/server/src/common/actions/account.actions.ts
+++ b/server/src/common/actions/account.actions.ts
@@ -29,11 +29,7 @@ export async function register(registration: RegistrationSchema): Promise<{
 
   // on s'assure que l'organisme existe pour un OF
   const type = registration.organisation.type;
-  if (
-    type === "ORGANISME_FORMATION_FORMATEUR" ||
-    type === "ORGANISME_FORMATION_RESPONSABLE" ||
-    type === "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR"
-  ) {
+  if (type === "ORGANISME_FORMATION") {
     const { uai, siret } = registration.organisation;
     try {
       await getOrganismeByUAIAndSIRET(uai, siret);

--- a/server/src/common/actions/helpers/permissions-organisme.ts
+++ b/server/src/common/actions/helpers/permissions-organisme.ts
@@ -27,9 +27,7 @@ export async function buildOrganismePermissions(
   const organisme = await getOrganismeById(organismeId);
   const organisation = ctx.organisation;
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       const userOrganisme = await organismesDb().findOne({
         siret: organisation.siret,
         uai: organisation.uai as string,

--- a/server/src/common/actions/helpers/permissions.ts
+++ b/server/src/common/actions/helpers/permissions.ts
@@ -6,7 +6,7 @@ import logger from "@/common/logger";
 import { Organisme } from "@/common/model/@types/Organisme";
 import { organismesDb } from "@/common/model/collections";
 import { AuthContext } from "@/common/model/internal/AuthContext";
-import { OrganisationOrganismeFormation, OrganisationType } from "@/common/model/organisations.model";
+import { OrganisationOrganismeFormation } from "@/common/model/organisations.model";
 
 export async function requireOrganismeIndicateursAccess(ctx: AuthContext, organismeId: ObjectId): Promise<void> {
   if (!(await canAccessOrganismeIndicateurs(ctx, organismeId))) {
@@ -15,7 +15,7 @@ export async function requireOrganismeIndicateursAccess(ctx: AuthContext, organi
 }
 
 export function requireOrganisationOF(ctx: AuthContext): OrganisationOrganismeFormation {
-  if (!isOrganisationOF(ctx.organisation.type)) {
+  if (ctx.organisation.type !== "ORGANISME_FORMATION") {
     throw Boom.forbidden("Permissions invalides");
   }
   return (ctx as AuthContext<OrganisationOrganismeFormation>).organisation;
@@ -24,9 +24,7 @@ export function requireOrganisationOF(ctx: AuthContext): OrganisationOrganismeFo
 export async function getOrganismeRestriction(ctx: AuthContext): Promise<any> {
   const organisation = ctx.organisation;
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       const linkedOrganismesIds = await findOrganismesAccessiblesByOrganisationOF(
         ctx as AuthContext<OrganisationOrganismeFormation>
       );
@@ -67,9 +65,7 @@ export async function getOrganismeRestriction(ctx: AuthContext): Promise<any> {
 export async function getIndicateursOrganismesRestriction(ctx: AuthContext): Promise<any> {
   const organisation = ctx.organisation;
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       const linkedOrganismesIds = await findOrganismesAccessiblesByOrganisationOF(
         ctx as AuthContext<OrganisationOrganismeFormation>
       );
@@ -103,9 +99,7 @@ export async function getIndicateursOrganismesRestriction(ctx: AuthContext): Pro
 export async function getIndicateursEffectifsRestriction(ctx: AuthContext): Promise<any> {
   const organisation = ctx.organisation;
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       const linkedOrganismesIds = await findOrganismesAccessiblesByOrganisationOF(
         ctx as AuthContext<OrganisationOrganismeFormation>
       );
@@ -140,9 +134,7 @@ export async function getIndicateursEffectifsRestriction(ctx: AuthContext): Prom
 export async function getEffectifsAnonymesRestriction(ctx: AuthContext): Promise<any> {
   const organisation = ctx.organisation;
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       const linkedOrganismesIds = await findOrganismesAccessiblesByOrganisationOF(
         ctx as AuthContext<OrganisationOrganismeFormation>
       );
@@ -184,9 +176,7 @@ export async function getEffectifsAnonymesRestriction(ctx: AuthContext): Promise
 export async function getOrganismeIndicateursEffectifsRestriction(ctx: AuthContext): Promise<any> {
   const organisation = ctx.organisation;
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       const linkedOrganismesIds = await findOrganismesAccessiblesByOrganisationOF(
         ctx as AuthContext<OrganisationOrganismeFormation>
       );
@@ -231,9 +221,7 @@ export async function getOrganismeIndicateursEffectifsRestriction(ctx: AuthConte
 export async function getEffectifsNominatifsRestriction(ctx: AuthContext): Promise<any> {
   const organisation = ctx.organisation;
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       const linkedOrganismesIds = await findOrganismesAccessiblesByOrganisationOF(
         ctx as AuthContext<OrganisationOrganismeFormation>
       );
@@ -306,9 +294,7 @@ export async function canAccessOrganismeIndicateurs(ctx: AuthContext, organismeI
   const organisme = await getOrganismeById(organismeId);
   const organisation = ctx.organisation;
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       const linkedOrganismesIds = await findOrganismesAccessiblesByOrganisationOF(
         ctx as AuthContext<OrganisationOrganismeFormation>
       );
@@ -345,9 +331,7 @@ async function canAccessOrganismesFormateurs(ctx: AuthContext, organismeId: Obje
   const organisme = await getOrganismeById(organismeId);
   const organisation = ctx.organisation;
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       return organisme._id.equals(organismeId);
     }
 
@@ -371,20 +355,10 @@ async function canAccessOrganismesFormateurs(ctx: AuthContext, organismeId: Obje
   }
 }
 
-export function isOrganisationOF(type: OrganisationType): boolean {
-  return (
-    type === "ORGANISME_FORMATION_FORMATEUR" ||
-    type === "ORGANISME_FORMATION_RESPONSABLE" ||
-    type === "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR"
-  );
-}
-
 export async function canManageOrganismeEffectifs(ctx: AuthContext, organismeId: ObjectId): Promise<boolean> {
   const organisation = ctx.organisation;
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       const linkedOrganismesIds = await findOrganismesAccessiblesByOrganisationOF(
         ctx as AuthContext<OrganisationOrganismeFormation>
       );

--- a/server/src/common/actions/organisations.actions.ts
+++ b/server/src/common/actions/organisations.actions.ts
@@ -307,9 +307,7 @@ async function getInvitationById(ctx: AuthContext, invitationId: ObjectId): Prom
 export async function buildOrganisationLabel(organisationId: ObjectId): Promise<string> {
   const organisation = await getOrganisationById(organisationId);
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       const organisme = await organismesDb().findOne({
         siret: organisation.siret,
         ...(organisation.uai ? { uai: organisation.uai } : {}),

--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -7,7 +7,6 @@ import {
   findOrganismesAccessiblesByOrganisationOF,
   findOrganismesFormateursIdsOfOrganisme,
   getOrganismeRestriction,
-  isOrganisationOF,
 } from "@/common/actions/helpers/permissions";
 import { findDataFromSiret } from "@/common/actions/infoSiret.actions";
 import { getOrganisationOrganisme, listContactsOrganisation } from "@/common/actions/organisations.actions";
@@ -654,9 +653,7 @@ async function fetchFromAPIEntreprise(siret: string): Promise<any> {
 async function canConfigureOrganismeERP(ctx: AuthContext, organismeId: ObjectId): Promise<boolean> {
   const organisation = ctx.organisation;
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       const linkedOrganismesIds = await findOrganismesAccessiblesByOrganisationOF(
         ctx as AuthContext<OrganisationOrganismeFormation>
       );
@@ -735,13 +732,14 @@ export async function listContactsOrganisme(organismeId: ObjectId) {
 }
 
 export async function listOrganisationOrganismes(ctx: AuthContext): Promise<WithId<OrganismeWithPermissions>[]> {
-  const restrictionOwnOrganisme = isOrganisationOF(ctx.organisation.type)
-    ? {
-        _id: {
-          $ne: (await getOrganisationOrganisme(ctx))._id,
-        },
-      }
-    : {};
+  const restrictionOwnOrganisme =
+    ctx.organisation.type === "ORGANISME_FORMATION"
+      ? {
+          _id: {
+            $ne: (await getOrganisationOrganisme(ctx))._id,
+          },
+        }
+      : {};
   const organismes = (await organismesDb()
     .find(
       {
@@ -783,9 +781,7 @@ export async function listOrganismesFormateurs(
 async function getInfoTransmissionEffectifsCondition(ctx: AuthContext) {
   const organisation = ctx.organisation;
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       const linkedOrganismesIds = await findOrganismesAccessiblesByOrganisationOF(
         ctx as AuthContext<OrganisationOrganismeFormation>
       );

--- a/server/src/common/model/@types/Organisation.ts
+++ b/server/src/common/model/@types/Organisation.ts
@@ -5,9 +5,7 @@ export interface Organisation {
    * Type d'organisation (exemple DREETS, ACADEMIE, etc)
    */
   type:
-    | "ORGANISME_FORMATION_FORMATEUR"
-    | "ORGANISME_FORMATION_RESPONSABLE"
-    | "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR"
+    | "ORGANISME_FORMATION"
     | "TETE_DE_RESEAU"
     | "DREETS"
     | "DRAAF"

--- a/server/src/common/model/organisations.model.ts
+++ b/server/src/common/model/organisations.model.ts
@@ -9,9 +9,7 @@ import { date, object, objectId, string, stringOrNull } from "./json-schema/json
 
 // types en doublon avec l'UI
 export const organisationTypes = [
-  "ORGANISME_FORMATION_FORMATEUR",
-  "ORGANISME_FORMATION_RESPONSABLE",
-  "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR",
+  "ORGANISME_FORMATION",
   "TETE_DE_RESEAU",
   "DREETS",
   "DRAAF",
@@ -38,12 +36,8 @@ export type Organisation = NewOrganisation & { created_at: Date };
 
 export type OrganisationType = (typeof organisationTypes)[number];
 
-// OFRF, OFR, OFF
 export interface OrganisationOrganismeFormation {
-  type:
-    | "ORGANISME_FORMATION_FORMATEUR"
-    | "ORGANISME_FORMATION_RESPONSABLE"
-    | "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR";
+  type: "ORGANISME_FORMATION";
   siret: string;
   uai: string | null;
 }
@@ -81,19 +75,10 @@ export interface OrganisationAdministrateur {
   type: "ADMINISTRATEUR";
 }
 
-const OFTypeLabelByType = {
-  ORGANISME_FORMATION_FORMATEUR: "OF",
-  ORGANISME_FORMATION_RESPONSABLE: "OFR",
-  ORGANISME_FORMATION_RESPONSABLE_FORMATEUR: "OFRF",
-};
 export function getOrganisationLabel(organisation: NewOrganisation): string {
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
-      return `${OFTypeLabelByType[organisation.type]} UAI : ${organisation.uai || "Inconnu"} - SIRET : ${
-        organisation.siret
-      }`;
+    case "ORGANISME_FORMATION": {
+      return `OFA UAI : ${organisation.uai || "Inconnu"} - SIRET : ${organisation.siret}`;
     }
 
     case "TETE_DE_RESEAU":

--- a/server/src/common/validation/registrationSchema.ts
+++ b/server/src/common/validation/registrationSchema.ts
@@ -16,11 +16,7 @@ export const registrationSchema = {
   }),
   organisation: z.discriminatedUnion("type", [
     z.object({
-      type: z.enum([
-        "ORGANISME_FORMATION_FORMATEUR",
-        "ORGANISME_FORMATION_RESPONSABLE",
-        "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR",
-      ]),
+      type: z.literal("ORGANISME_FORMATION"),
       uai: z.string().nullable(),
       siret: z.string(),
     }),

--- a/server/src/db/migrations/20230320000001-create-organisations.ts
+++ b/server/src/db/migrations/20230320000001-create-organisations.ts
@@ -90,17 +90,11 @@ export const up = async (db: Db, _client: MongoClient) => {
       console.info(`Aucun organisme fiable trouvé pour ${user.email} (SIRET/UAI=${user.siret}/${user.uai})`);
     });
 
-    const natureOFToOrganisationType = {
-      responsable_formateur: "RESPONSABLE_FORMATEUR",
-      responsable: "RESPONSABLE",
-      formateur: "FORMATEUR",
-      inconnue: "FORMATEUR",
-    };
     await Promise.all(
       Object.values(organisations).map(async (organisation: any) => {
         const { insertedId } = await db.collection("organisations").insertOne(
           stripUndefinedFields({
-            type: `ORGANISME_FORMATION_${natureOFToOrganisationType[organisation.nature] || "FORMATEUR"}`,
+            type: "ORGANISME_FORMATION",
             siret: organisation.siret,
             uai: organisation.uai,
           })

--- a/server/src/db/migrations/20230921000000-simplify-organisations-ofa.ts
+++ b/server/src/db/migrations/20230921000000-simplify-organisations-ofa.ts
@@ -1,0 +1,20 @@
+import { Db } from "mongodb";
+
+export const up = async (db: Db) => {
+  await db.collection("organisations").updateMany(
+    {
+      type: {
+        $in: [
+          "ORGANISME_FORMATION_FORMATEUR",
+          "ORGANISME_FORMATION_RESPONSABLE",
+          "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR",
+        ],
+      },
+    },
+    {
+      $set: {
+        type: "ORGANISME_FORMATION",
+      },
+    }
+  );
+};

--- a/server/src/db/migrations/20230921000000-simplify-organisations-ofa.ts
+++ b/server/src/db/migrations/20230921000000-simplify-organisations-ofa.ts
@@ -15,6 +15,9 @@ export const up = async (db: Db) => {
       $set: {
         type: "ORGANISME_FORMATION",
       },
+    },
+    {
+      bypassDocumentValidation: true,
     }
   );
 };

--- a/server/src/jobs/seed/start/index.ts
+++ b/server/src/jobs/seed/start/index.ts
@@ -142,7 +142,7 @@ export const seedSampleUsers = async () => {
         has_accept_cgu_version: "",
       },
       organisation: {
-        type: "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR",
+        type: "ORGANISME_FORMATION",
         uai: "0010856A",
         siret: "77931004400028",
       },

--- a/server/tests/integration/http/organisme.routes.test.ts
+++ b/server/tests/integration/http/organisme.routes.test.ts
@@ -339,7 +339,7 @@ describe("Routes /organismes/:id", () => {
       await Promise.all([
         organisationsDb().insertOne({
           _id: new ObjectId(id(1)),
-          type: "ORGANISME_FORMATION_FORMATEUR",
+          type: "ORGANISME_FORMATION",
           uai: userOrganisme.uai as string,
           siret: userOrganisme.siret,
           created_at: getCurrentTime(),
@@ -444,7 +444,7 @@ describe("Routes /organismes/:id", () => {
                     {
                       _id: expect.any(String),
                       created_at: expect.any(String),
-                      email: "OF UAI : 0000000A - SIRET : 00000000000018@tdb.local",
+                      email: "OFA UAI : 0000000A - SIRET : 00000000000018@tdb.local",
                       fonction: "Responsable administratif",
                       nom: "Dupont",
                       prenom: "Jean",

--- a/server/tests/utils/permissions.ts
+++ b/server/tests/utils/permissions.ts
@@ -121,7 +121,7 @@ const profilsOrganisation = [
   {
     label: "OF cible",
     organisation: {
-      type: "ORGANISME_FORMATION_FORMATEUR",
+      type: "ORGANISME_FORMATION",
       uai: "0000000A",
       siret: "00000000000018",
     },
@@ -129,7 +129,7 @@ const profilsOrganisation = [
   {
     label: "OF non lié",
     organisation: {
-      type: "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR",
+      type: "ORGANISME_FORMATION",
       uai: "1111111B",
       siret: "11111111100006",
     },
@@ -137,7 +137,7 @@ const profilsOrganisation = [
   {
     label: "OF formateur",
     organisation: {
-      type: "ORGANISME_FORMATION_FORMATEUR",
+      type: "ORGANISME_FORMATION",
       uai: "0000000B",
       siret: "00000000000026",
     },
@@ -145,7 +145,7 @@ const profilsOrganisation = [
   {
     label: "OF responsable",
     organisation: {
-      type: "ORGANISME_FORMATION_RESPONSABLE",
+      type: "ORGANISME_FORMATION",
       uai: "0000000C",
       siret: "00000000000034",
     },

--- a/ui/common/internal/Organisation.ts
+++ b/ui/common/internal/Organisation.ts
@@ -4,9 +4,7 @@ import { TETE_DE_RESEAUX_BY_ID } from "@/common/constants/networks";
 
 // types en doublon avec le serveur
 export const organisationTypes = [
-  "ORGANISME_FORMATION_FORMATEUR",
-  "ORGANISME_FORMATION_RESPONSABLE",
-  "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR",
+  "ORGANISME_FORMATION",
   "TETE_DE_RESEAU",
   "DREETS",
   "DRAAF",
@@ -37,12 +35,8 @@ interface AbstractOrganisation {
   created_at: Date;
 }
 
-// OFRF, OFR, OFF
 export interface OrganisationOrganismeFormation extends AbstractOrganisation {
-  type:
-    | "ORGANISME_FORMATION_FORMATEUR"
-    | "ORGANISME_FORMATION_RESPONSABLE"
-    | "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR";
+  type: "ORGANISME_FORMATION";
   siret: string;
   uai: string;
 }
@@ -80,19 +74,10 @@ export interface OrganisationAdministrateur extends AbstractOrganisation {
   type: "ADMINISTRATEUR";
 }
 
-const OFTypeLabelByType = {
-  ORGANISME_FORMATION_FORMATEUR: "OF",
-  ORGANISME_FORMATION_RESPONSABLE: "OFR",
-  ORGANISME_FORMATION_RESPONSABLE_FORMATEUR: "OFRF",
-};
 export function getOrganisationLabel(organisation: Organisation): string {
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
-      return `${OFTypeLabelByType[organisation.type]} UAI : ${organisation.uai || "Inconnu"} - SIRET : ${
-        organisation.siret
-      }`;
+    case "ORGANISME_FORMATION": {
+      return `OFA UAI : ${organisation.uai || "Inconnu"} - SIRET : ${organisation.siret}`;
     }
 
     case "TETE_DE_RESEAU":

--- a/ui/components/Page/components/NavigationMenu.tsx
+++ b/ui/components/Page/components/NavigationMenu.tsx
@@ -16,9 +16,7 @@ import { Close, MenuFill, ParentGroupIcon } from "@/theme/components/icons";
 
 function getMesOrganismesLabelFromOrganisationType(type: OrganisationType): string {
   switch (type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR":
+    case "ORGANISME_FORMATION":
       return "Mes organismes";
 
     case "TETE_DE_RESEAU":
@@ -199,9 +197,7 @@ function NavBarAutreOrganisme({ organismeId }: { organismeId: string }): ReactEl
 
 function getNavBarComponent(auth?: AuthContext): ReactElement {
   switch (auth?.organisation?.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       return <NavBarOrganismeFormation />;
     }
 

--- a/ui/modules/auth/inscription/common.ts
+++ b/ui/modules/auth/inscription/common.ts
@@ -12,16 +12,3 @@ export type InscriptionOrganistionChildProps = {
   organisation?: NewOrganisation | null;
   setOrganisation: SetterOrganisation;
 };
-
-export const natureOFToOrganisationType = {
-  responsable_formateur: "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR",
-  responsable: "ORGANISME_FORMATION_RESPONSABLE",
-  formateur: "ORGANISME_FORMATION_FORMATEUR",
-  inconnue: "ORGANISME_FORMATION_FORMATEUR",
-} as const;
-
-export function getOrganisationTypeFromNature(
-  nature: keyof typeof natureOFToOrganisationType
-): (typeof natureOFToOrganisationType)[typeof nature] {
-  return natureOFToOrganisationType[nature] || "ORGANISME_FORMATION_FORMATEUR";
-}

--- a/ui/modules/auth/inscription/components/SearchBySIRETForm.tsx
+++ b/ui/modules/auth/inscription/components/SearchBySIRETForm.tsx
@@ -23,7 +23,7 @@ import { siretRegex } from "@/common/domain/siret";
 import { _post } from "@/common/httpClient";
 import { sleep } from "@/common/utils/misc";
 import Link from "@/components/Links/Link";
-import { getOrganisationTypeFromNature, InscriptionOrganistionChildProps } from "@/modules/auth/inscription/common";
+import { InscriptionOrganistionChildProps } from "@/modules/auth/inscription/common";
 
 import OrganismeDetails from "./OrganismeDetails";
 
@@ -132,7 +132,7 @@ export default function SearchBySIRETForm({ organisation, setOrganisation }: Ins
                     isDisabled={organismes[0].ferme || organisation}
                     onClick={() =>
                       setOrganisation({
-                        type: getOrganisationTypeFromNature(organismes[0].nature),
+                        type: "ORGANISME_FORMATION",
                         siret: organismes[0].siret,
                         uai: organismes[0].uai || null, // peut être absent si non présent dans le référentiel
                       })
@@ -170,7 +170,7 @@ export default function SearchBySIRETForm({ organisation, setOrganisation }: Ins
                             isDisabled={organisme.ferme}
                             onClick={() =>
                               setOrganisation({
-                                type: getOrganisationTypeFromNature(organisme.nature),
+                                type: "ORGANISME_FORMATION",
                                 siret: organisme.siret,
                                 uai: organisme.uai || null, // peut être absent si non présent dans le référentiel
                               })

--- a/ui/modules/auth/inscription/components/SearchByUAIForm.tsx
+++ b/ui/modules/auth/inscription/components/SearchByUAIForm.tsx
@@ -23,7 +23,7 @@ import { UAI_REGEX } from "@/common/domain/uai";
 import { _post } from "@/common/httpClient";
 import { sleep } from "@/common/utils/misc";
 import Link from "@/components/Links/Link";
-import { getOrganisationTypeFromNature, InscriptionOrganistionChildProps } from "@/modules/auth/inscription/common";
+import { InscriptionOrganistionChildProps } from "@/modules/auth/inscription/common";
 
 import OrganismeDetails from "./OrganismeDetails";
 
@@ -133,7 +133,7 @@ export default function SearchByUAIForm({ organisation, setOrganisation }: Inscr
                     isDisabled={organismes[0].ferme || organisation}
                     onClick={() =>
                       setOrganisation({
-                        type: getOrganisationTypeFromNature(organismes[0].nature),
+                        type: "ORGANISME_FORMATION",
                         siret: organismes[0].siret,
                         uai: organismes[0].uai,
                       })
@@ -171,7 +171,7 @@ export default function SearchByUAIForm({ organisation, setOrganisation }: Inscr
                             isDisabled={organisme.ferme}
                             onClick={() =>
                               setOrganisation({
-                                type: getOrganisationTypeFromNature(organisme.nature),
+                                type: "ORGANISME_FORMATION",
                                 siret: organisme.siret,
                                 uai: organisme.uai,
                               })

--- a/ui/modules/dashboard/DashboardOrganisme.tsx
+++ b/ui/modules/dashboard/DashboardOrganisme.tsx
@@ -36,7 +36,7 @@ import useAuth from "@/hooks/useAuth";
 import { DashboardWelcome } from "@/theme/components/icons/DashboardWelcome";
 
 import { ExternalLinks } from "../admin/OrganismeDetail";
-import { NewOrganisation, getOrganisationTypeFromNature } from "../auth/inscription/common";
+import { NewOrganisation } from "../auth/inscription/common";
 import { IndicateursEffectifs, IndicateursOrganismes } from "../models/indicateurs";
 import InfoTransmissionDonnees from "../organismes/InfoTransmissionDonnees";
 
@@ -54,10 +54,7 @@ const DashboardOrganisme = ({ organisme, modePublique }: Props) => {
   const { auth, organisationType } = useAuth();
 
   const { organisme: ownOrganisme } = useOrganisationOrganisme(
-    modePublique &&
-      (organisationType === "ORGANISME_FORMATION_FORMATEUR" ||
-        organisationType === "ORGANISME_FORMATION_RESPONSABLE" ||
-        organisationType === "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR")
+    modePublique && organisationType === "ORGANISME_FORMATION"
   );
   const isOFviewingItsPublicPage = modePublique && organisme?._id === ownOrganisme?._id;
 
@@ -190,7 +187,7 @@ const DashboardOrganisme = ({ organisme, modePublique }: Props) => {
                 ml={4}
                 onClick={async () => {
                   await _post<NewOrganisation>("/api/v1/admin/impersonate", {
-                    type: getOrganisationTypeFromNature(organisme.nature as any),
+                    type: "ORGANISME_FORMATION",
                     siret: organisme.siret,
                     uai: organisme.uai ?? (null as any), // peut être absent si non présent dans le référentiel
                   });
@@ -733,9 +730,7 @@ export default withAuth(DashboardOrganisme);
 export function getForbiddenErrorText(ctx: AuthContext): string {
   const organisation = ctx.organisation;
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR":
+    case "ORGANISME_FORMATION":
       return "Vous n’avez pas accès aux données de cet organisme.";
 
     case "TETE_DE_RESEAU":
@@ -765,9 +760,7 @@ function getIndicateursEffectifsPartielsMessage(ctx: AuthContext, organisme: Org
 
   const organisation = ctx.organisation;
   switch (organisation.type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       return false;
     }
 
@@ -803,5 +796,4 @@ function getIndicateursEffectifsPartielsMessage(ctx: AuthContext, organisme: Org
     case "ADMINISTRATEUR":
       return false;
   }
-  return false; // cas autre
 }

--- a/ui/modules/indicateurs/IndicateursForm.tsx
+++ b/ui/modules/indicateurs/IndicateursForm.tsx
@@ -216,16 +216,12 @@ function IndicateursForm(props: IndicateursFormProps) {
             value={effectifsFilters.organisme_academies}
             onChange={(academies) => updateState({ organisme_academies: academies })}
           />
-          {organisationType !== "ORGANISME_FORMATION_FORMATEUR" &&
-            organisationType !== "ORGANISME_FORMATION_RESPONSABLE" &&
-            organisationType !== "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR" && (
-              <FiltreOrganismeBassinEmploi
-                value={effectifsFilters.organisme_bassinsEmploi}
-                onChange={(organisme_bassinsEmploi) =>
-                  updateState({ organisme_bassinsEmploi: organisme_bassinsEmploi })
-                }
-              />
-            )}
+          {organisationType !== "ORGANISME_FORMATION" && (
+            <FiltreOrganismeBassinEmploi
+              value={effectifsFilters.organisme_bassinsEmploi}
+              onChange={(organisme_bassinsEmploi) => updateState({ organisme_bassinsEmploi: organisme_bassinsEmploi })}
+            />
+          )}
         </SimpleGrid>
         <Text fontWeight="700" textTransform="uppercase">
           Domaine d’activité
@@ -442,9 +438,7 @@ function getPermissionsEffectifsNominatifs(
   organisationType: OrganisationType
 ): boolean | Array<(typeof typesEffectifNominatif)[number]> {
   switch (organisationType) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR":
+    case "ORGANISME_FORMATION":
       // return true;
       return false; // FIXME temporaire, en attendant la PR qui va descendre les permissions des effectifs à aux formations
 
@@ -467,17 +461,13 @@ function getPermissionsEffectifsNominatifs(
     case "ADMINISTRATEUR":
       return true;
   }
-  return false;
 }
 
 function MessageBandeauIndicateurs({ organisationType }: { organisationType: OrganisationType }) {
   let text: string | null | JSX.Element = null;
 
   switch (organisationType) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-      break;
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR":
+    case "ORGANISME_FORMATION":
       text = (
         <>
           Retrouvez ici les indicateurs et les organismes dont les formations en apprentissage sont{" "}

--- a/ui/modules/indicateurs/permissions-onglet-graphique.ts
+++ b/ui/modules/indicateurs/permissions-onglet-graphique.ts
@@ -2,9 +2,7 @@ import { OrganisationType } from "@/common/internal/Organisation";
 
 export function canViewOngletIndicateursVueGraphique(organisationType: OrganisationType): boolean {
   switch (organisationType) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR":
+    case "ORGANISME_FORMATION":
     case "TETE_DE_RESEAU":
       return false;
 

--- a/ui/modules/organismes/ListeOrganismesPage.tsx
+++ b/ui/modules/organismes/ListeOrganismesPage.tsx
@@ -284,9 +284,7 @@ export default ListeOrganismesPage;
 
 function getHeaderTitleFromOrganisationType(type: OrganisationType) {
   switch (type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR":
+    case "ORGANISME_FORMATION":
       return "Mes organismes formateurs";
 
     case "TETE_DE_RESEAU":
@@ -312,9 +310,7 @@ function getHeaderTitleFromOrganisationType(type: OrganisationType) {
 
 function getTextContextFromOrganisationType(type: OrganisationType) {
   switch (type) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR":
+    case "ORGANISME_FORMATION":
       return "rattachés à votre organisme";
 
     case "TETE_DE_RESEAU":

--- a/ui/pages/auth/inscription/profil.tsx
+++ b/ui/pages/auth/inscription/profil.tsx
@@ -41,10 +41,7 @@ export const getServerSideProps = async (context) => ({ props: { ...(await getAu
 
 function OrganisationRibbon({ organisation }: { organisation: Organisation }) {
   const { toastError } = useToaster();
-  const isOrganismeFormation =
-    organisation.type === "ORGANISME_FORMATION_FORMATEUR" ||
-    organisation.type === "ORGANISME_FORMATION_RESPONSABLE" ||
-    organisation.type === "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR";
+  const isOrganismeFormation = organisation.type === "ORGANISME_FORMATION";
 
   const [organisationFormationLabel, setOrganisationFormationLabel] = useState("");
   const [isLoading, setIsLoading] = useState(true);
@@ -81,9 +78,7 @@ function OrganisationRibbon({ organisation }: { organisation: Organisation }) {
       <Box color="grey.800">
         {(() => {
           switch (organisation.type) {
-            case "ORGANISME_FORMATION_FORMATEUR":
-            case "ORGANISME_FORMATION_RESPONSABLE":
-            case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+            case "ORGANISME_FORMATION": {
               return (
                 <>
                   <Text fontSize="20px" fontWeight="bold">
@@ -224,10 +219,7 @@ function ProfileForm({ organisation, fixedEmail }: { organisation: Organisation;
   const passwordMinLength = organisation.type === "ADMINISTRATEUR" ? 20 : 12;
   const [showPasswordCharacters, setShowPasswordCharacters] = React.useState(false);
 
-  const isOrganismeFormation =
-    organisation.type === "ORGANISME_FORMATION_FORMATEUR" ||
-    organisation.type === "ORGANISME_FORMATION_RESPONSABLE" ||
-    organisation.type === "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR";
+  const isOrganismeFormation = organisation.type === "ORGANISME_FORMATION";
   return (
     <Formik
       initialValues={{

--- a/ui/pages/connexion-api.tsx
+++ b/ui/pages/connexion-api.tsx
@@ -212,13 +212,7 @@ const ConnexionAPIPage = () => {
       </Head>
 
       <Center w="100%" pt={[4, 8]} mb={5}>
-        <ConnexionAPIContent
-          authorizedOrganisationTypes={[
-            "ORGANISME_FORMATION_FORMATEUR",
-            "ORGANISME_FORMATION_RESPONSABLE",
-            "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR",
-          ]}
-        />
+        <ConnexionAPIContent authorizedOrganisationTypes={["ORGANISME_FORMATION"]} />
       </Center>
     </Page>
   );

--- a/ui/pages/enquete-sifa.tsx
+++ b/ui/pages/enquete-sifa.tsx
@@ -29,8 +29,4 @@ const PageEnqueteSIFADeMonOrganisme = () => {
   );
 };
 
-export default withAuth(PageEnqueteSIFADeMonOrganisme, [
-  "ORGANISME_FORMATION_FORMATEUR",
-  "ORGANISME_FORMATION_RESPONSABLE",
-  "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR",
-]);
+export default withAuth(PageEnqueteSIFADeMonOrganisme, ["ORGANISME_FORMATION"]);

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -48,9 +48,7 @@ function DashboardOwnOrganisme() {
 
 function getDashboardComponent(organisationType: OrganisationType) {
   switch (organisationType) {
-    case "ORGANISME_FORMATION_FORMATEUR":
-    case "ORGANISME_FORMATION_RESPONSABLE":
-    case "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR": {
+    case "ORGANISME_FORMATION": {
       return <DashboardOwnOrganisme />;
     }
 

--- a/ui/pages/organismes/[organismeId]/enquete-sifa.tsx
+++ b/ui/pages/organismes/[organismeId]/enquete-sifa.tsx
@@ -28,9 +28,4 @@ const PageEnqueteSIFADeSonOrganisme = () => {
   );
 };
 
-export default withAuth(PageEnqueteSIFADeSonOrganisme, [
-  "ORGANISME_FORMATION_FORMATEUR",
-  "ORGANISME_FORMATION_RESPONSABLE",
-  "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR",
-  "ADMINISTRATEUR",
-]);
+export default withAuth(PageEnqueteSIFADeSonOrganisme, ["ORGANISME_FORMATION", "ADMINISTRATEUR"]);


### PR DESCRIPTION
En gros :
      type: z.enum([
        "ORGANISME_FORMATION_FORMATEUR",
        "ORGANISME_FORMATION_RESPONSABLE",
        "ORGANISME_FORMATION_RESPONSABLE_FORMATEUR",
      ]),
  =>
      type: z.literal("ORGANISME_FORMATION")

Car cette distinction initialement basée sur la nature de l'organisme n'est pas utilisée. La nature n'est même pas à prendre en compte car il faut regarder les organismes formateurs pour connaître le type de relation...