### PR TITLE
feat: ajout collection ROME

### DIFF
--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -388,9 +388,12 @@ program
   .option("-q, --queued", "Run job asynchronously", false)
   .action(createJobAction("hydrate:formations-catalogue"));
 
-/**
- * Job de remplissage des formations du catalogue
- */
+program
+  .command("hydrate:rome")
+  .description("Remplissage du ROME")
+  .option("-q, --queued", "Run job asynchronously", false)
+  .action(createJobAction("hydrate:rome"));
+
 program
   .command("hydrate:rncp")
   .description("Remplissage du RNCP")

--- a/server/src/common/model/collections.ts
+++ b/server/src/common/model/collections.ts
@@ -35,6 +35,7 @@ import OrganismesModelDescriptor from "./organismes.model";
 import OrganismesReferentielModelDescriptor from "./organismesReferentiel.model";
 import OrganismesSolteaModelDescriptor from "./organismesSoltea.model";
 import rncpModelDescriptor from "./rncp.model";
+import romeModelDescriptor, { IRome } from "./rome.model";
 import usersModelDescriptor from "./users.model";
 import usersMigrationModelDescriptor from "./usersMigration.model";
 
@@ -57,6 +58,7 @@ export const modelDescriptors = [
   fiabilisationUaiSiretModelDescriptor,
   bassinsEmploiDescriptor,
   contratsDecaModelDescriptor,
+  romeModelDescriptor,
   rncpModelDescriptor,
 ];
 
@@ -82,5 +84,6 @@ export const fiabilisationUaiSiretDb = () =>
 export const bassinsEmploiDb = () => getDbCollection<BassinsEmploi>(bassinsEmploiDescriptor.collectionName);
 export const organismesSolteaDb = () =>
   getDbCollection<OrganismeSoltea>(OrganismesSolteaModelDescriptor.collectionName);
+export const romeDb = () => getDbCollection<IRome>(romeModelDescriptor.collectionName);
 export const rncpDb = () => getDbCollection<Rncp>(rncpModelDescriptor.collectionName);
 export const contratsDecaDb = () => getDbCollection<ContratDeca>(contratsDecaModelDescriptor.collectionName);

--- a/server/src/common/model/common.ts
+++ b/server/src/common/model/common.ts
@@ -2,7 +2,7 @@ import { ObjectId } from "bson";
 import type { CreateIndexesOptions, IndexSpecification } from "mongodb";
 import { z, ZodType } from "zod";
 
-export type CollectionName = "users" | "jobs";
+export type CollectionName = "users" | "jobs" | "rome";
 
 export interface IModelDescriptor {
   zod: ZodType;

--- a/server/src/common/model/rome.model.ts
+++ b/server/src/common/model/rome.model.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+import { IModelDescriptor, zObjectId } from "./common";
+
+export const romeSchema = z
+  .object({
+    code: z.string().describe("Code ROME"),
+    label_fiche: z.string().describe("Label fiche métier"),
+    label_domaine: z.string().describe("Label domaine professionnel"),
+    label_famille: z.string().describe("Label famille de métier"),
+  })
+  .strict();
+
+export type IRome = z.output<typeof romeSchema>;
+
+export default {
+  collectionName: "rome",
+  indexes: [[{ code: 1 }, { unique: true }]],
+  zod: romeSchema.merge(z.object({ _id: zObjectId })).strict(),
+} as IModelDescriptor;

--- a/server/src/jobs/hydrate/hydrate-rome.ts
+++ b/server/src/jobs/hydrate/hydrate-rome.ts
@@ -1,0 +1,142 @@
+import { PromisePool } from "@supercharge/promise-pool";
+import axios from "axios";
+import { read, utils } from "xlsx";
+
+import parentLogger from "@/common/logger";
+import { romeDb } from "@/common/model/collections";
+import { IRome } from "@/common/model/rome.model";
+
+const logger = parentLogger.child({
+  module: "job:hydrate:rome",
+});
+
+/*
+  Ce job construit l'arborescence des domaines et sous-domaines d'activité à partir du excel officiel téléchargeable
+  depuis la page https://www.pole-emploi.fr/employeur/vos-recrutements/le-rome-et-les-fiches-metiers.html
+
+  Étapes :
+  - récupération du fichier https://www.pole-emploi.fr/files/live/sites/PE/files/ROME_ArboPrincipale.xlsx
+  - transformation pour récupérer chaque fiche métier avec les labels des catégories parentes
+  - écriture dans la collection rome
+
+  Note : ce fichier est l'équivalent du fichier `server/scripts/extract-arborescence-rome.ts` utilisé pour généré le fichier static frontend.
+*/
+export async function hydrateROME() {
+  logger.info("récupération du fichier ROME_ArboPrincipale.xlsx");
+  const res = await axios.get("https://www.pole-emploi.fr/files/live/sites/PE/files/ROME_ArboPrincipale.xlsx", {
+    responseType: "arraybuffer",
+  });
+  if (res.status !== 200) {
+    throw new Error(`Invalid response status. Expected 200 but received ${res.status}`);
+  }
+
+  logger.info("parsing du fichier");
+  const workbook = read(res.data);
+  const arboPrincipaleSheetName = workbook.SheetNames.find((name) => name.includes("Arbo Principale"));
+  if (!arboPrincipaleSheetName) {
+    throw new Error(`Onglet Arbo Principale non trouvée. Le fichier a sans doute changé de format.`);
+  }
+  const arboPrincipaleSheet = workbook.Sheets[arboPrincipaleSheetName];
+
+  const rawJsonData = utils
+    .sheet_to_json<Record<"familleMetier" | "domaineProfessionnel" | "numeroOrdre" | "name" | "codeOGR", any>>(
+      arboPrincipaleSheet,
+      {
+        // exemple : A	11	01	Chauffeur / Chauffeuse de machines agricoles 11987
+        header: ["familleMetier", "domaineProfessionnel", "numeroOrdre", "name", "codeOGR"],
+      }
+    )
+    .slice(1); // removes the header
+
+  logger.info("transformation des données");
+
+  const arborescenceRome = rawJsonData.reduce((acc, row) => {
+    // conditions ordonnées de la plus restrictive à la moins restrictive
+    if (row.codeOGR !== " ") {
+      // pas besoin des appellations de métiers
+      // acc[row.familleMetier].children[row.domaineProfessionnel].children[row.numeroOrdre].children[row.codeOGR] = {
+      //   id: `${row.familleMetier}${row.domaineProfessionnel}${row.numeroOrdre}-${row.codeOGR}`,
+      //   codeOGR: row.codeOGR,
+      //   name: row.name,
+      // };
+    } else if (row.numeroOrdre !== " ") {
+      acc[row.familleMetier].children[row.domaineProfessionnel].children[row.numeroOrdre] = {
+        id: `${row.familleMetier}${row.domaineProfessionnel}${row.numeroOrdre}`,
+        name: row.name,
+        // children: {},
+      };
+    } else if (row.domaineProfessionnel !== " ") {
+      acc[row.familleMetier].children[row.domaineProfessionnel] = {
+        id: `${row.familleMetier}${row.domaineProfessionnel}`,
+        name: row.name,
+        children: {},
+      };
+    } else {
+      acc[row.familleMetier] = {
+        id: row.familleMetier,
+        name: row.name,
+        children: {},
+      };
+    }
+    return acc;
+  }, {});
+
+  // tri et transformation en tableau
+  const famillesMetiers = Object.keys(arborescenceRome)
+    .sort()
+    .map((key) => {
+      const famille = arborescenceRome[key];
+      return {
+        ...famille,
+        children: Object.keys(famille.children)
+          .sort()
+          .map((key) => {
+            const domaine = famille.children[key];
+            return {
+              ...domaine,
+              children: Object.keys(domaine.children)
+                .sort()
+                .map((key) => domaine.children[key]),
+            };
+          }),
+      };
+    });
+
+  const fichesROME: IRome[] = famillesMetiers
+    .flatMap((famille) => {
+      return famille.children.map((domaine) => {
+        return domaine.children.map(
+          (fiche) =>
+            ({
+              code: fiche.id,
+              label_fiche: fiche.name,
+              label_domaine: domaine.name,
+              label_famille: famille.name,
+            }) satisfies IRome
+        );
+      });
+    })
+    .flat();
+
+  logger.info({ count: fichesROME.length }, "import des fiches rome");
+
+  await PromisePool.for(fichesROME)
+    .withConcurrency(50)
+    .handleError(async (error) => {
+      logger.error({ error: error }, "item error");
+      throw error;
+    })
+    .process(async ({ code, ...fiche }) => {
+      await romeDb().updateOne(
+        {
+          code,
+        },
+        {
+          $set: fiche,
+        },
+        {
+          upsert: true,
+        }
+      );
+    });
+}

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -20,6 +20,7 @@ import { hydrateEffectifsComputed } from "./hydrate/effectifs/hydrate-effectifs-
 import { hydrateEffectifsFormationsNiveaux } from "./hydrate/effectifs/hydrate-effectifs-formations-niveaux";
 import { hydrateFormationsCatalogue } from "./hydrate/hydrate-formations-catalogue";
 import { hydrateRNCP } from "./hydrate/hydrate-rncp";
+import { hydrateROME } from "./hydrate/hydrate-rome";
 import { hydrateOpenApi } from "./hydrate/open-api/hydrate-open-api";
 import { hydrateOrganismesEffectifsCount } from "./hydrate/organismes/hydrate-effectifs_count";
 import { hydrateOrganismesFromReferentiel } from "./hydrate/organismes/hydrate-organismes";
@@ -169,6 +170,8 @@ export async function runJob(job: IJobsCronTask | IJobsSimple): Promise<number> 
         return hydrateFromReferentiel();
       case "hydrate:formations-catalogue":
         return hydrateFormationsCatalogue();
+      case "hydrate:rome":
+        return hydrateROME();
       case "hydrate:rncp":
         return hydrateRNCP();
       case "hydrate:organismes-formations":


### PR DESCRIPTION
pour les analyses Metabase de @felixat13


Nouvelle commande / job :
- `hydrate:rome` : qui ajoute dans la collection `rome` les fiches métiers du [ROME](https://www.pole-emploi.org/opendata/repertoire-operationnel-des-meti.html?type=article) avec les labels des catégories parentes.

PS: J'ai utilisé zod pour gérer le schéma de validation mongo et les types TS (calqué sur les Jobs). On va sans doute pouvoir migrer petit à petit chaque collection...