### PR TITLE
fix: tente de corriger mailpit avec chemin /smtp

### DIFF
--- a/.infra/docker-compose.preview-system.yml
+++ b/.infra/docker-compose.preview-system.yml
@@ -92,6 +92,7 @@ services:
     environment:
       - MP_DATA_FILE=/data/mailpit.db
       - MP_UI_AUTH_FILE=/auth/auth
+      - MP_WEBROOT=/smtp/
       - VIRTUAL_HOST=smtp.{{dns_name}}
       - VIRTUAL_PATH=/
       - VIRTUAL_PORT=8025

--- a/.infra/docker-compose.recette.yml
+++ b/.infra/docker-compose.recette.yml
@@ -25,6 +25,7 @@ services:
     environment:
       - MP_DATA_FILE=/data/mailpit.db
       - MP_UI_AUTH_FILE=/auth
+      - MP_WEBROOT=/smtp/
     logging:
       driver: "fluentd"
       options:


### PR DESCRIPTION
La PR #3233 n'a pas suffit. Il manquerait une configuration côté mailpit pour bien gérer le préfixe (sans slash). On pourrait sans doute s'en sortir avec que nginx, mais on ne va pas faire 150 essais / erreurs :upside_down_face: 