### PR TITLE
feat: show opcos in dashboard

### DIFF
--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -839,6 +839,7 @@ export function getOrganismeProjection(
     prepa_apprentissage: 1,
     enseigne: 1,
     raison_sociale: 1,
+    opcos: 1,
     reseaux: 1,
     adresse: 1,
     organismesResponsables: 1,

--- a/ui/common/internal/Organisme.ts
+++ b/ui/common/internal/Organisme.ts
@@ -12,6 +12,10 @@ export interface Organisme {
    */
   siret: string;
   /**
+   * OPCOs du CFA, s'ils existent
+   */
+  opcos?: string[];
+  /**
    * Réseaux du CFA, s'ils existent
    */
   reseaux?: (

--- a/ui/modules/dashboard/DashboardOrganisme.tsx
+++ b/ui/modules/dashboard/DashboardOrganisme.tsx
@@ -357,6 +357,28 @@ const DashboardOrganisme = ({ organisme, modePublique }: Props) => {
               </HStack>
             )}
 
+            {organisme.opcos && organisme.opcos?.length > 0 && (
+              <HStack>
+                <Text>
+                  Cet organisme est rattaché {organisme.opcos?.length === 1 ? "à l'OPCO" : "aux OPCOS"}
+                  &nbsp;:
+                </Text>
+                {organisme.opcos.map((opco) => (
+                  <Badge
+                    fontSize="epsilon"
+                    textColor="grey.800"
+                    paddingX="1w"
+                    paddingY="2px"
+                    backgroundColor="#ECEAE3"
+                    textTransform="none"
+                    key={opco}
+                  >
+                    {opco.toUpperCase()}
+                  </Badge>
+                ))}
+              </HStack>
+            )}
+
             <HStack>
               <Text>Raison sociale&nbsp;:</Text>
               <Text fontWeight="bold">{organisme.raison_sociale || "Inconnue"}</Text>


### PR DESCRIPTION
~A besoin de #3333.~

:warning: en attente de savoir si on veut vraiment afficher cette information. Pour l'instant, [non](https://mission-apprentissage.slack.com/archives/C02FR2L1VB8/p1698763215567389?thread_ts=1698753928.815609&cid=C02FR2L1VB8).

![image](https://github.com/mission-apprentissage/flux-retour-cfas/assets/8938024/e47fd7ec-20b9-4835-a5c8-0c28e6e9034a)
