### PR TITLE
fix: vérification de l'UAI et siret dès la validation de l'import excel

### DIFF
--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -864,3 +864,39 @@ export function getOrganismeListProjection(
     },
   });
 }
+
+export async function getInvalidUaisFromDossierApprenant(data: any[]) {
+  if (!data) return [];
+  const uais = new Set<string>();
+  for (const dossier of data) {
+    uais.add(dossier.etablissement_formateur_uai);
+    uais.add(dossier.etablissement_lieu_de_formation_uai);
+    uais.add(dossier.etablissement_responsable_uai);
+  }
+  const invalidsUais: string[] = [];
+  for (const uai of uais) {
+    const organisme = await organismesDb().findOne({ uai: uai });
+    if (!organisme) {
+      invalidsUais.push(uai);
+    }
+  }
+  return invalidsUais;
+}
+
+export async function getInvalidSiretsFromDossierApprenant(data: any[]) {
+  if (!data) return [];
+  const sirets = new Set<string>();
+  for (const dossier of data) {
+    sirets.add(dossier.etablissement_formateur_siret);
+    sirets.add(dossier.etablissement_lieu_de_formation_siret);
+    sirets.add(dossier.etablissement_responsable_siret);
+  }
+  const invalidsSirets: string[] = [];
+  for (const siret of sirets) {
+    const organisme = await organismesDb().findOne({ siret: siret });
+    if (!organisme) {
+      invalidsSirets.push(siret);
+    }
+  }
+  return invalidsSirets;
+}

--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -13,6 +13,7 @@ import { findDataFromSiret } from "@/common/actions/infoSiret.actions";
 import { getOrganisationOrganisme, listContactsOrganisation } from "@/common/actions/organisations.actions";
 import { getMetiersBySiret } from "@/common/apis/apiLba";
 import logger from "@/common/logger";
+import { EffectifsQueue } from "@/common/model/@types/EffectifsQueue";
 import { Organisme } from "@/common/model/@types/Organisme";
 import { organismesDb, effectifsDb, organisationsDb } from "@/common/model/collections";
 import { AuthContext } from "@/common/model/internal/AuthContext";
@@ -865,13 +866,12 @@ export function getOrganismeListProjection(
   });
 }
 
-export async function getInvalidUaisFromDossierApprenant(data: any[]) {
-  if (!data) return [];
+export async function getInvalidUaisFromDossierApprenant(data: Partial<EffectifsQueue>[]): Promise<string[]> {
   const uais = new Set<string>();
   for (const dossier of data) {
-    uais.add(dossier.etablissement_formateur_uai);
-    uais.add(dossier.etablissement_lieu_de_formation_uai);
-    uais.add(dossier.etablissement_responsable_uai);
+    if (dossier.etablissement_formateur_uai) uais.add(dossier.etablissement_formateur_uai);
+    if (dossier.etablissement_lieu_de_formation_uai) uais.add(dossier.etablissement_lieu_de_formation_uai);
+    if (dossier.etablissement_responsable_uai) uais.add(dossier.etablissement_responsable_uai);
   }
   const invalidsUais: string[] = [];
   for (const uai of uais) {
@@ -883,13 +883,12 @@ export async function getInvalidUaisFromDossierApprenant(data: any[]) {
   return invalidsUais;
 }
 
-export async function getInvalidSiretsFromDossierApprenant(data: any[]) {
-  if (!data) return [];
+export async function getInvalidSiretsFromDossierApprenant(data: Partial<EffectifsQueue>[]): Promise<string[]> {
   const sirets = new Set<string>();
   for (const dossier of data) {
-    sirets.add(dossier.etablissement_formateur_siret);
-    sirets.add(dossier.etablissement_lieu_de_formation_siret);
-    sirets.add(dossier.etablissement_responsable_siret);
+    if (dossier.etablissement_formateur_siret) sirets.add(dossier.etablissement_formateur_siret);
+    if (dossier.etablissement_lieu_de_formation_siret) sirets.add(dossier.etablissement_lieu_de_formation_siret);
+    if (dossier.etablissement_responsable_siret) sirets.add(dossier.etablissement_responsable_siret);
   }
   const invalidsSirets: string[] = [];
   for (const siret of sirets) {

--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -875,7 +875,7 @@ export async function getInvalidUaisFromDossierApprenant(data: any[]) {
   }
   const invalidsUais: string[] = [];
   for (const uai of uais) {
-    const organisme = await organismesDb().findOne({ uai: uai });
+    const organisme = await organismesDb().findOne({ uai: { $eq: uai } });
     if (!organisme) {
       invalidsUais.push(uai);
     }
@@ -893,7 +893,7 @@ export async function getInvalidSiretsFromDossierApprenant(data: any[]) {
   }
   const invalidsSirets: string[] = [];
   for (const siret of sirets) {
-    const organisme = await organismesDb().findOne({ siret: siret });
+    const organisme = await organismesDb().findOne({ siret: { $eq: siret } });
     if (!organisme) {
       invalidsSirets.push(siret);
     }

--- a/server/src/common/validation/dossierApprenantSchemaV3.ts
+++ b/server/src/common/validation/dossierApprenantSchemaV3.ts
@@ -113,6 +113,39 @@ export const dossierApprenantSchemaV3WithMoreRequiredFields = () => {
   );
 };
 
+export async function dossierApprenantSchemaV3WithMoreRequiredFieldsValidatingUAISiret(
+  invalidsUais: string[],
+  invalidsSirets: string[]
+) {
+  const validateUAI = (uai: string) => !invalidsUais.includes(uai);
+  const validateSiret = (siret: string) => !invalidsSirets.includes(siret);
+  const messageUai = "UAI non valide";
+  const messageSiret = "Siret non valide";
+
+  return dossierApprenantSchemaV3WithMoreRequiredFields().merge(
+    z.object({
+      etablissement_responsable_uai: primitivesV1.etablissement_responsable.uai.refine(validateUAI, {
+        message: messageUai,
+      }),
+      etablissement_responsable_siret: primitivesV1.etablissement_responsable.siret.refine(validateSiret, {
+        message: messageSiret,
+      }),
+      etablissement_formateur_uai: primitivesV1.etablissement_formateur.uai.refine(validateUAI, {
+        message: messageUai,
+      }),
+      etablissement_formateur_siret: primitivesV1.etablissement_formateur.siret.refine(validateSiret, {
+        message: messageSiret,
+      }),
+      etablissement_lieu_de_formation_uai: primitivesV1.etablissement_lieu_de_formation.uai.refine(validateUAI, {
+        message: messageUai,
+      }),
+      etablissement_lieu_de_formation_siret: primitivesV1.etablissement_lieu_de_formation.siret.refine(validateSiret, {
+        message: messageSiret,
+      }),
+    })
+  );
+}
+
 export type DossierApprenantSchemaV3ZodType = z.input<ReturnType<typeof dossierApprenantSchemaV3>>;
 
 export default dossierApprenantSchemaV3;

--- a/server/src/common/validation/dossierApprenantSchemaV3.ts
+++ b/server/src/common/validation/dossierApprenantSchemaV3.ts
@@ -113,7 +113,7 @@ export const dossierApprenantSchemaV3WithMoreRequiredFields = () => {
   );
 };
 
-export async function dossierApprenantSchemaV3WithMoreRequiredFieldsValidatingUAISiret(
+export function dossierApprenantSchemaV3WithMoreRequiredFieldsValidatingUAISiret(
   invalidsUais: string[],
   invalidsSirets: string[]
 ) {

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -66,6 +66,8 @@ import {
   searchOrganismes,
   verifyOrganismeAPIKeyToUser,
   getOrganismeByUAIAndSIRET,
+  getInvalidSiretsFromDossierApprenant,
+  getInvalidUaisFromDossierApprenant,
 } from "@/common/actions/organismes/organismes.actions";
 import { searchOrganismesFormations } from "@/common/actions/organismes/organismes.formations.actions";
 import { createSession } from "@/common/actions/sessions.actions";
@@ -84,7 +86,7 @@ import stripNullProperties from "@/common/utils/stripNullProperties";
 import { passwordSchema, validateFullObjectSchema, validateFullZodObjectSchema } from "@/common/utils/validationUtils";
 import { SReqPostVerifyUser } from "@/common/validation/ApiERPSchema";
 import { configurationERPSchema } from "@/common/validation/configurationERPSchema";
-import { dossierApprenantSchemaV3WithMoreRequiredFields } from "@/common/validation/dossierApprenantSchemaV3";
+import { dossierApprenantSchemaV3WithMoreRequiredFieldsValidatingUAISiret } from "@/common/validation/dossierApprenantSchemaV3";
 import loginSchemaLegacy from "@/common/validation/loginSchemaLegacy";
 import objectIdSchema from "@/common/validation/objectIdSchema";
 import organismeOrFormationSearchSchema from "@/common/validation/organismeOrFormationSearchSchema";
@@ -475,7 +477,12 @@ function setupRoutes(app: Application) {
             "/validate",
             returnResult(async (req) => {
               const data = await z
-                .array(dossierApprenantSchemaV3WithMoreRequiredFields())
+                .array(
+                  await dossierApprenantSchemaV3WithMoreRequiredFieldsValidatingUAISiret(
+                    await getInvalidUaisFromDossierApprenant(req.body),
+                    await getInvalidSiretsFromDossierApprenant(req.body)
+                  )
+                )
                 .safeParseAsync(
                   Array.isArray(req.body) ? req.body.map((dossier) => stripNullProperties(dossier)) : req.body
                 );

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -478,9 +478,9 @@ function setupRoutes(app: Application) {
             returnResult(async (req) => {
               const data = await z
                 .array(
-                  await dossierApprenantSchemaV3WithMoreRequiredFieldsValidatingUAISiret(
-                    await getInvalidUaisFromDossierApprenant(req.body),
-                    await getInvalidSiretsFromDossierApprenant(req.body)
+                  dossierApprenantSchemaV3WithMoreRequiredFieldsValidatingUAISiret(
+                    await getInvalidUaisFromDossierApprenant(Array.isArray(req.body) ? req.body : []),
+                    await getInvalidSiretsFromDossierApprenant(Array.isArray(req.body) ? req.body : [])
                   )
                 )
                 .safeParseAsync(


### PR DESCRIPTION
On vérifie que l'UAI et le siret sont valides (c'est à dire qu'ils sont présents dans la plateforme).

Je suis moyennement content de mon approche MAIS je la trouve pas mal quand même, parce qu'il faut que ça fonctionne avec Zod et que ça souligne au bon endroit.

En gros la limite, c'est que ça ne valide pas le couple UAI siret, mais chacun indépendamment. Mais ça permet d'avoir les erreurs bien affichées au bon endroit.

Et surtout les problèmes qu'on a actuellement, ce n'est pas du tout sur le couple mais sur des erreurs de fautes de frappes.

J'ai fait à la va-vite parce que j'ai ZERO temps aujourd'hui 😭 😭 😭 