### PR TITLE
fix: condition sur le bandeau de transmission

### DIFF
--- a/ui/modules/organismes/BandeauTransmission.tsx
+++ b/ui/modules/organismes/BandeauTransmission.tsx
@@ -58,7 +58,7 @@ function getContenuBandeauTransmission({
   }
 
   if (organisme.mode_de_transmission === "API") {
-    if (differenceInDays(new Date(organisme.mode_de_transmission_configuration_date as string), new Date()) < 7) {
+    if (differenceInDays(new Date(), new Date(organisme.mode_de_transmission_configuration_date as string)) < 7) {
       return (
         <>
           Votre outil de gestion est {erpName}. Les {modeIndicateurs ? "indicateurs sont nuls" : "effectifs sont vides"}{" "}


### PR DESCRIPTION
Il faut indiquer la date la plus récente à gauche pour avoir une différence positive. (c'est le cas ailleurs dans les relances)