### PR TITLE
feat(server): suppression des utilisateurs (v2) n'ayant pas de last_connection

### DIFF
--- a/server/src/db/migrations/20231114154156-delete_users_without_last_connection_date.ts
+++ b/server/src/db/migrations/20231114154156-delete_users_without_last_connection_date.ts
@@ -1,0 +1,5 @@
+import { Db } from "mongodb";
+
+export const up = async (db: Db) => {
+  await db.collection("users").deleteMany({ last_connection: { $exists: false } });
+};


### PR DESCRIPTION
Migration rapide pour nettoyer la base des utilisateurs (ancienne collection) ne s'étant jamais connectés.

Il ne devrait rester que les utilisateurs de type ERP et transmettant en V2.