### PR TITLE
feat(ui): déplacement des of inconnus dans onglets non retenus

### DIFF
--- a/ui/modules/organismes/ListeOrganismesPage.tsx
+++ b/ui/modules/organismes/ListeOrganismesPage.tsx
@@ -84,11 +84,9 @@ function ListeOrganismesPage(props: ListeOrganismesPageProps) {
       } else if (
         // Organismes à masquer :
         // organismes fermés et ne transmettant pas
-        // organismes inconnus (sans raison sociale ni enseigne) et absents du référentiel ou fermé
+        // organismes inconnus (sans raison sociale ni enseigne)
         (organisme.ferme && !organisme.last_transmission_date) ||
-        (!organisme.enseigne &&
-          !organisme.raison_sociale &&
-          (organisme.est_dans_le_referentiel === "absent" || organisme.ferme))
+        (!organisme.enseigne && !organisme.raison_sociale)
       ) {
         nbOrganismesFermes++;
         organismesNonRetenus.push(organisme);


### PR DESCRIPTION
Vu avec @nadinelouchart reorganisation des onglets : on mets dans l'onglet 3 les organismes fermés ne transmettant plus + les organismes inconnus.