### PR TITLE
fix: les UAI sont passés en majuscule lors de l'import (api toutes versions)

### DIFF
--- a/server/src/common/validation/utils/zodPrimitives.ts
+++ b/server/src/common/validation/utils/zodPrimitives.ts
@@ -52,7 +52,7 @@ const extensions = {
       (v: any) => (v ? String(v).replace(/[\s.-]+/g, "") : v),
       z.string().trim().regex(SIRET_REGEX, "SIRET invalide") // e.g 01234567890123
     ),
-  uai: () => z.string().trim().regex(UAI_REGEX, "UAI invalide"), // e.g 0123456B
+  uai: () => z.string().trim().toUpperCase().regex(UAI_REGEX, "UAI invalide"), // e.g 0123456B
   code_naf: () =>
     z.preprocess(
       (v: any) => (v ? String(v.replace(".", "")) : v), // parfois, le code naf contient un point


### PR DESCRIPTION
Voir: https://mission-apprentissage.slack.com/archives/C02FR2L1VB8/p1695803791717199