### PR TITLE
fix(ui): hide dashboard duplicate

### DIFF
--- a/server/src/common/actions/organismes/organismes.duplicates.actions.ts
+++ b/server/src/common/actions/organismes/organismes.duplicates.actions.ts
@@ -39,6 +39,7 @@ export const getDuplicatesOrganismes = async () => {
     ])
     .toArray();
 
+  // TODO : pas bien à faire en lookup mongo
   await Promise.all(
     duplicatesGroup.map(async (currentDuplicateGroup) => {
       currentDuplicateGroup.duplicates = await Promise.all(

--- a/ui/modules/dashboard/DashboardTransverse.tsx
+++ b/ui/modules/dashboard/DashboardTransverse.tsx
@@ -33,7 +33,7 @@ import FiltreDate from "@/modules/indicateurs/filters/FiltreDate";
 import FiltreOrganismeTerritoire from "@/modules/indicateurs/filters/FiltreOrganismeTerritoire";
 import { DashboardWelcome } from "@/theme/components/icons/DashboardWelcome";
 
-import DashboardAdministrateur from "../admin/DashboardAdministrateur";
+// import DashboardAdministrateur from "../admin/DashboardAdministrateur";
 import {
   convertEffectifsFiltersToQuery,
   EffectifsFilters,
@@ -166,7 +166,7 @@ const DashboardTransverse = () => {
         </Container>
       </Box>
       <Container maxW="xl" p="8">
-        {auth.organisation.type === "ADMINISTRATEUR" && <DashboardAdministrateur />}
+        {/* {auth.organisation.type === "ADMINISTRATEUR" && <DashboardAdministrateur />} */}
         <Heading as="h1" color="#465F9D" fontSize="beta" fontWeight="700" mb={3}>
           Aperçu des données de l’apprentissage
         </Heading>

--- a/ui/pages/admin/fusion-organismes/index.tsx
+++ b/ui/pages/admin/fusion-organismes/index.tsx
@@ -4,20 +4,21 @@ import React from "react";
 import { getAuthServerSideProps } from "@/common/SSR/getAuthServerSideProps";
 import SimplePage from "@/components/Page/SimplePage";
 import withAuth from "@/components/withAuth";
-import { useOrganismesDuplicatsLists } from "@/hooks/organismes";
-import OrganismesDoublonsPage from "@/modules/admin/fusion-organismes/OrganismesDoublonsPage";
+// import { useOrganismesDuplicatsLists } from "@/hooks/organismes";
+// import OrganismesDoublonsPage from "@/modules/admin/fusion-organismes/OrganismesDoublonsPage";
 
 export const getServerSideProps = async (context) => ({ props: { ...(await getAuthServerSideProps(context)) } });
 
 const PageEffectifsDeSonOrganisme = () => {
-  const { organismesDuplicats, isLoading } = useOrganismesDuplicatsLists();
+  // const { organismesDuplicats, isLoading } = useOrganismesDuplicatsLists();
 
   return (
     <SimplePage title="Vérifier les duplicats d'organisme">
       <Container maxW="xl" p="8">
-        {organismesDuplicats && (
+        {/* {organismesDuplicats && (
           <OrganismesDoublonsPage isLoading={isLoading} organismesDuplicats={organismesDuplicats} />
-        )}
+        )} */}
+        Fonctionnalité en cours de développement
       </Container>
     </SimplePage>
   );


### PR DESCRIPTION
Problème de performances sur la feature de fusion : jointure nbUsers sur les organismes duplicates qui pose pb.
Temporairement je désactive la feature et je corrigerais lundi.