### PR TITLE
fix: contrôle précis (v2v3+televersement) sur les années scolaire pour accepter seulement un an max

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -96,7 +96,7 @@ fileignoreconfig:
 - filename: server/tests/integration/jobs/emails/reminder.test.ts
   checksum: 6268b3f12640edc2569bfd412081dc9d8092b15140e07fa01a29697f3d476158
 - filename: server/tests/integration/jobs/ingestion/process-ingestion.test.ts
-  checksum: af289c4843ed8ccada8725ee7bcddfe595a1b1ed4318e557ee19d4b103f3d24f
+  checksum: 97afa4b5eb76c0d2dc041a0f9fff185b5502acb7b70c7227660e323f6df79bba
 - filename: shared/constants/plausible-goals.ts
   checksum: e77a9f86790a10fe8193f4e945228e7435308d4eb1d7769888b690ba234a66c5
 - filename: ui/components/Page/components/Footer.tsx

--- a/server/src/common/validation/utils/zodPrimitives.ts
+++ b/server/src/common/validation/utils/zodPrimitives.ts
@@ -10,7 +10,6 @@ import {
   RNCP_REGEX,
   SIRET_REGEX,
   UAI_REGEX,
-  YEAR_RANGE_REGEX,
   INE_REGEX,
   NIR_LOOSE_REGEX,
   CODE_POSTAL_REGEX,
@@ -238,7 +237,22 @@ export const primitivesV1 = {
       z
         .string()
         .trim()
-        .regex(YEAR_RANGE_REGEX, "Format invalide (format attendu : 2023-2024)")
+        .refine(
+          (value) => {
+            const match = value.match(/^([12][0-9]{3})-([12][0-9]{3})$/);
+            if (match) {
+              const [, year1, year2] = match;
+              const year1Num = parseInt(year1, 10);
+              const year2Num = parseInt(year2, 10);
+              return year1Num === year2Num || year1Num + 1 === year2Num;
+            }
+            return false;
+          },
+          {
+            message:
+              "Format invalide (format attendu : 2023-2024). Les années doivent être consécutives ou identiques (ex : 2023-2024 ou 2023-2023)",
+          }
+        )
         .describe("Période scolaire")
         .openapi({
           type: "string",

--- a/server/static/open-api.json
+++ b/server/static/open-api.json
@@ -156,9 +156,7 @@
                       "example": "50022141"
                     },
                     "annee_scolaire": {
-                      "type": "string",
-                      "description": "Période scolaire",
-                      "examples": ["2022-2023", "2023-2023"]
+                      "type": "string"
                     },
                     "statut_apprenant": {
                       "type": "integer",
@@ -265,19 +263,19 @@
                       "type": "string",
                       "description": "Date de début de contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-05-13T12:26:20.445Z"
+                      "example": "2023-05-20T15:28:57.272Z"
                     },
                     "contrat_date_fin": {
                       "type": "string",
                       "description": "Date de fin de contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     },
                     "contrat_date_rupture": {
                       "type": "string",
                       "description": "Date de rupture du contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     }
                   },
                   "required": [
@@ -351,9 +349,7 @@
                             "example": "50022141"
                           },
                           "annee_scolaire": {
-                            "type": "string",
-                            "description": "Période scolaire",
-                            "examples": ["2022-2023", "2023-2023"]
+                            "type": "string"
                           },
                           "statut_apprenant": {
                             "type": "integer",
@@ -460,19 +456,19 @@
                             "type": "string",
                             "description": "Date de début de contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-05-13T12:26:20.445Z"
+                            "example": "2023-05-20T15:28:57.272Z"
                           },
                           "contrat_date_fin": {
                             "type": "string",
                             "description": "Date de fin de contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "contrat_date_rupture": {
                             "type": "string",
                             "description": "Date de rupture du contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "validation_errors": {
                             "type": "array",
@@ -579,9 +575,7 @@
                       "example": "50022141"
                     },
                     "annee_scolaire": {
-                      "type": "string",
-                      "description": "Période scolaire",
-                      "examples": ["2022-2023", "2023-2023"]
+                      "type": "string"
                     },
                     "statut_apprenant": {
                       "type": "integer",
@@ -688,19 +682,19 @@
                       "type": "string",
                       "description": "Date de début de contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-05-13T12:26:20.445Z"
+                      "example": "2023-05-20T15:28:57.272Z"
                     },
                     "contrat_date_fin": {
                       "type": "string",
                       "description": "Date de fin de contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     },
                     "contrat_date_rupture": {
                       "type": "string",
                       "description": "Date de rupture du contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     }
                   },
                   "required": [
@@ -774,9 +768,7 @@
                             "example": "50022141"
                           },
                           "annee_scolaire": {
-                            "type": "string",
-                            "description": "Période scolaire",
-                            "examples": ["2022-2023", "2023-2023"]
+                            "type": "string"
                           },
                           "statut_apprenant": {
                             "type": "integer",
@@ -883,19 +875,19 @@
                             "type": "string",
                             "description": "Date de début de contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-05-13T12:26:20.445Z"
+                            "example": "2023-05-20T15:28:57.272Z"
                           },
                           "contrat_date_fin": {
                             "type": "string",
                             "description": "Date de fin de contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "contrat_date_rupture": {
                             "type": "string",
                             "description": "Date de rupture du contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "validation_errors": {
                             "type": "array",
@@ -986,9 +978,7 @@
                       "example": "2000-10-28T00:00:00.000Z"
                     },
                     "annee_scolaire": {
-                      "type": "string",
-                      "description": "Période scolaire",
-                      "examples": ["2022-2023", "2023-2023"]
+                      "type": "string"
                     },
                     "statut_apprenant": {
                       "type": "integer",
@@ -1043,19 +1033,19 @@
                       "type": "string",
                       "description": "Date de début de contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-05-13T12:26:20.445Z"
+                      "example": "2023-05-20T15:28:57.272Z"
                     },
                     "contrat_date_fin": {
                       "type": "string",
                       "description": "Date de fin de contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     },
                     "contrat_date_rupture": {
                       "type": "string",
                       "description": "Date de rupture du contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     },
                     "nir_apprenant": {
                       "type": "string",
@@ -1114,13 +1104,13 @@
                       "type": "string",
                       "description": "Date de l'obtention du diplôme de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     },
                     "date_exclusion_formation": {
                       "type": "string",
                       "description": "Date d'exclusion de l'apprenant de la formation, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     },
                     "cause_exclusion_formation": {
                       "type": "string",
@@ -1160,19 +1150,19 @@
                       "type": "string",
                       "description": "Date de début de contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-05-13T12:26:20.445Z"
+                      "example": "2023-05-20T15:28:57.272Z"
                     },
                     "contrat_date_fin_2": {
                       "type": "string",
                       "description": "Date de fin de contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     },
                     "contrat_date_rupture_2": {
                       "type": "string",
                       "description": "Date de rupture du contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     },
                     "cause_rupture_contrat_2": {
                       "type": "string",
@@ -1190,19 +1180,19 @@
                       "type": "string",
                       "description": "Date de début de contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-05-13T12:26:20.445Z"
+                      "example": "2023-05-20T15:28:57.272Z"
                     },
                     "contrat_date_fin_3": {
                       "type": "string",
                       "description": "Date de fin de contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     },
                     "contrat_date_rupture_3": {
                       "type": "string",
                       "description": "Date de rupture du contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     },
                     "cause_rupture_contrat_3": {
                       "type": "string",
@@ -1220,19 +1210,19 @@
                       "type": "string",
                       "description": "Date de début de contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-05-13T12:26:20.445Z"
+                      "example": "2023-05-20T15:28:57.272Z"
                     },
                     "contrat_date_fin_4": {
                       "type": "string",
                       "description": "Date de fin de contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     },
                     "contrat_date_rupture_4": {
                       "type": "string",
                       "description": "Date de rupture du contrat de l'apprenant, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     },
                     "cause_rupture_contrat_4": {
                       "type": "string",
@@ -1286,13 +1276,13 @@
                       "type": "string",
                       "description": "Date d'entrée de l'apprenant dans la formation, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-05-13T12:26:20.445Z"
+                      "example": "2023-05-20T15:28:57.272Z"
                     },
                     "date_fin_formation": {
                       "type": "string",
                       "description": "Date de fin de la formation, au format ISO-8601",
                       "format": "YYYY-MM-DD",
-                      "example": "2023-10-10T12:26:20.444Z"
+                      "example": "2023-10-17T15:28:57.272Z"
                     },
                     "etablissement_responsable_uai": {
                       "type": "string",
@@ -1421,9 +1411,7 @@
                             "example": "2000-10-28T00:00:00.000Z"
                           },
                           "annee_scolaire": {
-                            "type": "string",
-                            "description": "Période scolaire",
-                            "examples": ["2022-2023", "2023-2023"]
+                            "type": "string"
                           },
                           "statut_apprenant": {
                             "type": "integer",
@@ -1478,19 +1466,19 @@
                             "type": "string",
                             "description": "Date de début de contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-05-13T12:26:20.445Z"
+                            "example": "2023-05-20T15:28:57.272Z"
                           },
                           "contrat_date_fin": {
                             "type": "string",
                             "description": "Date de fin de contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "contrat_date_rupture": {
                             "type": "string",
                             "description": "Date de rupture du contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "nir_apprenant": {
                             "type": "string",
@@ -1549,13 +1537,13 @@
                             "type": "string",
                             "description": "Date de l'obtention du diplôme de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "date_exclusion_formation": {
                             "type": "string",
                             "description": "Date d'exclusion de l'apprenant de la formation, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "cause_exclusion_formation": {
                             "type": "string",
@@ -1595,19 +1583,19 @@
                             "type": "string",
                             "description": "Date de début de contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-05-13T12:26:20.445Z"
+                            "example": "2023-05-20T15:28:57.272Z"
                           },
                           "contrat_date_fin_2": {
                             "type": "string",
                             "description": "Date de fin de contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "contrat_date_rupture_2": {
                             "type": "string",
                             "description": "Date de rupture du contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "cause_rupture_contrat_2": {
                             "type": "string",
@@ -1625,19 +1613,19 @@
                             "type": "string",
                             "description": "Date de début de contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-05-13T12:26:20.445Z"
+                            "example": "2023-05-20T15:28:57.272Z"
                           },
                           "contrat_date_fin_3": {
                             "type": "string",
                             "description": "Date de fin de contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "contrat_date_rupture_3": {
                             "type": "string",
                             "description": "Date de rupture du contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "cause_rupture_contrat_3": {
                             "type": "string",
@@ -1655,19 +1643,19 @@
                             "type": "string",
                             "description": "Date de début de contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-05-13T12:26:20.445Z"
+                            "example": "2023-05-20T15:28:57.272Z"
                           },
                           "contrat_date_fin_4": {
                             "type": "string",
                             "description": "Date de fin de contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "contrat_date_rupture_4": {
                             "type": "string",
                             "description": "Date de rupture du contrat de l'apprenant, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "cause_rupture_contrat_4": {
                             "type": "string",
@@ -1721,13 +1709,13 @@
                             "type": "string",
                             "description": "Date d'entrée de l'apprenant dans la formation, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-05-13T12:26:20.445Z"
+                            "example": "2023-05-20T15:28:57.272Z"
                           },
                           "date_fin_formation": {
                             "type": "string",
                             "description": "Date de fin de la formation, au format ISO-8601",
                             "format": "YYYY-MM-DD",
-                            "example": "2023-10-10T12:26:20.444Z"
+                            "example": "2023-10-17T15:28:57.272Z"
                           },
                           "etablissement_responsable_uai": {
                             "type": "string",


### PR DESCRIPTION
Vu avec Nadine et Catherine, l'idée est de ne permettre que les années calendaires ou scolaire et de bloquer les personnes qui mettent: 2023-2025 (2 ans)