### PR TITLE
fix: accepter les espaces, tirets et points et les supprimer silencieusement dans les siret

### DIFF
--- a/server/src/common/validation/utils/zodPrimitives.ts
+++ b/server/src/common/validation/utils/zodPrimitives.ts
@@ -47,7 +47,7 @@ const extensions = {
     ),
   siret: () =>
     z.preprocess(
-      (v: any) => (v ? String(v) : v),
+      (v: any) => (v ? String(v).replace(/\s+/g, "") : v),
       z.string().trim().regex(SIRET_REGEX, "SIRET invalide") // e.g 01234567890123
     ),
   uai: () => z.string().trim().regex(UAI_REGEX, "UAI invalide"), // e.g 0123456B

--- a/server/src/common/validation/utils/zodPrimitives.ts
+++ b/server/src/common/validation/utils/zodPrimitives.ts
@@ -47,7 +47,7 @@ const extensions = {
     ),
   siret: () =>
     z.preprocess(
-      (v: any) => (v ? String(v).replace(/\s+/g, "") : v),
+      (v: any) => (v ? String(v).replace(/[\s.-]+/g, "") : v),
       z.string().trim().regex(SIRET_REGEX, "SIRET invalide") // e.g 01234567890123
     ),
   uai: () => z.string().trim().regex(UAI_REGEX, "UAI invalide"), // e.g 0123456B

--- a/server/tests/integration/jobs/ingestion/process-ingestion.test.ts
+++ b/server/tests/integration/jobs/ingestion/process-ingestion.test.ts
@@ -417,7 +417,7 @@ describe("Processus d'ingestion", () => {
         contrat_date_fin_2: "2022-06-30T00:00:00.000Z",
         contrat_date_rupture_2: "2022-06-30T00:00:00.000Z",
         cause_rupture_contrat_2: "abandon",
-        siret_employeur: "12345678901234",
+        siret_employeur: "123 456 7890 1234",
         siret_employeur_2: "12345678901234",
         formation_presentielle: true,
         date_inscription_formation: "2021-09-01T00:00:00.000Z",


### PR DESCRIPTION
On a eu des gens qui ont envoyé des sirets formatés avec des espaces et des points dans le téléversement. Ça ne sert à rien de les embêter avec ça.