### PR TITLE
fix: affichage de la date en format français dans le rapport d'import excel

### DIFF
--- a/ui/modules/organismes/Televersement.tsx
+++ b/ui/modules/organismes/Televersement.tsx
@@ -20,6 +20,7 @@ import { useDropzone } from "react-dropzone";
 import XLSX from "xlsx";
 
 import { _post } from "@/common/httpClient";
+import { formatDateNumericDayMonthYear } from "@/common/utils/dateUtils";
 import parseExcelBoolean from "@/common/utils/parseExcelBoolean";
 import parseExcelDate from "@/common/utils/parseExcelDate";
 import { cyrb53Hash, normalize } from "@/common/utils/stringUtils";
@@ -63,6 +64,13 @@ function toEffectifsQueue(data: any[], organismeId: string) {
         (e.date_de_naissance_apprenant || "").trim()
     ),
   }));
+}
+
+function fromIsoLikeDateStringToFrenchDate(date: string) {
+  if (!date || String(date) !== date) return date;
+  if (date.match(/^(\d{4})-(\d{2})-(\d{2})$/)) {
+    return formatDateNumericDayMonthYear(date);
+  }
 }
 
 export default function Televersement({ organismeId, isMine }: { organismeId: string; isMine: boolean }) {
@@ -307,13 +315,20 @@ export default function Televersement({ organismeId, isMine }: { organismeId: st
                         if (error) {
                           return (
                             <Td key={key}>
-                              <Text color="grey.500">{row[key] || "Donnée manquante"}</Text>
+                              <Text color="grey.500">
+                                {(dateFields.includes(key) ? fromIsoLikeDateStringToFrenchDate(row[key]) : row[key]) ||
+                                  "Donnée manquante"}
+                              </Text>
                               <Text color="red.500">{error.message.replace("String", "Texte")}</Text>
                             </Td>
                           );
                         }
                       }
-                      return <Td key={key}>{row[key]}</Td>;
+                      return (
+                        <Td key={key}>
+                          {dateFields.includes(key) ? fromIsoLikeDateStringToFrenchDate(row[key]) : row[key]}
+                        </Td>
+                      );
                     })}
                   </Tr>
                 ))}


### PR DESCRIPTION
C'était en YYYY-MM-DD et un client a dit "au secours les dates sont inversées il y a un bug".
C'est plus joli en français (même si dans le fond on a un format pas très lisible (et yyyy-mm-dd c'est mieux) mais moins pire que l'infect mm/dd/yyyy qui est une abomination)

<img width="898" alt="Capture d’écran 2023-09-26 à 14 14 42" src="https://github.com/mission-apprentissage/flux-retour-cfas/assets/1575946/d188e8a4-3661-41bb-83f6-c70d00962745">
