### PR TITLE
fix: répare le lien vers l'arbo rome en local

### DIFF
--- a/ui/common/httpClient.ts
+++ b/ui/common/httpClient.ts
@@ -73,6 +73,20 @@ const getHttpsAgent = () => {
     : undefined;
 };
 
+/**
+ * Récupère un fichier exposé par l'UI.
+ * Nécessaire pour l'environnement local, car les ports sont maintenant exposés.
+ */
+export const _getUI = async <T = any>(path: string, options?: AxiosRequestConfig<any>): Promise<T> => {
+  const response = await axios.get(path, {
+    headers: getHeaders(),
+    validateStatus: () => true,
+    httpsAgent: getHttpsAgent(),
+    ...options,
+  });
+  return handleResponse<T>(path, response);
+};
+
 export const _get = async <T = any>(path: string, options?: AxiosRequestConfig<any>): Promise<T> => {
   const response = await axios.get(`${publicConfig.baseUrl}${path}`, {
     headers: getHeaders(),

--- a/ui/modules/indicateurs/filters/FiltreFormationSecteurProfessionnel.tsx
+++ b/ui/modules/indicateurs/filters/FiltreFormationSecteurProfessionnel.tsx
@@ -16,7 +16,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import TreeView, { flattenTree } from "react-accessible-treeview";
 
-import { _get, _post } from "@/common/httpClient";
+import { _get, _getUI, _post } from "@/common/httpClient";
 import { normalize } from "@/common/utils/stringUtils";
 import InputLegend from "@/components/InputLegend/InputLegend";
 import { ArrowTriangleDownIcon } from "@/modules/dashboard/icons";
@@ -45,7 +45,7 @@ const FiltreFormationSecteurProfessionnel = (props: FiltreFormationSecteurProfes
   const { data: famillesMetiers, isFetching: isLoading } = useQuery<RomeNode[]>(
     ["arborescence-rome-14-06-2021.json"],
     async () => {
-      const famillersMetiers = await _get<FamilleMetier[]>("/arborescence-rome-14-06-2021.json");
+      const famillersMetiers = await _getUI<FamilleMetier[]>("/arborescence-rome-14-06-2021.json");
       return famillersMetiers.map((familleMetiers) => normalizeRomeNodeInPlace(familleMetiers));
     },
     {


### PR DESCRIPTION
Suite à la nouvelle infra, les ports sont maintenant exposés. Or les requêtes sont toutes préfixées par l'URL du serveur.
Donc on va chercher explicitement le fichier sans préfixe serveur pour accéder à l'UI.

Pour tester avant / après, c'est sur la page Mes / Ses indicateurs en local.
Avant, erreur 404.
Après, le fichier est téléchargé.