### PR TITLE
refactor: nouvelle règle ESLint sur les FIXME

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -75,6 +75,12 @@ module.exports = {
         optionalDependencies: false,
       },
     ],
+    "no-warning-comments": [
+      "error",
+      {
+        terms: ["FIXME"],
+      },
+    ],
   },
   settings: {
     "import/extensions": [".js", ".ts"],

--- a/server/src/common/actions/helpers/filters.ts
+++ b/server/src/common/actions/helpers/filters.ts
@@ -206,7 +206,7 @@ export const fullEffectifsFiltersConfigurations: {
       if (/^\d{3,}$/.test(value)) {
         return [{ "_computed.organisme.siret": new RegExp(escapeRegExp(value)) }];
       }
-      return [{ "_computed.organisme.nom": new RegExp(escapeRegExp(value)) }]; // FIXME rapatrier le nom (enseigne/raison_sociale) de l'organisme
+      return [{ "_computed.organisme.nom": new RegExp(escapeRegExp(value)) }]; // TODO probablement ajouter un champ nom (enseigne + raison_sociale) de l'organisme
     },
   },
   organisme_reseaux: {

--- a/server/src/common/actions/helpers/permissions-organisme.ts
+++ b/server/src/common/actions/helpers/permissions-organisme.ts
@@ -46,7 +46,7 @@ export async function buildOrganismePermissions(
         infoTransmissionEffectifs: isOrganismeOrFormateur,
         indicateursEffectifs: isOrganismeOrFormateur,
         effectifsNominatifs: isOrganismeOrFormateur,
-        manageEffectifs: isOrganismeOrFormateur, // FIXME à faire revalider, est-ce qu'un responsable peut gérer sifa / les effectifs de l'organisme
+        manageEffectifs: isOrganismeOrFormateur,
       };
     }
 

--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -560,11 +560,25 @@ export async function getOrganismeByAPIKey(api_key: string) {
 }
 
 export async function findOrganismesBySIRET(siret: string): Promise<Organisme[]> {
-  // FIXME projection à définir
   const organismes = await organismesDb()
-    .find({
-      siret: siret,
-    })
+    .find(
+      {
+        siret: siret,
+      },
+      {
+        projection: {
+          siret: 1,
+          uai: 1,
+          enseigne: 1,
+          raison_sociale: 1,
+          ferme: 1,
+          nature: {
+            $ifNull: ["$nature", "inconnue"],
+          },
+          adresse: 1,
+        },
+      }
+    )
     .toArray();
   if (organismes.length === 0) {
     logger.warn({ module: "inscription", siret }, "aucun organisme trouvé en base");
@@ -574,11 +588,25 @@ export async function findOrganismesBySIRET(siret: string): Promise<Organisme[]>
 }
 
 export async function findOrganismesByUAI(uai: string): Promise<Organisme[]> {
-  // FIXME projection à définir
   const organismes = await organismesDb()
-    .find({
-      uai: uai,
-    })
+    .find(
+      {
+        uai: uai,
+      },
+      {
+        projection: {
+          siret: 1,
+          uai: 1,
+          enseigne: 1,
+          raison_sociale: 1,
+          ferme: 1,
+          nature: {
+            $ifNull: ["$nature", "inconnue"],
+          },
+          adresse: 1,
+        },
+      }
+    )
     .toArray();
   if (organismes.length === 0) {
     logger.warn({ module: "inscription", uai }, "aucun organisme trouvé en base");

--- a/server/src/common/model/@types/index.ts
+++ b/server/src/common/model/@types/index.ts
@@ -4,7 +4,6 @@ export type { Formation } from "./Formation";
 export type { JobEvent } from "./JobEvent";
 export type { JwtSession } from "./JwtSession";
 export type { MaintenanceMessage } from "./MaintenanceMessage";
-// FIXME ajouter le type de l'organisation
 export type { Organisme } from "./Organisme";
 export type { OrganismesReferentiel } from "./OrganismesReferentiel";
 export type { User } from "./User";

--- a/server/src/common/model/organismes.model.ts
+++ b/server/src/common/model/organismes.model.ts
@@ -59,7 +59,7 @@ const indexes: [IndexSpecification, CreateIndexesOptions][] = [
     { nom: "text", siret: "text", uai: "text" },
     { name: "nom_siret_uai_text", default_language: "french" },
   ],
-  [{ "adresse.departement": 1 }, { name: "departement" }], // FIXME n'a pas l'air d'améliorer les performances
+  [{ "adresse.departement": 1 }, { name: "departement" }],
   [{ "adresse.region": 1 }, { name: "region" }],
   [{ created_at: 1 }, { name: "created_at" }],
 ];

--- a/server/src/http/helpers/passport-handlers.ts
+++ b/server/src/http/helpers/passport-handlers.ts
@@ -29,7 +29,7 @@ export const authMiddleware = () => {
           if (!user) {
             throw Boom.unauthorized("Vous n'êtes pas connecté");
           }
-          // FIXME à quoi sert ce champ ?
+          // TODO champ probablement à supprimer
           if (user.invalided_token) {
             await updateUser(user._id, { invalided_token: false });
             return done(null, { invalided_token: true });

--- a/server/src/http/middlewares/requireJwtAuthentication.ts
+++ b/server/src/http/middlewares/requireJwtAuthentication.ts
@@ -6,17 +6,6 @@ import { getUserLegacy } from "@/common/actions/legacy/users.legacy.actions";
 import config from "@/config";
 
 export default () => {
-  const findUserOrCfa = async (usernameOrUai) => {
-    const foundUser = await getUserLegacy(usernameOrUai);
-    if (foundUser) return foundUser;
-
-    // FIXME devrait être supprimé car authentification seulement utilisée pour les ERP
-    // const foundOrganisme = await findOrganismeByUai(usernameOrUai);
-    // if (foundOrganisme) return { username: usernameOrUai, permissions: [tdbRoles.cfa] };
-
-    return null;
-  };
-
   const jwtStrategyOptions = {
     // JWT can be passed as header
     jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -27,7 +16,7 @@ export default () => {
     "jwtStrategy1",
     new JwtStrategy(jwtStrategyOptions, async (jwt_payload, done) => {
       try {
-        const foundUser = await findUserOrCfa(jwt_payload.sub);
+        const foundUser = await getUserLegacy(jwt_payload.sub);
         if (!foundUser) {
           Sentry.setUser(null);
           return done(null, false);

--- a/server/src/http/routes/admin.routes/users.routes.ts
+++ b/server/src/http/routes/admin.routes/users.routes.ts
@@ -64,7 +64,6 @@ export default () => {
     async ({ body, params }, res) => {
       const { id } = params;
 
-      // FIXME : mise à jour de l'organisation ?
       await updateUser(id, {
         ...body,
         invalided_token: true,

--- a/server/src/jobs/ingestion/process-ingestion.ts
+++ b/server/src/jobs/ingestion/process-ingestion.ts
@@ -481,14 +481,12 @@ async function findOrganismeWithStats(
   let uai: string;
   let siret: string;
   if (fiabilisationResult?.type === "A_FIABILISER") {
-    // FIXME seulement 4 en prod !!! potentiellement prendre plus de choses
     uai = fiabilisationResult.uai_fiable as string;
     siret = fiabilisationResult.siret_fiable as string;
   } else {
     uai = uai_etablissement;
     siret = siret_etablissement as string;
   }
-  // TODO/FIXME peut-être vérifier dans fiabilisationUaiSiretDb, avec couple uai/siret, sinon uai, sinon siret ???
 
   // 2. On cherche l'organisme avec le couple uai/siret
   const organisme = await findOrganismeByUaiAndSiret(uai, siret, projection);

--- a/server/src/jobs/seed/types/generate-types.ts
+++ b/server/src/jobs/seed/types/generate-types.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 
-// FIXME à déplacer en dehors de la codebase car dépendances de dev
+// TODO à déplacer en dehors de la codebase car dépendances de dev
 import { compileBSON, getDatabaseSchemas } from "bson-schema-to-typescript";
 import traverse from "json-schema-traverse";
 import { upperFirst } from "lodash-es";

--- a/server/tests/integration/http/organisme.routes.test.ts
+++ b/server/tests/integration/http/organisme.routes.test.ts
@@ -477,7 +477,6 @@ describe("Routes /organismes/:id", () => {
 
     describe("Permissions", () => {
       beforeEach(async () => {
-        // FIXME revoir les statuts
         await effectifsDb().insertMany([
           // 5 apprentis
           ...generate(5, () =>

--- a/server/tests/integration/http/referentiel.route.test.ts
+++ b/server/tests/integration/http/referentiel.route.test.ts
@@ -7,7 +7,7 @@ import { initTestApp } from "@tests/utils/testUtils";
 
 let httpClient: AxiosInstance;
 
-// FIXME route authentifiée
+// TODO route non utilisée, probablement à supprimer sachant qu'on a le dossier shared avec les constantes réseaux
 xdescribe("Referentiel Route", () => {
   beforeEach(async () => {
     const app = await initTestApp();

--- a/server/tests/integration/http/rncp.routes.test.ts
+++ b/server/tests/integration/http/rncp.routes.test.ts
@@ -6,8 +6,6 @@ import { useMongo } from "@tests/jest/setupMongo";
 import { organismes, testPermissions } from "@tests/utils/permissions";
 import { RequestAsOrganisationFunc, expectUnauthorizedError, initTestApp } from "@tests/utils/testUtils";
 
-// FIXME route authentifiée
-
 let app: Awaited<ReturnType<typeof initTestApp>>;
 let httpClient: AxiosInstance;
 let requestAsOrganisation: RequestAsOrganisationFunc;

--- a/ui/components/Page/components/Header.tsx
+++ b/ui/components/Page/components/Header.tsx
@@ -36,7 +36,6 @@ const UserMenu = () => {
     window.location.href = "/";
   };
 
-  // FIXME: corriger le chargement de l'auth
   return (
     <>
       {!auth && (

--- a/ui/components/withAuth.tsx
+++ b/ui/components/withAuth.tsx
@@ -7,7 +7,6 @@ const withAuth = (Component: any, authorizedOrganisationTypes: OrganisationType[
   const AuthenticatedPage = (props) => {
     const router = useRouter();
     const { auth, organisationType } = useAuth();
-    // FIXME probablement lever une erreur si le compte n'est confirmé
     if (!auth) {
       if (typeof window !== "undefined") {
         router.push("/auth/connexion");

--- a/ui/hooks/useAuth.ts
+++ b/ui/hooks/useAuth.ts
@@ -5,7 +5,6 @@ import { AuthContext } from "@/common/internal/AuthContext";
 import { AuthenticationContext } from "@/components/UserWrapper/UserWrapper";
 
 export default function useAuth() {
-  // FIXME loading state ?
   const { auth, setAuth } = useContext(AuthenticationContext);
   const organisationType = auth?.organisation?.type;
 

--- a/ui/modules/admin/userSchema.ts
+++ b/ui/modules/admin/userSchema.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-// FIXME modèle à revoir
 const userSchema = () =>
   z.object({
     civility: z.string({ required_error: "Champ obligatoire" }),

--- a/ui/modules/auth/inscription/InscriptionOperateurPublic.tsx
+++ b/ui/modules/auth/inscription/InscriptionOperateurPublic.tsx
@@ -31,7 +31,7 @@ const typesOrganisation = [
     label: "Organisation nationale",
     value: "OPERATEUR_PUBLIC_NATIONAL",
   },
-  // FIXME, pas pris en compte pour l'instant, car il faut pouvoir enregistrer l'utilisateur / envoyer un mail
+  // TODO, pas pris en compte pour l'instant, car il faut pouvoir enregistrer l'utilisateur / envoyer un mail
   // {
   //   label: "Autre opérateur public",
   //   value: "AUTRE",

--- a/ui/modules/auth/inscription/components/OrganismeDetails.tsx
+++ b/ui/modules/auth/inscription/components/OrganismeDetails.tsx
@@ -18,7 +18,7 @@ export default function OrganismeDetails({ organisme }) {
         </b>
       </Text>
       <Text>
-        Raison sociale : <b>{organisme.raison_sociale || organisme.nom || organisme.enseigne}</b>
+        Raison sociale : <b>{organisme.enseigne || organisme.raison_sociale}</b>
       </Text>
       <Text>
         Adresse : <b>{organisme.adresse?.complete}</b>

--- a/ui/modules/models/indicateurs.ts
+++ b/ui/modules/models/indicateurs.ts
@@ -19,7 +19,7 @@ export type IndicateursEffectifsAvecOrganisme = IndicateursEffectifs & {
 export type IndicateursEffectifsAvecFormation = IndicateursEffectifs & {
   rncp_code: string | null;
   rncp: Record<any, any> | null;
-}; // FIXME importer le modèle complet
+}; // TODO importer le modèle complet
 
 export interface IndicateursOrganismes {
   tauxCouverture: number;

--- a/ui/modules/mon-espace/SIFA/SIFAPage.tsx
+++ b/ui/modules/mon-espace/SIFA/SIFAPage.tsx
@@ -41,7 +41,7 @@ function useOrganismesEffectifs(organismeId: string) {
   useEffect(() => {
     if (prevOrganismeId.current !== organismeId) {
       prevOrganismeId.current = organismeId;
-      // FIXME, reset toutes les queries ?!
+      // FIX ME: reset toutes les queries ?! Cet effect est probablement à supprimer car inutile
       // queryClient.resetQueries("organismesEffectifs", { exact: true });
     }
   }, [queryClient, organismeId]);
@@ -241,7 +241,7 @@ const SIFAPage = (props: SIFAPageProps) => {
                   return (
                     <EffectifsTableContainer
                       key={anneSco + cfd}
-                      canEdit={true} // FIXME organisation liée à l'organisme uniquement ?
+                      canEdit={true}
                       effectifs={effectifs}
                       formation={formation}
                       searchValue={searchValue}

--- a/ui/modules/mon-espace/organisation/InvitationForm.tsx
+++ b/ui/modules/mon-espace/organisation/InvitationForm.tsx
@@ -33,7 +33,6 @@ const InvitationForm = (props: InvitationFormProps) => {
         toastSuccess("Un email d'invitation a été envoyé au destinataire.");
         props.onInvitation?.();
       } catch (err) {
-        // FIXME le mécanisme toaster devrait être global pour les erreurs non catchées
         console.error(err);
         toastError(err?.json?.data?.message || "Oups, une erreur est survenue, merci de réessayer plus tard");
       }

--- a/ui/pages/auth/modifier-mot-de-passe.tsx
+++ b/ui/pages/auth/modifier-mot-de-passe.tsx
@@ -35,7 +35,7 @@ const ResetPasswordPage = () => {
   const [show, setShow] = React.useState(false);
   const onShowPassword = () => setShow(!show);
 
-  // FIXME on pourrait avoir le type d'organisation dans le token pour l'avoir
+  // TODO on pourrait avoir le type d'organisation dans le token pour l'avoir
   // const minLength = auth?.organisation?.type === "ADMINISTRATEUR" ? 20 : 12;
   const minLength = 12;
 

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -635,6 +635,5 @@ function SectionApercuChiffresCles() {
 
 export default function Home() {
   const { auth } = useAuth();
-  // FIXME vérifier le chargement
   return auth ? <DashboardPage /> : <PublicLandingPage />;
 }


### PR DESCRIPTION
- ajoute une règle ESLint qui détecte les FIXME et déclenche une erreur : ceci permettra d'utiliser `// FIXME blabla` pendant le développement d'une PR et d'être contraint d'y repasser avant de la donner à review.
- supprime les fixme existants ou les transforme en TODO (= idées d'amélioration)
- bonus (un peu important aussi _(sécu)_ ) : corrige une projection à faire dans la recherche d'organisme qui fuitait toutes les infos sur un organisme (dont les clés d'API v3, nb effectifs, etc).