### PR TITLE
fix: ne pas afficher d'erreurs trompeuses pour les uai siret

### DIFF
--- a/server/src/common/validation/dossierApprenantSchemaV3.ts
+++ b/server/src/common/validation/dossierApprenantSchemaV3.ts
@@ -118,8 +118,8 @@ export function dossierApprenantSchemaV3WithMoreRequiredFieldsValidatingUAISiret
   invalidsUais: string[],
   invalidsSirets: string[]
 ) {
-  const validateUAI = (uai: string) => !invalidsUais.includes(uai);
-  const validateSiret = (siret: string) => !invalidsSirets.includes(siret);
+  const validateUAI = (uai: string) => !invalidsUais.includes(String(uai));
+  const validateSiret = (siret: string) => !invalidsSirets.includes(String(siret));
   const messageUai = "UAI non valide";
   const messageSiret = "Siret non valide";
 


### PR DESCRIPTION
Donc je constate bien le problème, J'ai des preprocess qui ne se font pas vraiment (par exemple si j'ai une autre erreur dans la ligne, alors le preprocess n'est pas fait avant le refine). On dirait qu'il y a des problèmes actuellement : https://github.com/colinhacks/zod/pull/2719#issuecomment-1750809994 et surtout https://github.com/colinhacks/zod/issues/2671

En attendant que Zod fix, je limite les dégats en mettant quand même en string.