### PR TITLE
feat(server): migration de suppression des objectId dans le champ ERPs des organismes

### DIFF
--- a/server/src/db/migrations/20231025075713-remove-erps-value-objectId-in-organismes.ts
+++ b/server/src/db/migrations/20231025075713-remove-erps-value-objectId-in-organismes.ts
@@ -1,0 +1,15 @@
+import { Db, ObjectId } from "mongodb";
+
+export const up = async (db: Db) => {
+  const collection = db.collection("organismes");
+
+  const distinctErpsValuesToRemove = (await collection.distinct("erps", { erps: { $exists: true, $ne: [] } })).filter(
+    (erpValue) => ObjectId.isValid(erpValue)
+  );
+
+  await Promise.all(
+    distinctErpsValuesToRemove.map(async (erpValueToRemove) => {
+      await collection.updateMany({ erps: erpValueToRemove }, { $pull: { erps: erpValueToRemove } });
+    })
+  );
+};


### PR DESCRIPTION
Ajout d'une migration qui supprime tous les champs ERPs de type ObjectId