### PR TITLE
fix: afficher jamais connecté sur les utilisateurs plutôt que invalid date

### DIFF
--- a/ui/pages/admin/users/index.tsx
+++ b/ui/pages/admin/users/index.tsx
@@ -96,7 +96,11 @@ const UsersColumns: AccessorKeyColumnDef<UserNormalized>[] = [
       <>
         <Text fontSize="sm">Créé le {formatDateNumericDayMonthYear(row.original?.created_at)}</Text>
         <Text fontSize="xs" color="#777">
-          Dernière connexion le {formatDateNumericDayMonthYear(row.original?.last_connection)}
+          {row.original?.last_connection ? (
+            <>Dernière connexion le {formatDateNumericDayMonthYear(row.original?.last_connection)}</>
+          ) : (
+            <>Jamais connecté</>
+          )}
         </Text>
       </>
     ),


### PR DESCRIPTION
Et merde, il y a un accent dans la branche. Je crois que ça ne pose pas problème, mais github me le signale.