### PR TITLE
feat: ajout rncp.opcos et effectifs computed opcos

### DIFF
--- a/server/src/common/model/@types/Effectif.ts
+++ b/server/src/common/model/@types/Effectif.ts
@@ -28,7 +28,7 @@ export interface Effectif {
   /**
    * Identifiant de l'organisme id source transmettant
    */
-  source_organisme_id: string;
+  source_organisme_id?: string;
   /**
    * Année scolaire sur laquelle l'apprenant est enregistré (ex: "2020-2021")
    */
@@ -1854,6 +1854,7 @@ export interface Effectif {
     };
     formation?: {
       codes_rome?: string[];
+      opcos?: string[];
     };
   };
 }

--- a/server/src/common/model/@types/Rncp.ts
+++ b/server/src/common/model/@types/Rncp.ts
@@ -8,4 +8,8 @@ export interface Rncp {
   etat_fiche: string;
   actif: boolean;
   romes: string[];
+  /**
+   * Information récupérée depuis les CSV des OPCOs et non le RNCP
+   */
+  opcos?: string[];
 }

--- a/server/src/common/model/effectifs.model/effectifs.model.ts
+++ b/server/src/common/model/effectifs.model/effectifs.model.ts
@@ -80,6 +80,7 @@ const indexes: [IndexSpecification, CreateIndexesOptions][] = [
   [{ "_computed.organisme.siret": 1 }, {}],
   [{ "_computed.organisme.fiable": 1 }, {}],
   [{ "_computed.formation.codes_rome": 1 }, {}],
+  [{ "_computed.formation.opcos": 1 }, {}],
 ];
 
 export const schema = object(
@@ -148,6 +149,7 @@ export const schema = object(
         }),
         formation: object({
           codes_rome: arrayOf(string()),
+          opcos: arrayOf(string()),
         }),
       },
       {

--- a/server/src/common/model/rncp.model.ts
+++ b/server/src/common/model/rncp.model.ts
@@ -4,7 +4,10 @@ import { arrayOf, boolean, number, object, objectId, string } from "./json-schem
 
 const collectionName = "rncp";
 
-const indexes: [IndexSpecification, CreateIndexesOptions][] = [[{ rncp: 1 }, { unique: true }]];
+const indexes: [IndexSpecification, CreateIndexesOptions][] = [
+  [{ rncp: 1 }, { unique: true }],
+  [{ opcos: 1 }, {}],
+];
 
 const schema = object(
   {
@@ -16,6 +19,7 @@ const schema = object(
     etat_fiche: string(),
     actif: boolean(),
     romes: arrayOf(string()),
+    opcos: arrayOf(string(), { description: "Information récupérée depuis les CSV des OPCOs et non le RNCP" }),
   },
   { required: ["rncp", "intitule", "etat_fiche", "actif", "romes"], additionalProperties: false }
 );

--- a/server/src/jobs/hydrate/effectifs/hydrate-effectifs-computed.ts
+++ b/server/src/jobs/hydrate/effectifs/hydrate-effectifs-computed.ts
@@ -38,6 +38,7 @@ export async function hydrateEffectifsComputed() {
                 },
                 formation: {
                   codes_rome: { $ifNull: [{ $first: "$_rncp.romes" }, []] },
+                  opcos: { $first: "$_rncp.opcos" },
                 },
               },
             },

--- a/server/src/jobs/hydrate/hydrate-organismes-opcos.ts
+++ b/server/src/jobs/hydrate/hydrate-organismes-opcos.ts
@@ -8,7 +8,7 @@ import { getStaticFilePath } from "@/common/utils/getStaticFilePath";
 
 // le nom doit correspondre à la clé de l'opco et au nom du fichier CSV
 // dans le dossier server/static/opcos
-const OPCOS = ["2i", "ep"];
+export const OPCOS = ["2i", "ep"];
 
 const jobLogger = parentLogger.child({
   module: "job:hydrate:opcos",

--- a/server/src/jobs/hydrate/hydrate-rncp.ts
+++ b/server/src/jobs/hydrate/hydrate-rncp.ts
@@ -108,7 +108,7 @@ export async function hydrateRNCP() {
         {
           $set: stripEmptyFields({
             ...fiche,
-            opcos: opcosByRNCP[rncp],
+            opcos: opcosByRNCP[rncp] ?? [],
           }),
         },
         {


### PR DESCRIPTION
Contenu :
- Modifie le job hydrate:rncp pour ajouter le champ opcos en provenant des 2 fichiers CSV OPCOs
- Modifie le job hydrate:effectifs-computed pour ajouter le champ _computed.formation.opcos avec les informations présentes dans la collection rncp
- Ajout d'indexes sur les champs car ils seront utilisés pour du filtrage, par @felixat13 dans un premier temps.

Note : readJsonFromCsvFile lit les fichiers de manière synchrone. Ce n'est pas grave ici étant donné qu'on est dans un job et pas dans le serveur web, mais c'est pas génial non plus.