### PR TITLE
test: utilisation expect(...).resolves pour les promesses

### DIFF
--- a/server/tests/integration/common/actions/engine.organismes.utils.test.ts
+++ b/server/tests/integration/common/actions/engine.organismes.utils.test.ts
@@ -74,14 +74,14 @@ describe("Tests des actions  engine utilitaires organismes", () => {
 
       testsCases.forEach((test) => {
         it(test.label, async () => {
-          expect(await isOrganismeFiableForCouple(test.uai, test.siret)).toBe(test.expectedFiable);
+          await expect(isOrganismeFiableForCouple(test.uai, test.siret)).resolves.toBe(test.expectedFiable);
         });
       });
     });
 
     describe("Vérification des cas de couples fiables", () => {
       it("Vérifie qu'on couple dont l'UAI et le SIRET matchent dans le référentiel est pas fiable", async () => {
-        expect(await isOrganismeFiableForCouple(UAI_REFERENTIEL, SIRET_REFERENTIEL)).toBe(true);
+        await expect(isOrganismeFiableForCouple(UAI_REFERENTIEL, SIRET_REFERENTIEL)).resolves.toBe(true);
       });
     });
   });

--- a/server/tests/integration/http/dossiersApprenantsV2.route.test.ts
+++ b/server/tests/integration/http/dossiersApprenantsV2.route.test.ts
@@ -232,7 +232,7 @@ describe("Dossiers Apprenants Route", () => {
       });
 
       // Check Nb Items added
-      expect(await effectifsQueueDb().countDocuments({})).toBe(1);
+      await expect(effectifsQueueDb().countDocuments({})).resolves.toBe(1);
     });
   });
 });

--- a/server/tests/integration/http/effectif.routes.test.ts
+++ b/server/tests/integration/http/effectif.routes.test.ts
@@ -77,7 +77,7 @@ describe("Routes diverses", () => {
       testPermissions(accesOrganisme, async (organisation, allowed) => {
         const response = await requestAsOrganisation(organisation, "delete", `/api/v1/effectif/${effectifId}`);
         expect(response.status).toStrictEqual(allowed ? 200 : 403);
-        expect(await effectifsDb().countDocuments()).toStrictEqual(allowed ? 0 : 1);
+        await expect(effectifsDb().countDocuments()).resolves.toStrictEqual(allowed ? 0 : 1);
       });
     });
   });

--- a/server/tests/integration/jobs/hydrate/hydrate-deca.test.ts
+++ b/server/tests/integration/jobs/hydrate/hydrate-deca.test.ts
@@ -10,7 +10,7 @@ describe("Job hydrateContratsDeca", () => {
   useMongo();
   describe("getLastDecaCreatedDateInDb", () => {
     it("Vérifie la non récupération de la dernière date d'ajout d'une entrée dans la collection contratsDeca si la collection est vide", async () => {
-      expect(await getLastDecaCreatedDateInDb()).toStrictEqual(null);
+      await expect(getLastDecaCreatedDateInDb()).resolves.toStrictEqual(null);
     });
 
     it("Vérifie la récupération de la dernière date d'ajout d'une entrée dans la collection contratsDeca pour une date dans le passé", async () => {
@@ -21,7 +21,7 @@ describe("Job hydrateContratsDeca", () => {
         dataDeca.contrats.map((currentContrat) => ({ ...(currentContrat as Contrat), created_at: dateToTest }))
       );
 
-      expect(await getLastDecaCreatedDateInDb()).toStrictEqual(dateToTest);
+      await expect(getLastDecaCreatedDateInDb()).resolves.toStrictEqual(dateToTest);
     });
 
     it("Vérifie la récupération de la dernière date d'ajout d'une entrée dans la collection contratsDeca pour la date du jour", async () => {
@@ -33,7 +33,7 @@ describe("Job hydrateContratsDeca", () => {
         dataDeca.contrats.map((currentContrat) => ({ ...(currentContrat as Contrat), created_at: new Date() }))
       );
 
-      expect(await getLastDecaCreatedDateInDb()).toStrictEqual(addDays(new Date(), -1));
+      await expect(getLastDecaCreatedDateInDb()).resolves.toStrictEqual(addDays(new Date(), -1));
     });
   });
 

--- a/server/tests/integration/jobs/ingestion/process-ingestion.test.ts
+++ b/server/tests/integration/jobs/ingestion/process-ingestion.test.ts
@@ -114,7 +114,7 @@ describe("Processus d'ingestion", () => {
         });
 
         // Check nb effectifsQueue
-        expect(await effectifsQueueDb().countDocuments({})).toBe(1);
+        await expect(effectifsQueueDb().countDocuments({})).resolves.toBe(1);
 
         // TODO : Vérifier le locker
       });
@@ -167,7 +167,7 @@ describe("Processus d'ingestion", () => {
         });
 
         // Check nb effectifsQueue
-        expect(await effectifsDb().countDocuments({})).toBe(1);
+        await expect(effectifsDb().countDocuments({})).resolves.toBe(1);
 
         const insertedDossier = await effectifsDb().findOne({});
 
@@ -314,10 +314,10 @@ describe("Processus d'ingestion", () => {
         });
 
         // Check nb effectifsQueue
-        expect(await effectifsQueueDb().countDocuments({})).toBe(2);
+        await expect(effectifsQueueDb().countDocuments({})).resolves.toBe(2);
 
         // Check nb d'effectifs
-        expect(await effectifsDb().countDocuments({})).toBe(1);
+        await expect(effectifsDb().countDocuments({})).resolves.toBe(1);
 
         // Check historique
         const effectifInserted = await effectifsDb().findOne({ id_erp_apprenant: commonSampleData.id_erp_apprenant });
@@ -362,10 +362,10 @@ describe("Processus d'ingestion", () => {
         });
 
         // Check nb effectifsQueue
-        expect(await effectifsQueueDb().countDocuments({})).toBe(2);
+        await expect(effectifsQueueDb().countDocuments({})).resolves.toBe(2);
 
         // Check nb d'effectifs
-        expect(await effectifsDb().countDocuments({})).toBe(2);
+        await expect(effectifsDb().countDocuments({})).resolves.toBe(2);
 
         // Check historiques des effectifs
         const effectifInserted = await effectifsDb().findOne({ "formation.cfd": commonSampleData.id_formation });
@@ -498,7 +498,7 @@ describe("Processus d'ingestion", () => {
         });
 
         // Check nb effectifsQueue
-        expect(await effectifsQueueDb().countDocuments({})).toBe(1);
+        await expect(effectifsQueueDb().countDocuments({})).resolves.toBe(1);
 
         const insertedDossier = await effectifsDb().findOne({});
 
@@ -625,7 +625,7 @@ describe("Processus d'ingestion", () => {
         });
 
         // Check nb effectifsQueue
-        expect(await effectifsQueueDb().countDocuments({})).toBe(1);
+        await expect(effectifsQueueDb().countDocuments({})).resolves.toBe(1);
 
         const insertedDossier = await effectifsDb().findOne({});
 
@@ -722,10 +722,10 @@ describe("Processus d'ingestion", () => {
         });
 
         // Check nb effectifsQueue
-        expect(await effectifsQueueDb().countDocuments({})).toBe(2);
+        await expect(effectifsQueueDb().countDocuments({})).resolves.toBe(2);
 
         // Check nb d'effectifs
-        expect(await effectifsDb().countDocuments({})).toBe(1);
+        await expect(effectifsDb().countDocuments({})).resolves.toBe(1);
 
         // Check historique
         const effectifInserted = await effectifsDb().findOne({ id_erp_apprenant: "987654321" });
@@ -784,7 +784,7 @@ describe("Processus d'ingestion", () => {
           expect(updatedInput?.effectif_id).toBeUndefined();
 
           // check that no data was created
-          expect(await effectifsDb().countDocuments({})).toBe(0);
+          await expect(effectifsDb().countDocuments({})).resolves.toBe(0);
         });
       });
 
@@ -833,7 +833,7 @@ describe("Processus d'ingestion", () => {
         expect(updatedInput?.effectif_id).toBeUndefined();
 
         // check that no data was created
-        expect(await effectifsDb().countDocuments({})).toBe(0);
+        await expect(effectifsDb().countDocuments({})).resolves.toBe(0);
       });
 
       it("Vérifie qu'on ne crée pas de donnée et remonte une erreur lorsque le dossier ne respecte pas le format du nom / prenom du jeune pour un organisme fiable", async () => {
@@ -891,7 +891,7 @@ describe("Processus d'ingestion", () => {
         expect(updatedInput?.effectif_id).toBeUndefined();
 
         // check that no data was created
-        expect(await effectifsDb().countDocuments({})).toBe(0);
+        await expect(effectifsDb().countDocuments({})).resolves.toBe(0);
       });
 
       it("Vérifie qu'on ne crée pas de donnée et renvoie une erreur lorsque les champs date ne sont pas iso", async () => {
@@ -944,7 +944,7 @@ describe("Processus d'ingestion", () => {
         expect(updatedInput?.effectif_id).toBeUndefined();
 
         // check that no data was created
-        expect(await effectifsDb().countDocuments({})).toBe(0);
+        await expect(effectifsDb().countDocuments({})).resolves.toBe(0);
       });
 
       it("Vérifie qu'on ne crée pas de donnée et remonte une erreur lorsque le dossier ne respecte pas le format de l'année scolaire pour un organisme fiable", async () => {
@@ -998,7 +998,7 @@ describe("Processus d'ingestion", () => {
         expect(updatedInput?.effectif_id).toBeUndefined();
 
         // check that no data was created
-        expect(await effectifsDb().countDocuments({})).toBe(0);
+        await expect(effectifsDb().countDocuments({})).resolves.toBe(0);
       });
     });
 
@@ -1060,7 +1060,7 @@ describe("Processus d'ingestion", () => {
         expect(updatedInput?.effectif_id).toBeUndefined();
 
         // check effectifs count
-        expect(await effectifsDb().countDocuments({})).toBe(1);
+        await expect(effectifsDb().countDocuments({})).resolves.toBe(1);
 
         // Check Séquence historique
         const effectifInserted = await effectifsDb().findOne({ id_erp_apprenant: commonSampleData.id_erp_apprenant });


### PR DESCRIPTION
Permet de passer de
![2023-10-27_11-37](https://github.com/mission-apprentissage/flux-retour-cfas/assets/8938024/a861b2d2-1797-4d03-b672-71e9ff1e6441)
à
![2023-10-27_11-36](https://github.com/mission-apprentissage/flux-retour-cfas/assets/8938024/e6c58f4e-8133-441e-91b4-5614d2577bff)
en cas d'erreur d'un appel asynchrone dont on vérifie le résultat.