### PR TITLE
feat(server): masquer les effectifs d'OF dont on ne connait pas la raison sociale ou l'enseigne

### DIFF
--- a/server/src/common/actions/effectifs.actions.ts
+++ b/server/src/common/actions/effectifs.actions.ts
@@ -204,6 +204,8 @@ export const addEffectifComputedFields = (organisme: Organisme): Effectif["_comp
       ...(organisme.uai ? { uai: organisme.uai } : {}),
       ...(organisme.siret ? { siret: organisme.siret } : {}),
       ...(organisme.reseaux ? { reseaux: organisme.reseaux } : {}),
+      ...(organisme.enseigne ? { enseigne: organisme.enseigne } : {}),
+      ...(organisme.raison_sociale ? { raison_sociale: organisme.raison_sociale } : {}),
       fiable: organisme.fiabilisation_statut === "FIABLE" && !organisme.ferme,
     },
   };

--- a/server/src/common/actions/indicateurs/indicateurs.actions.ts
+++ b/server/src/common/actions/indicateurs/indicateurs.actions.ts
@@ -42,6 +42,8 @@ export async function getIndicateursEffectifsParDepartement(
             await getIndicateursEffectifsRestriction(ctx),
             ...buildMongoFilters(filters, effectifsFiltersConfigurations),
           ],
+          "computed.organisme.raison_sociale": { $exists: true },
+          "computed.organisme.enseigne": { $exists: true },
           "_computed.organisme.fiable": true, // TODO : a supprimer si on permet de choisir de voir les effectifs des non fiables
         },
       },
@@ -259,6 +261,8 @@ export async function getIndicateursEffectifsParOrganisme(
             await getEffectifsAnonymesRestriction(ctx),
             ...buildMongoFilters(filters, fullEffectifsFiltersConfigurations),
           ],
+          "computed.organisme.raison_sociale": { $exists: true },
+          "computed.organisme.enseigne": { $exists: true },
           "_computed.organisme.fiable": true, // TODO : a supprimer si on permet de choisir de voir les effectifs des non fiables
         },
       },
@@ -460,6 +464,8 @@ export async function getOrganismeIndicateursEffectifsParFormation(
             await getOrganismeIndicateursEffectifsRestriction(ctx),
             ...buildMongoFilters(filters, effectifsFiltersConfigurations),
           ],
+          "computed.organisme.raison_sociale": { $exists: true },
+          "computed.organisme.enseigne": { $exists: true },
           "_computed.organisme.fiable": true, // TODO : a supprimer si on permet de choisir de voir les effectifs des non fiables
         },
       },
@@ -661,6 +667,8 @@ export async function getEffectifsNominatifs(
             await getEffectifsNominatifsRestriction(ctx),
             ...buildMongoFilters(filters, fullEffectifsFiltersConfigurations),
           ],
+          "computed.organisme.raison_sociale": { $exists: true },
+          "computed.organisme.enseigne": { $exists: true },
           "_computed.organisme.fiable": true, // TODO : a supprimer si on permet de choisir de voir les effectifs des non fiables
         },
       },

--- a/server/src/common/actions/indicateurs/indicateurs.actions.ts
+++ b/server/src/common/actions/indicateurs/indicateurs.actions.ts
@@ -42,8 +42,8 @@ export async function getIndicateursEffectifsParDepartement(
             await getIndicateursEffectifsRestriction(ctx),
             ...buildMongoFilters(filters, effectifsFiltersConfigurations),
           ],
-          "computed.organisme.raison_sociale": { $exists: true },
-          "computed.organisme.enseigne": { $exists: true },
+          "_computed.organisme.raison_sociale": { $exists: true },
+          "_computed.organisme.enseigne": { $exists: true },
           "_computed.organisme.fiable": true, // TODO : a supprimer si on permet de choisir de voir les effectifs des non fiables
         },
       },
@@ -261,8 +261,8 @@ export async function getIndicateursEffectifsParOrganisme(
             await getEffectifsAnonymesRestriction(ctx),
             ...buildMongoFilters(filters, fullEffectifsFiltersConfigurations),
           ],
-          "computed.organisme.raison_sociale": { $exists: true },
-          "computed.organisme.enseigne": { $exists: true },
+          "_computed.organisme.raison_sociale": { $exists: true },
+          "_computed.organisme.enseigne": { $exists: true },
           "_computed.organisme.fiable": true, // TODO : a supprimer si on permet de choisir de voir les effectifs des non fiables
         },
       },
@@ -464,8 +464,8 @@ export async function getOrganismeIndicateursEffectifsParFormation(
             await getOrganismeIndicateursEffectifsRestriction(ctx),
             ...buildMongoFilters(filters, effectifsFiltersConfigurations),
           ],
-          "computed.organisme.raison_sociale": { $exists: true },
-          "computed.organisme.enseigne": { $exists: true },
+          "_computed.organisme.raison_sociale": { $exists: true },
+          "_computed.organisme.enseigne": { $exists: true },
           "_computed.organisme.fiable": true, // TODO : a supprimer si on permet de choisir de voir les effectifs des non fiables
         },
       },
@@ -667,8 +667,8 @@ export async function getEffectifsNominatifs(
             await getEffectifsNominatifsRestriction(ctx),
             ...buildMongoFilters(filters, fullEffectifsFiltersConfigurations),
           ],
-          "computed.organisme.raison_sociale": { $exists: true },
-          "computed.organisme.enseigne": { $exists: true },
+          "_computed.organisme.raison_sociale": { $exists: true },
+          "_computed.organisme.enseigne": { $exists: true },
           "_computed.organisme.fiable": true, // TODO : a supprimer si on permet de choisir de voir les effectifs des non fiables
         },
       },

--- a/server/src/common/model/effectifs.model/effectifs.model.ts
+++ b/server/src/common/model/effectifs.model/effectifs.model.ts
@@ -78,6 +78,8 @@ const indexes: [IndexSpecification, CreateIndexesOptions][] = [
   [{ "_computed.organisme.reseaux": 1 }, {}],
   [{ "_computed.organisme.uai": 1 }, {}],
   [{ "_computed.organisme.siret": 1 }, {}],
+  [{ "_computed.organisme.enseigne": 1 }, {}],
+  [{ "_computed.organisme.raison_sociale": 1 }, {}],
   [{ "_computed.organisme.fiable": 1 }, {}],
   [{ "_computed.formation.codes_rome": 1 }, {}],
   [{ "_computed.formation.opcos": 1 }, {}],
@@ -146,6 +148,8 @@ export const schema = object(
           }),
           siret: string({ pattern: SIRET_REGEX_PATTERN, maxLength: 14, minLength: 14 }),
           fiable: boolean({ description: `organismes.fiabilisation_statut == "FIABLE" && ferme != false` }),
+          enseigne: string({ description: "Enseigne de l'organisme de formation" }),
+          raison_sociale: string({ description: "Raison sociale de l'organisme de formation" }),
         }),
         formation: object({
           codes_rome: arrayOf(string()),

--- a/server/src/jobs/hydrate/effectifs/hydrate-effectifs-computed.ts
+++ b/server/src/jobs/hydrate/effectifs/hydrate-effectifs-computed.ts
@@ -35,6 +35,8 @@ export async function hydrateEffectifsComputed() {
                   siret: { $first: "$_organisme.siret" },
                   bassinEmploi: { $first: "$_organisme.adresse.bassinEmploi" },
                   fiable: { $cond: [{ $eq: [{ $first: "$_organisme.fiabilisation_statut" }, "FIABLE"] }, true, false] },
+                  enseigne: { $first: "$_organisme.enseigne" },
+                  raison_sociale: { $first: "$_organisme.raison_sociale" },
                 },
                 formation: {
                   codes_rome: { $ifNull: [{ $first: "$_rncp.romes" }, []] },

--- a/server/tests/integration/http/organisme.routes.test.ts
+++ b/server/tests/integration/http/organisme.routes.test.ts
@@ -221,6 +221,7 @@ describe("Routes /organismes/:id", () => {
         reseaux: ["CCI"],
         nature: "responsable_formateur",
         raison_sociale: "ADEN Formations (Caen)",
+        enseigne: "ADEN Formations (Caen)",
         fiabilisation_statut: "FIABLE",
         ferme: false,
         uai: "0000000A",

--- a/server/tests/utils/permissions.ts
+++ b/server/tests/utils/permissions.ts
@@ -42,6 +42,7 @@ export const commonOrganismeAttributes: Omit<{ [key in keyof Organisme]: Organis
   reseaux: ["CCI"],
   erps: ["YMAG"],
   nature: "responsable_formateur",
+  enseigne: "ADEN Formations (Caen)",
   raison_sociale: "ADEN Formations (Caen)",
   fiabilisation_statut: "FIABLE",
   ferme: false,
@@ -61,6 +62,8 @@ export const organismes: WithId<Organisme>[] = [
     _id: new ObjectId(id(1)),
     uai: "0000000A",
     siret: "00000000000018",
+    enseigne: "ADEN Formations (Caen)",
+    raison_sociale: "ADEN Formations (Caen)",
     organismesFormateurs: [
       {
         _id: new ObjectId(id(2)),
@@ -77,6 +80,8 @@ export const organismes: WithId<Organisme>[] = [
     _id: new ObjectId(id(2)),
     uai: "0000000B",
     siret: "00000000000026",
+    enseigne: "Test OFA 2",
+    raison_sociale: "Test OFA 2",
     organismesResponsables: [
       {
         _id: new ObjectId(id(1)),
@@ -88,6 +93,8 @@ export const organismes: WithId<Organisme>[] = [
     _id: new ObjectId(id(3)),
     uai: "0000000C",
     siret: "00000000000034",
+    enseigne: "Test OFA 3",
+    raison_sociale: "Test OFA 3",
     organismesFormateurs: [
       {
         _id: new ObjectId(id(1)),
@@ -100,6 +107,8 @@ export const organismes: WithId<Organisme>[] = [
     _id: new ObjectId(id(10)),
     uai: "1111111B",
     siret: "11111111100006",
+    enseigne: "Test OFA 10",
+    raison_sociale: "Test OFA 10",
   },
 ];
 


### PR DESCRIPTION
Vu avec @nadinelouchart on masque les effectifs lié à des OF "inconnus".

- Ajout dans le champ computed des effectifs de la raison sociale et de l'enseigne
- Ajout dans le filtre des requêtes d'un filtrage sur ces 2 champs