### PR TITLE
feat: ajout des filtres sur la liste des utilisateurs

### DIFF
--- a/server/src/common/actions/users.actions.ts
+++ b/server/src/common/actions/users.actions.ts
@@ -198,7 +198,17 @@ export const getAllUsers = async (
                       },
                     },
                   },
-                  { $project: { type: 1, nom: 1, raison_sociale: 1, reseaux: 1, nature: 1 } },
+                  {
+                    $project: {
+                      type: 1,
+                      nom: 1,
+                      raison_sociale: 1,
+                      reseaux: 1,
+                      nature: 1,
+                      "adresse.departement": 1,
+                      "adresse.region": 1,
+                    },
+                  },
                 ],
               },
             },

--- a/ui/common/constants/usersConstants.ts
+++ b/ui/common/constants/usersConstants.ts
@@ -3,3 +3,9 @@ export const USER_STATUS_LABELS = {
   PENDING_ADMIN_VALIDATION: "en attente validation admin",
   CONFIRMED: "accès confirmé",
 };
+
+export const USER_STATUS_STYLE = {
+  PENDING_EMAIL_VALIDATION: "red",
+  PENDING_ADMIN_VALIDATION: "orange",
+  CONFIRMED: "green",
+};

--- a/ui/common/internal/Organisation.ts
+++ b/ui/common/internal/Organisation.ts
@@ -15,6 +15,20 @@ export const organisationTypes = [
   "ADMINISTRATEUR",
 ] as const;
 
+export const TYPES_ORGANISATION = [
+  { key: "ACADEMIE", nom: "Académie" },
+  { key: "ADMINISTRATEUR", nom: "Administrateur" },
+  { key: "CARIF_OREF_NATIONAL", nom: "Carif-Oref national" },
+  { key: "CARIF_OREF_REGIONAL", nom: "Carif-Oref régional" },
+  { key: "CONSEIL_REGIONAL", nom: "Conseil régional" },
+  { key: "DDETS", nom: "DDETS" },
+  { key: "DRAAF", nom: "DRAAF" },
+  { key: "DREETS", nom: "DREETS" },
+  { key: "OPERATEUR_PUBLIC_NATIONAL", nom: "Opérateur public national" },
+  { key: "ORGANISME_FORMATION", nom: "Organisme de formation" },
+  { key: "TETE_DE_RESEAU", nom: "Tête de réseau" },
+] as const;
+
 export type Organisation = { _id: string } & (
   | OrganisationOrganismeFormation
   | OrganisationTeteReseau

--- a/ui/common/internal/User.ts
+++ b/ui/common/internal/User.ts
@@ -1,33 +1,46 @@
-// récupéré de l'API et adapté pour ne pas avoir certains champs optionnels
+export interface UsersPaginated {
+  pagination: Pagination;
+  data: User[];
+}
 
 export interface User {
   _id: string;
-  /**
-   * Email utilisateur
-   */
+  account_status: string;
+  password_updated_at: Date;
+  created_at: Date;
   email: string;
-  /**
-   * civilité
-   */
-  civility: "Madame" | "Monsieur";
-  /**
-   * Le nom de l'utilisateur
-   */
+  civility: string;
   nom: string;
-  /**
-   * Le prénom de l'utilisateur
-   */
   prenom: string;
-  /**
-   * Le téléphone de l'utilisateur
-   */
-  telephone: string;
-  /**
-   * La fonction de l'utilisateur
-   */
   fonction: string;
-  /**
-   * Date de création du compte
-   */
-  created_at: string;
+  telephone: string;
+  has_accept_cgu_version: string;
+  organisation_id: string;
+  organisation: UserOrganisation;
+  last_connection: string;
+}
+
+export interface UserOrganisation {
+  _id: string;
+  created_at: Date;
+  type: string;
+  uai: string;
+  siret: string;
+  organisme: UserOrganisme;
+  label: string;
+}
+
+export interface UserOrganisme {
+  _id: string;
+  nom: string;
+  reseaux: any[];
+  nature: string;
+  raison_sociale: string;
+}
+
+export interface Pagination {
+  total: number;
+  page: number;
+  limit: number;
+  lastPage: number;
 }

--- a/ui/common/internal/User.ts
+++ b/ui/common/internal/User.ts
@@ -36,6 +36,10 @@ export interface UserOrganisme {
   reseaux: any[];
   nature: string;
   raison_sociale: string;
+  adresse?: {
+    departement?: string;
+    region?: string;
+  };
 }
 
 export interface Pagination {

--- a/ui/components/FilterButton/FilterButton.tsx
+++ b/ui/components/FilterButton/FilterButton.tsx
@@ -1,14 +1,14 @@
 import { Badge, Button, HStack, Stack, Text } from "@chakra-ui/react";
 import { Dispatch, SetStateAction } from "react";
 
-interface OrganismesFilterButtonProps {
+interface FilterButtonProps {
   isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   buttonLabel: string;
   badge?: number;
 }
 
-export function OrganismesFilterButton(props: OrganismesFilterButtonProps) {
+export function FilterButton(props: FilterButtonProps) {
   const hasFilters = props.badge !== undefined && props.badge > 0;
   return (
     <Button

--- a/ui/hooks/users.ts
+++ b/ui/hooks/users.ts
@@ -1,0 +1,71 @@
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/router";
+import { useMemo } from "react";
+
+import { _get, _post, _put } from "@/common/httpClient";
+import { UsersPaginated } from "@/common/internal/User";
+import { UserNormalized, toUserNormalized } from "@/modules/admin/users/models/users";
+import {
+  UsersFiltersQuery,
+  filterUsersArrayFromUsersFilters,
+  parseUsersFiltersFromQuery,
+} from "@/modules/admin/users/models/users-filters";
+
+export function useUsers() {
+  const NO_LIMIT = 10_000;
+
+  const {
+    data: usersPaginated,
+    refetch: refetchUsers,
+    isLoading,
+  } = useQuery<UsersPaginated, any>(["admin/users"], () =>
+    _get("/api/v1/admin/users/", {
+      params: {
+        page: 1,
+        limit: NO_LIMIT,
+      },
+    })
+  );
+
+  const allUsers = useMemo(() => {
+    if (!usersPaginated) return [];
+    return usersPaginated.data.map((user) => toUserNormalized(user));
+  }, [usersPaginated]);
+
+  return {
+    isLoading,
+    refetchUsers,
+    allUsers,
+  };
+}
+
+export function useUsersFiltered(users: UserNormalized[]) {
+  const router = useRouter();
+
+  const filteredUsers = useMemo(() => {
+    return users
+      ? filterUsersArrayFromUsersFilters(
+          users,
+          parseUsersFiltersFromQuery(router.query as unknown as UsersFiltersQuery)
+        )
+      : [];
+  }, [users, router.query]);
+
+  return { filteredUsers };
+}
+
+export function useUsersSearched(usersFiltered: UserNormalized[], search: string) {
+  const searchedUsers = useMemo(() => {
+    if (!search) return usersFiltered;
+    return usersFiltered?.filter((user) => {
+      const searchLower = search.toLowerCase();
+      return (
+        user.normalizedNomPrenom.includes(searchLower) ||
+        user.normalizedEmail.includes(searchLower) ||
+        user.normalizedOrganismeNom.toLowerCase().includes(searchLower)
+      );
+    });
+  }, [search, usersFiltered]);
+
+  return { searchedUsers };
+}

--- a/ui/modules/admin/users/UsersFiltersPanel.tsx
+++ b/ui/modules/admin/users/UsersFiltersPanel.tsx
@@ -8,6 +8,7 @@ import {
   parsePaginationInfosFromQuery,
 } from "@/modules/models/pagination";
 
+import FiltreUsersAccountStatut from "./filters/FiltreUsersAccountStatut";
 import FiltreUserTypes from "./filters/FiltreUsersType";
 import {
   UsersFilters,
@@ -73,6 +74,10 @@ const UsersFiltersPanel = () => {
         {/* FILTRE Réseau */}
 
         {/* FILTRE Statut du compte */}
+        <FiltreUsersAccountStatut
+          value={usersFilters.account_status}
+          onChange={(account_status) => updateState({ account_status })}
+        />
 
         {/* FILTRE Période */}
 

--- a/ui/modules/admin/users/UsersFiltersPanel.tsx
+++ b/ui/modules/admin/users/UsersFiltersPanel.tsx
@@ -9,6 +9,8 @@ import {
 } from "@/modules/models/pagination";
 
 import FiltreUsersAccountStatut from "./filters/FiltreUsersAccountStatut";
+import FiltreUsersDepartment from "./filters/FiltreUsersDepartements";
+import FiltreUsersRegion from "./filters/FiltreUsersRegion";
 import FiltreUsersReseaux from "./filters/FiltreUsersReseaux";
 import FiltreUserTypes from "./filters/FiltreUsersType";
 import {
@@ -63,8 +65,13 @@ const UsersFiltersPanel = () => {
       </Text>
       <HStack>
         {/* FILTRE Département */}
+        <FiltreUsersDepartment
+          value={usersFilters.departements}
+          onChange={(departements) => updateState({ departements })}
+        />
 
         {/* FILTRE Région */}
+        <FiltreUsersRegion value={usersFilters.regions} onChange={(regions) => updateState({ regions })} />
 
         {/* FILTRE Type Utilisateur */}
         <FiltreUserTypes

--- a/ui/modules/admin/users/UsersFiltersPanel.tsx
+++ b/ui/modules/admin/users/UsersFiltersPanel.tsx
@@ -1,0 +1,69 @@
+import { Button, HStack, Stack, Text } from "@chakra-ui/react";
+import { useRouter } from "next/router";
+
+const UsersFiltersPanel = () => {
+  const router = useRouter();
+
+  //   const { organismesFilters, sort } = useMemo(() => {
+  //     const { pagination, sort } = parsePaginationInfosFromQuery(router.query as unknown as PaginationInfosQuery);
+  //     return {
+  //       organismesFilters: parseOrganismesFiltersFromQuery(router.query as unknown as OrganismesFiltersQuery),
+  //       pagination: pagination,
+  //       sort: sort ?? [{ desc: false, id: "nom" }],
+  //     };
+  //   }, [JSON.stringify(router.query)]);
+
+  //   const updateState = (newParams: Partial<{ [key in keyof OrganismesFilters]: any }>) => {
+  //     void router.push(
+  //       {
+  //         pathname: router.pathname,
+  //         query: {
+  //           ...(router.query.organismeId ? { organismeId: router.query.organismeId } : {}),
+  //           ...convertOrganismesFiltersToQuery({ ...organismesFilters, ...newParams }),
+  //           ...convertPaginationInfosToQuery({ sort, ...newParams }),
+  //         },
+  //       },
+  //       undefined,
+  //       { shallow: true }
+  //     );
+  //   };
+
+  const resetFilters = () => {
+    void router.push(
+      {
+        pathname: router.pathname,
+        query: { ...(router.query.organismeId ? { organismeId: router.query.organismeId } : {}) },
+      },
+      undefined,
+      { shallow: true }
+    );
+  };
+
+  return (
+    <Stack spacing="0.5">
+      <Text fontSize="zeta" fontWeight="extrabold">
+        FILTRER PAR
+      </Text>
+      <HStack>
+        {/* FILTRE Département */}
+
+        {/* FILTRE Région */}
+
+        {/* FILTRE Type Utilisateur */}
+
+        {/* FILTRE Réseau */}
+
+        {/* FILTRE Statut du compte */}
+
+        {/* FILTRE Période */}
+
+        {/* REINITIALISER */}
+        <Button variant="link" onClick={resetFilters} fontSize="omega">
+          réinitialiser
+        </Button>
+      </HStack>
+    </Stack>
+  );
+};
+
+export default UsersFiltersPanel;

--- a/ui/modules/admin/users/UsersFiltersPanel.tsx
+++ b/ui/modules/admin/users/UsersFiltersPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/modules/models/pagination";
 
 import FiltreUsersAccountStatut from "./filters/FiltreUsersAccountStatut";
+import FiltreUsersReseaux from "./filters/FiltreUsersReseaux";
 import FiltreUserTypes from "./filters/FiltreUsersType";
 import {
   UsersFilters,
@@ -72,6 +73,7 @@ const UsersFiltersPanel = () => {
         />
 
         {/* FILTRE Réseau */}
+        <FiltreUsersReseaux value={usersFilters.reseaux} onChange={(reseaux) => updateState({ reseaux })} />
 
         {/* FILTRE Statut du compte */}
         <FiltreUsersAccountStatut

--- a/ui/modules/admin/users/UsersFiltersPanel.tsx
+++ b/ui/modules/admin/users/UsersFiltersPanel.tsx
@@ -1,32 +1,47 @@
 import { Button, HStack, Stack, Text } from "@chakra-ui/react";
 import { useRouter } from "next/router";
+import { useMemo } from "react";
+
+import {
+  PaginationInfosQuery,
+  convertPaginationInfosToQuery,
+  parsePaginationInfosFromQuery,
+} from "@/modules/models/pagination";
+
+import FiltreUserTypes from "./filters/FiltreUsersType";
+import {
+  UsersFilters,
+  UsersFiltersQuery,
+  convertUsersFiltersToQuery,
+  parseUsersFiltersFromQuery,
+} from "./models/users-filters";
 
 const UsersFiltersPanel = () => {
   const router = useRouter();
 
-  //   const { organismesFilters, sort } = useMemo(() => {
-  //     const { pagination, sort } = parsePaginationInfosFromQuery(router.query as unknown as PaginationInfosQuery);
-  //     return {
-  //       organismesFilters: parseOrganismesFiltersFromQuery(router.query as unknown as OrganismesFiltersQuery),
-  //       pagination: pagination,
-  //       sort: sort ?? [{ desc: false, id: "nom" }],
-  //     };
-  //   }, [JSON.stringify(router.query)]);
+  const { usersFilters, sort } = useMemo(() => {
+    const { pagination, sort } = parsePaginationInfosFromQuery(router.query as unknown as PaginationInfosQuery);
+    return {
+      usersFilters: parseUsersFiltersFromQuery(router.query as unknown as UsersFiltersQuery),
+      pagination: pagination,
+      sort: sort ?? [{ desc: false, id: "nom" }],
+    };
+  }, [JSON.stringify(router.query)]);
 
-  //   const updateState = (newParams: Partial<{ [key in keyof OrganismesFilters]: any }>) => {
-  //     void router.push(
-  //       {
-  //         pathname: router.pathname,
-  //         query: {
-  //           ...(router.query.organismeId ? { organismeId: router.query.organismeId } : {}),
-  //           ...convertOrganismesFiltersToQuery({ ...organismesFilters, ...newParams }),
-  //           ...convertPaginationInfosToQuery({ sort, ...newParams }),
-  //         },
-  //       },
-  //       undefined,
-  //       { shallow: true }
-  //     );
-  //   };
+  const updateState = (newParams: Partial<{ [key in keyof UsersFilters]: any }>) => {
+    void router.push(
+      {
+        pathname: router.pathname,
+        query: {
+          ...(router.query.organismeId ? { organismeId: router.query.organismeId } : {}),
+          ...convertUsersFiltersToQuery({ ...usersFilters, ...newParams }),
+          ...convertPaginationInfosToQuery({ sort, ...newParams }),
+        },
+      },
+      undefined,
+      { shallow: true }
+    );
+  };
 
   const resetFilters = () => {
     void router.push(
@@ -50,6 +65,10 @@ const UsersFiltersPanel = () => {
         {/* FILTRE Région */}
 
         {/* FILTRE Type Utilisateur */}
+        <FiltreUserTypes
+          value={usersFilters.type_utilisateur}
+          onChange={(type_utilisateur) => updateState({ type_utilisateur })}
+        />
 
         {/* FILTRE Réseau */}
 

--- a/ui/modules/admin/users/filters/FiltreUsersAccountStatut.tsx
+++ b/ui/modules/admin/users/filters/FiltreUsersAccountStatut.tsx
@@ -1,0 +1,50 @@
+import { Checkbox, CheckboxGroup, Stack } from "@chakra-ui/react";
+import { useState } from "react";
+
+import { USER_STATUS_LABELS } from "@/common/constants/usersConstants";
+import { FilterButton } from "@/components/FilterButton/FilterButton";
+import SimpleOverlayMenu from "@/modules/dashboard/SimpleOverlayMenu";
+
+interface FiltreUsersAccountStatutTypesProps {
+  value: string[];
+  onChange: (statutsCompte: string[]) => void;
+}
+
+function FiltreUsersAccountStatut(props: FiltreUsersAccountStatutTypesProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const statutsCompte = props.value;
+
+  return (
+    <div>
+      <FilterButton
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        buttonLabel="Statut du compte"
+        badge={statutsCompte?.length}
+      />
+      {isOpen && (
+        <SimpleOverlayMenu onClose={() => setIsOpen(false)} width="auto" p="3w">
+          <CheckboxGroup
+            defaultValue={statutsCompte}
+            size="sm"
+            onChange={(selectedAccountStatuts: string[]) => props.onChange(selectedAccountStatuts)}
+          >
+            <Stack>
+              <Checkbox iconSize="0.5rem" value="CONFIRMED" key="CONFIRMED">
+                {USER_STATUS_LABELS.CONFIRMED}
+              </Checkbox>
+              <Checkbox iconSize="0.5rem" value="PENDING_EMAIL_VALIDATION" key="PENDING_EMAIL_VALIDATION">
+                {USER_STATUS_LABELS.PENDING_EMAIL_VALIDATION}
+              </Checkbox>
+              <Checkbox iconSize="0.5rem" value="PENDING_ADMIN_VALIDATION" key="PENDING_ADMIN_VALIDATION">
+                {USER_STATUS_LABELS.PENDING_ADMIN_VALIDATION}
+              </Checkbox>
+            </Stack>
+          </CheckboxGroup>
+        </SimpleOverlayMenu>
+      )}
+    </div>
+  );
+}
+
+export default FiltreUsersAccountStatut;

--- a/ui/modules/admin/users/filters/FiltreUsersDepartements.tsx
+++ b/ui/modules/admin/users/filters/FiltreUsersDepartements.tsx
@@ -1,0 +1,41 @@
+import { Checkbox, CheckboxGroup, Stack } from "@chakra-ui/react";
+import { useState } from "react";
+import { DEPARTEMENTS_SORTED } from "shared";
+
+import { FilterButton } from "@/components/FilterButton/FilterButton";
+import SimpleOverlayMenu from "@/modules/dashboard/SimpleOverlayMenu";
+
+interface FiltreUsersDepartmentTypesProps {
+  value: string[];
+  onChange: (departements: string[]) => void;
+}
+
+function FiltreUsersDepartment(props: FiltreUsersDepartmentTypesProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const departements = props.value;
+
+  return (
+    <div>
+      <FilterButton isOpen={isOpen} setIsOpen={setIsOpen} buttonLabel="Département" badge={departements?.length} />
+      {isOpen && (
+        <SimpleOverlayMenu onClose={() => setIsOpen(false)} width="auto" p="3w">
+          <CheckboxGroup
+            defaultValue={departements}
+            size="sm"
+            onChange={(selectedDepartements: string[]) => props.onChange(selectedDepartements)}
+          >
+            <Stack>
+              {DEPARTEMENTS_SORTED.map((departement, i) => (
+                <Checkbox iconSize="0.5rem" value={departement.code} key={i}>
+                  {departement.nom}
+                </Checkbox>
+              ))}
+            </Stack>
+          </CheckboxGroup>
+        </SimpleOverlayMenu>
+      )}
+    </div>
+  );
+}
+
+export default FiltreUsersDepartment;

--- a/ui/modules/admin/users/filters/FiltreUsersRegion.tsx
+++ b/ui/modules/admin/users/filters/FiltreUsersRegion.tsx
@@ -1,0 +1,41 @@
+import { Checkbox, CheckboxGroup, Stack } from "@chakra-ui/react";
+import { useState } from "react";
+import { REGIONS_SORTED } from "shared";
+
+import { FilterButton } from "@/components/FilterButton/FilterButton";
+import SimpleOverlayMenu from "@/modules/dashboard/SimpleOverlayMenu";
+
+interface FiltreUsersRegionTypesProps {
+  value: string[];
+  onChange: (regions: string[]) => void;
+}
+
+function FiltreUsersRegion(props: FiltreUsersRegionTypesProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const regions = props.value;
+
+  return (
+    <div>
+      <FilterButton isOpen={isOpen} setIsOpen={setIsOpen} buttonLabel="Région" badge={regions?.length} />
+      {isOpen && (
+        <SimpleOverlayMenu onClose={() => setIsOpen(false)} width="auto" p="3w">
+          <CheckboxGroup
+            defaultValue={regions}
+            size="sm"
+            onChange={(selectedRegions: string[]) => props.onChange(selectedRegions)}
+          >
+            <Stack>
+              {REGIONS_SORTED.map((region, i) => (
+                <Checkbox iconSize="0.5rem" value={region.code} key={i}>
+                  {region.nom}
+                </Checkbox>
+              ))}
+            </Stack>
+          </CheckboxGroup>
+        </SimpleOverlayMenu>
+      )}
+    </div>
+  );
+}
+
+export default FiltreUsersRegion;

--- a/ui/modules/admin/users/filters/FiltreUsersReseaux.tsx
+++ b/ui/modules/admin/users/filters/FiltreUsersReseaux.tsx
@@ -1,0 +1,41 @@
+import { Checkbox, CheckboxGroup, Stack } from "@chakra-ui/react";
+import { useState } from "react";
+import { TETE_DE_RESEAUX_SORTED } from "shared";
+
+import { FilterButton } from "@/components/FilterButton/FilterButton";
+import SimpleOverlayMenu from "@/modules/dashboard/SimpleOverlayMenu";
+
+interface FiltreUsersReseauxTypesProps {
+  value: string[];
+  onChange: (reseaux: string[]) => void;
+}
+
+function FiltreUsersReseaux(props: FiltreUsersReseauxTypesProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const reseaux = props.value;
+
+  return (
+    <div>
+      <FilterButton isOpen={isOpen} setIsOpen={setIsOpen} buttonLabel="Réseaux" badge={reseaux?.length} />
+      {isOpen && (
+        <SimpleOverlayMenu onClose={() => setIsOpen(false)} width="auto" p="3w">
+          <CheckboxGroup
+            defaultValue={reseaux}
+            size="sm"
+            onChange={(selectedReseaux: string[]) => props.onChange(selectedReseaux)}
+          >
+            <Stack>
+              {TETE_DE_RESEAUX_SORTED.map((reseau, i) => (
+                <Checkbox iconSize="0.5rem" value={reseau.key} key={i}>
+                  {reseau.nom}
+                </Checkbox>
+              ))}
+            </Stack>
+          </CheckboxGroup>
+        </SimpleOverlayMenu>
+      )}
+    </div>
+  );
+}
+
+export default FiltreUsersReseaux;

--- a/ui/modules/admin/users/filters/FiltreUsersType.tsx
+++ b/ui/modules/admin/users/filters/FiltreUsersType.tsx
@@ -1,0 +1,46 @@
+import { Checkbox, CheckboxGroup, Stack } from "@chakra-ui/react";
+import { useState } from "react";
+
+import { organisationTypes } from "@/common/internal/Organisation";
+import SimpleOverlayMenu from "@/modules/dashboard/SimpleOverlayMenu";
+import { OrganismesFilterButton } from "@/modules/organismes/filters/OrganismesFilterButton";
+
+interface FiltreUsersTypesProps {
+  value: string[];
+  onChange: (typesUtilisateurs: string[]) => void;
+}
+
+function FiltreUserTypes(props: FiltreUsersTypesProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const typesUtilisateurs = props.value;
+
+  return (
+    <div>
+      <OrganismesFilterButton
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        buttonLabel="Type d'utilisateur"
+        badge={typesUtilisateurs?.length}
+      />
+      {isOpen && (
+        <SimpleOverlayMenu onClose={() => setIsOpen(false)} width="auto" p="3w">
+          <CheckboxGroup
+            defaultValue={typesUtilisateurs}
+            size="sm"
+            onChange={(selectedTypesUtilisateurs: string[]) => props.onChange(selectedTypesUtilisateurs)}
+          >
+            <Stack>
+              {organisationTypes.map((type, i) => (
+                <Checkbox iconSize="0.5rem" value={type} key={i}>
+                  {type}
+                </Checkbox>
+              ))}
+            </Stack>
+          </CheckboxGroup>
+        </SimpleOverlayMenu>
+      )}
+    </div>
+  );
+}
+
+export default FiltreUserTypes;

--- a/ui/modules/admin/users/filters/FiltreUsersType.tsx
+++ b/ui/modules/admin/users/filters/FiltreUsersType.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, CheckboxGroup, Stack } from "@chakra-ui/react";
 import { useState } from "react";
 
-import { organisationTypes } from "@/common/internal/Organisation";
+import { TYPES_ORGANISATION } from "@/common/internal/Organisation";
 import SimpleOverlayMenu from "@/modules/dashboard/SimpleOverlayMenu";
 import { OrganismesFilterButton } from "@/modules/organismes/filters/OrganismesFilterButton";
 
@@ -30,9 +30,9 @@ function FiltreUserTypes(props: FiltreUsersTypesProps) {
             onChange={(selectedTypesUtilisateurs: string[]) => props.onChange(selectedTypesUtilisateurs)}
           >
             <Stack>
-              {organisationTypes.map((type, i) => (
-                <Checkbox iconSize="0.5rem" value={type} key={i}>
-                  {type}
+              {TYPES_ORGANISATION.map((option, index) => (
+                <Checkbox iconSize="0.5rem" value={option.key} key={index}>
+                  {option.nom}
                 </Checkbox>
               ))}
             </Stack>

--- a/ui/modules/admin/users/filters/FiltreUsersType.tsx
+++ b/ui/modules/admin/users/filters/FiltreUsersType.tsx
@@ -2,8 +2,8 @@ import { Checkbox, CheckboxGroup, Stack } from "@chakra-ui/react";
 import { useState } from "react";
 
 import { TYPES_ORGANISATION } from "@/common/internal/Organisation";
+import { FilterButton } from "@/components/FilterButton/FilterButton";
 import SimpleOverlayMenu from "@/modules/dashboard/SimpleOverlayMenu";
-import { OrganismesFilterButton } from "@/modules/organismes/filters/OrganismesFilterButton";
 
 interface FiltreUsersTypesProps {
   value: string[];
@@ -16,7 +16,7 @@ function FiltreUserTypes(props: FiltreUsersTypesProps) {
 
   return (
     <div>
-      <OrganismesFilterButton
+      <FilterButton
         isOpen={isOpen}
         setIsOpen={setIsOpen}
         buttonLabel="Type d'utilisateur"

--- a/ui/modules/admin/users/models/users-filters.ts
+++ b/ui/modules/admin/users/models/users-filters.ts
@@ -6,12 +6,16 @@ export interface UsersFilters {
   type_utilisateur: string[];
   account_status: string[];
   reseaux: string[];
+  departements: string[];
+  regions: string[];
 }
 
 export interface UsersFiltersQuery {
   type_utilisateur?: string;
   account_status?: string;
   reseaux?: string;
+  departements?: string;
+  regions?: string;
 }
 
 export function parseUsersFiltersFromQuery(query: UsersFiltersQuery): UsersFilters {
@@ -19,6 +23,8 @@ export function parseUsersFiltersFromQuery(query: UsersFiltersQuery): UsersFilte
     type_utilisateur: query.type_utilisateur?.split(",") ?? [],
     account_status: query.account_status?.split(",") ?? [],
     reseaux: query.reseaux?.split(",") ?? [],
+    departements: query.departements?.split(",") ?? [],
+    regions: query.regions?.split(",") ?? [],
   };
 }
 
@@ -27,6 +33,8 @@ export function convertUsersFiltersToQuery(organismesFilters: Partial<UsersFilte
     type_utilisateur: organismesFilters.type_utilisateur?.join(","),
     account_status: organismesFilters.account_status?.join(","),
     reseaux: organismesFilters.reseaux?.join(","),
+    departements: organismesFilters.departements?.join(","),
+    regions: organismesFilters.regions?.join(","),
   });
 }
 
@@ -48,6 +56,12 @@ export function filterUsersArrayFromUsersFilters(
         item.organismeReseaux.length > 0 &&
         item.organismeReseaux.some((reseau) => usersFilters.reseaux?.includes(reseau))
     );
+
+  if (usersFilters.departements?.length && usersFilters.departements?.length > 0)
+    filteredUsers = filteredUsers?.filter((item) => usersFilters.departements?.includes(item.organismeDepartement));
+
+  if (usersFilters.regions?.length && usersFilters.regions?.length > 0)
+    filteredUsers = filteredUsers?.filter((item) => usersFilters.regions?.includes(item.organismeRegion));
 
   return filteredUsers;
 }

--- a/ui/modules/admin/users/models/users-filters.ts
+++ b/ui/modules/admin/users/models/users-filters.ts
@@ -1,0 +1,30 @@
+import { stripEmptyFields } from "@/common/utils/misc";
+
+export interface UsersFilters {
+  type_utilisateur: string[];
+}
+
+export interface UsersFiltersQuery {
+  type_utilisateur?: string;
+}
+
+export function parseUsersFiltersFromQuery(query: UsersFiltersQuery): UsersFilters {
+  return {
+    type_utilisateur: query.type_utilisateur?.split(",") ?? [],
+  };
+}
+
+export function convertUsersFiltersToQuery(organismesFilters: Partial<UsersFilters>): Partial<UsersFiltersQuery> {
+  return stripEmptyFields({
+    type_utilisateur: organismesFilters.type_utilisateur?.join(","),
+  });
+}
+
+export function filterUsersArrayFromUsersFilters(users, usersFilters: Partial<UsersFilters>) {
+  let filteredUsers = users;
+
+  if (usersFilters.type_utilisateur?.length && usersFilters.type_utilisateur?.length > 0)
+    filteredUsers = filteredUsers?.filter((item) => usersFilters.type_utilisateur?.includes(item.userType));
+
+  return filteredUsers;
+}

--- a/ui/modules/admin/users/models/users-filters.ts
+++ b/ui/modules/admin/users/models/users-filters.ts
@@ -5,17 +5,20 @@ import { UserNormalized } from "./users";
 export interface UsersFilters {
   type_utilisateur: string[];
   account_status: string[];
+  reseaux: string[];
 }
 
 export interface UsersFiltersQuery {
   type_utilisateur?: string;
   account_status?: string;
+  reseaux?: string;
 }
 
 export function parseUsersFiltersFromQuery(query: UsersFiltersQuery): UsersFilters {
   return {
     type_utilisateur: query.type_utilisateur?.split(",") ?? [],
     account_status: query.account_status?.split(",") ?? [],
+    reseaux: query.reseaux?.split(",") ?? [],
   };
 }
 
@@ -23,6 +26,7 @@ export function convertUsersFiltersToQuery(organismesFilters: Partial<UsersFilte
   return stripEmptyFields({
     type_utilisateur: organismesFilters.type_utilisateur?.join(","),
     account_status: organismesFilters.account_status?.join(","),
+    reseaux: organismesFilters.reseaux?.join(","),
   });
 }
 
@@ -37,6 +41,13 @@ export function filterUsersArrayFromUsersFilters(
 
   if (usersFilters.account_status?.length && usersFilters.account_status?.length > 0)
     filteredUsers = filteredUsers?.filter((item) => usersFilters.account_status?.includes(item.account_status));
+
+  if (usersFilters.reseaux?.length && usersFilters.reseaux?.length > 0)
+    filteredUsers = filteredUsers?.filter(
+      (item) =>
+        item.organismeReseaux.length > 0 &&
+        item.organismeReseaux.some((reseau) => usersFilters.reseaux?.includes(reseau))
+    );
 
   return filteredUsers;
 }

--- a/ui/modules/admin/users/models/users-filters.ts
+++ b/ui/modules/admin/users/models/users-filters.ts
@@ -1,30 +1,42 @@
 import { stripEmptyFields } from "@/common/utils/misc";
 
+import { UserNormalized } from "./users";
+
 export interface UsersFilters {
   type_utilisateur: string[];
+  account_status: string[];
 }
 
 export interface UsersFiltersQuery {
   type_utilisateur?: string;
+  account_status?: string;
 }
 
 export function parseUsersFiltersFromQuery(query: UsersFiltersQuery): UsersFilters {
   return {
     type_utilisateur: query.type_utilisateur?.split(",") ?? [],
+    account_status: query.account_status?.split(",") ?? [],
   };
 }
 
 export function convertUsersFiltersToQuery(organismesFilters: Partial<UsersFilters>): Partial<UsersFiltersQuery> {
   return stripEmptyFields({
     type_utilisateur: organismesFilters.type_utilisateur?.join(","),
+    account_status: organismesFilters.account_status?.join(","),
   });
 }
 
-export function filterUsersArrayFromUsersFilters(users, usersFilters: Partial<UsersFilters>) {
+export function filterUsersArrayFromUsersFilters(
+  users: UserNormalized[],
+  usersFilters: Partial<UsersFilters>
+): UserNormalized[] {
   let filteredUsers = users;
 
   if (usersFilters.type_utilisateur?.length && usersFilters.type_utilisateur?.length > 0)
     filteredUsers = filteredUsers?.filter((item) => usersFilters.type_utilisateur?.includes(item.userType));
+
+  if (usersFilters.account_status?.length && usersFilters.account_status?.length > 0)
+    filteredUsers = filteredUsers?.filter((item) => usersFilters.account_status?.includes(item.account_status));
 
   return filteredUsers;
 }

--- a/ui/modules/admin/users/models/users.ts
+++ b/ui/modules/admin/users/models/users.ts
@@ -16,6 +16,7 @@ export type UserNormalized = {
   userType: string;
   organismeId: string;
   organismeNom: string;
+  organismeReseaux: string[];
   nom: string;
   prenom: string;
   account_status: string;
@@ -28,10 +29,13 @@ export type UserNormalized = {
 export const toUserNormalized = (user: User): UserNormalized => {
   const organismeId = user?.organisation?.organisme?._id;
   const organismeNom = user?.organisation?.organisme?.nom || user?.organisation?.label || "";
+  const organismeReseaux = user?.organisation?.organisme?.reseaux || [];
+
   return {
     ...user,
     organismeId,
     organismeNom,
+    organismeReseaux,
     created_at: formatDateDayMonthYear(user.created_at),
     organisationType: user?.organisation?.label || "",
     userType: user?.organisation?.type || "",

--- a/ui/modules/admin/users/models/users.ts
+++ b/ui/modules/admin/users/models/users.ts
@@ -17,6 +17,8 @@ export type UserNormalized = {
   organismeId: string;
   organismeNom: string;
   organismeReseaux: string[];
+  organismeDepartement: string;
+  organismeRegion: string;
   nom: string;
   prenom: string;
   account_status: string;
@@ -30,12 +32,16 @@ export const toUserNormalized = (user: User): UserNormalized => {
   const organismeId = user?.organisation?.organisme?._id;
   const organismeNom = user?.organisation?.organisme?.nom || user?.organisation?.label || "";
   const organismeReseaux = user?.organisation?.organisme?.reseaux || [];
+  const organismeDepartement = user?.organisation?.organisme?.adresse?.departement || "";
+  const organismeRegion = user?.organisation?.organisme?.adresse?.region || "";
 
   return {
     ...user,
     organismeId,
     organismeNom,
     organismeReseaux,
+    organismeDepartement,
+    organismeRegion,
     created_at: formatDateDayMonthYear(user.created_at),
     organisationType: user?.organisation?.label || "",
     userType: user?.organisation?.type || "",

--- a/ui/modules/admin/users/models/users.ts
+++ b/ui/modules/admin/users/models/users.ts
@@ -1,0 +1,42 @@
+import { User, UserOrganisation } from "@/common/internal/User";
+import { formatDateDayMonthYear } from "@/common/utils/dateUtils";
+
+export type UserNormalized = {
+  _id: string;
+  password_updated_at: Date;
+  civility: string;
+  telephone: string;
+  has_accept_cgu_version: string;
+  organisation_id: string;
+  organisation: UserOrganisation;
+  normalizedNomPrenom: string;
+  normalizedEmail: string;
+  normalizedOrganismeNom: string;
+  organisationType: string;
+  userType: string;
+  organismeId: string;
+  organismeNom: string;
+  nom: string;
+  prenom: string;
+  account_status: string;
+  created_at: string;
+  email: string;
+  fonction: string;
+  last_connection: string;
+};
+
+export const toUserNormalized = (user: User): UserNormalized => {
+  const organismeId = user?.organisation?.organisme?._id;
+  const organismeNom = user?.organisation?.organisme?.nom || user?.organisation?.label || "";
+  return {
+    ...user,
+    organismeId,
+    organismeNom,
+    created_at: formatDateDayMonthYear(user.created_at),
+    organisationType: user?.organisation?.label || "",
+    userType: user?.organisation?.type || "",
+    normalizedOrganismeNom: organismeNom.toLowerCase(),
+    normalizedNomPrenom: user.nom.toLowerCase() + " " + user.prenom.toLowerCase(),
+    normalizedEmail: user.email.toLowerCase(),
+  };
+};

--- a/ui/modules/organismes/filters/FiltreOrganismeDepartements.tsx
+++ b/ui/modules/organismes/filters/FiltreOrganismeDepartements.tsx
@@ -5,7 +5,7 @@ import { DEPARTEMENTS_SORTED } from "shared";
 import useAuth from "@/hooks/useAuth";
 import SimpleOverlayMenu from "@/modules/dashboard/SimpleOverlayMenu";
 
-import { OrganismesFilterButton } from "./OrganismesFilterButton";
+import { FilterButton } from "../../../components/FilterButton/FilterButton";
 
 interface FiltreOrganismeDepartementsProps {
   value: string[];
@@ -35,12 +35,7 @@ function FiltreOrganismeDepartements(props: FiltreOrganismeDepartementsProps) {
 
   return (
     <div>
-      <OrganismesFilterButton
-        isOpen={isOpen}
-        setIsOpen={setIsOpen}
-        buttonLabel="Département"
-        badge={departements?.length}
-      />
+      <FilterButton isOpen={isOpen} setIsOpen={setIsOpen} buttonLabel="Département" badge={departements?.length} />
       {isOpen && (
         <SimpleOverlayMenu onClose={() => setIsOpen(false)} width="auto" p="3w">
           <CheckboxGroup

--- a/ui/modules/organismes/filters/FiltreOrganismeEtat.tsx
+++ b/ui/modules/organismes/filters/FiltreOrganismeEtat.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 import SimpleOverlayMenu from "@/modules/dashboard/SimpleOverlayMenu";
 
-import { OrganismesFilterButton } from "./OrganismesFilterButton";
+import { FilterButton } from "../../../components/FilterButton/FilterButton";
 
 interface FiltreOrganismesEtatProps {
   value: boolean[];
@@ -16,7 +16,7 @@ function FiltreOrganismesEtat(props: FiltreOrganismesEtatProps) {
 
   return (
     <div>
-      <OrganismesFilterButton isOpen={isOpen} setIsOpen={setIsOpen} buttonLabel="État" badge={etats?.length} />
+      <FilterButton isOpen={isOpen} setIsOpen={setIsOpen} buttonLabel="État" badge={etats?.length} />
       {isOpen && (
         <SimpleOverlayMenu onClose={() => setIsOpen(false)} width="auto" p="3w">
           <CheckboxGroup

--- a/ui/modules/organismes/filters/FiltreOrganismeNature.tsx
+++ b/ui/modules/organismes/filters/FiltreOrganismeNature.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 import SimpleOverlayMenu from "@/modules/dashboard/SimpleOverlayMenu";
 
-import { OrganismesFilterButton } from "./OrganismesFilterButton";
+import { FilterButton } from "../../../components/FilterButton/FilterButton";
 
 interface FiltreOrganismesNatureProps {
   value: string[];
@@ -16,7 +16,7 @@ function FiltreOrganismesNature(props: FiltreOrganismesNatureProps) {
 
   return (
     <div>
-      <OrganismesFilterButton isOpen={isOpen} setIsOpen={setIsOpen} buttonLabel="Nature" badge={natures?.length} />
+      <FilterButton isOpen={isOpen} setIsOpen={setIsOpen} buttonLabel="Nature" badge={natures?.length} />
       {isOpen && (
         <SimpleOverlayMenu onClose={() => setIsOpen(false)} width="auto" p="3w">
           <CheckboxGroup value={props.value} onChange={(value) => props.onChange(value.map((v: string) => v))}>

--- a/ui/modules/organismes/filters/FiltreOrganismeRegions.tsx
+++ b/ui/modules/organismes/filters/FiltreOrganismeRegions.tsx
@@ -4,7 +4,7 @@ import { REGIONS_SORTED } from "shared";
 
 import SimpleOverlayMenu from "@/modules/dashboard/SimpleOverlayMenu";
 
-import { OrganismesFilterButton } from "./OrganismesFilterButton";
+import { FilterButton } from "../../../components/FilterButton/FilterButton";
 
 interface FiltreOrganismeRegionsProps {
   value: string[];
@@ -17,7 +17,7 @@ function FiltreOrganismeRegions(props: FiltreOrganismeRegionsProps) {
 
   return (
     <div>
-      <OrganismesFilterButton isOpen={isOpen} setIsOpen={setIsOpen} buttonLabel="Région" badge={regions?.length} />
+      <FilterButton isOpen={isOpen} setIsOpen={setIsOpen} buttonLabel="Région" badge={regions?.length} />
       {isOpen && (
         <SimpleOverlayMenu onClose={() => setIsOpen(false)} width="auto" p="3w">
           <CheckboxGroup

--- a/ui/modules/organismes/filters/FiltreOrganismeTransmission.tsx
+++ b/ui/modules/organismes/filters/FiltreOrganismeTransmission.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 import SimpleOverlayMenu from "@/modules/dashboard/SimpleOverlayMenu";
 
-import { OrganismesFilterButton } from "./OrganismesFilterButton";
+import { FilterButton } from "../../../components/FilterButton/FilterButton";
 
 interface FiltreOrganismeTransmissionProps {
   fieldName: string;
@@ -17,12 +17,7 @@ function FiltreOrganismeTransmission(props: FiltreOrganismeTransmissionProps) {
 
   return (
     <div>
-      <OrganismesFilterButton
-        isOpen={isOpen}
-        setIsOpen={setIsOpen}
-        buttonLabel="Transmission"
-        badge={transmissions?.length}
-      />
+      <FilterButton isOpen={isOpen} setIsOpen={setIsOpen} buttonLabel="Transmission" badge={transmissions?.length} />
       {isOpen && (
         <SimpleOverlayMenu onClose={() => setIsOpen(false)} width="auto" p="3w">
           <CheckboxGroup

--- a/ui/modules/organismes/filters/FiltreOrganismeUai.tsx
+++ b/ui/modules/organismes/filters/FiltreOrganismeUai.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 import SimpleOverlayMenu from "@/modules/dashboard/SimpleOverlayMenu";
 
-import { OrganismesFilterButton } from "./OrganismesFilterButton";
+import { FilterButton } from "../../../components/FilterButton/FilterButton";
 
 interface FiltreOrganismeUaiProps {
   value: boolean[];
@@ -16,7 +16,7 @@ function FiltreOrganismeUai(props: FiltreOrganismeUaiProps) {
 
   return (
     <div>
-      <OrganismesFilterButton isOpen={isOpen} setIsOpen={setIsOpen} buttonLabel="UAI" badge={etatUAI?.length} />
+      <FilterButton isOpen={isOpen} setIsOpen={setIsOpen} buttonLabel="UAI" badge={etatUAI?.length} />
       {isOpen && (
         <SimpleOverlayMenu onClose={() => setIsOpen(false)} width="auto" p="3w">
           <CheckboxGroup

--- a/ui/modules/organismes/filters/FiltreYesNo.tsx
+++ b/ui/modules/organismes/filters/FiltreYesNo.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 import SimpleOverlayMenu from "@/modules/dashboard/SimpleOverlayMenu";
 
-import { OrganismesFilterButton } from "./OrganismesFilterButton";
+import { FilterButton } from "../../../components/FilterButton/FilterButton";
 
 interface FiltreYesNoProps {
   fieldName: string;
@@ -19,12 +19,7 @@ function FiltreYesNo(props: FiltreYesNoProps) {
 
   return (
     <div>
-      <OrganismesFilterButton
-        isOpen={isOpen}
-        setIsOpen={setIsOpen}
-        buttonLabel={buttonLabel}
-        badge={selectionItems?.length}
-      />
+      <FilterButton isOpen={isOpen} setIsOpen={setIsOpen} buttonLabel={buttonLabel} badge={selectionItems?.length} />
       {isOpen && (
         <SimpleOverlayMenu onClose={() => setIsOpen(false)} width="auto" p="3w">
           <CheckboxGroup

--- a/ui/pages/admin/users/index.tsx
+++ b/ui/pages/admin/users/index.tsx
@@ -1,16 +1,19 @@
+import { SearchIcon } from "@chakra-ui/icons";
 import {
   Box,
+  Button,
+  Divider,
   Heading,
   HStack,
   Input,
+  InputGroup,
+  InputRightElement,
   Modal,
   ModalCloseButton,
   ModalContent,
   ModalHeader,
   ModalOverlay,
-  Stack,
   Text,
-  VStack,
 } from "@chakra-ui/react";
 import { useQuery } from "@tanstack/react-query";
 import { AccessorKeyColumnDef, SortingState } from "@tanstack/react-table";
@@ -19,7 +22,7 @@ import NavLink from "next/link";
 import { useRouter } from "next/router";
 import { useMemo, useState } from "react";
 
-import { USER_STATUS_LABELS } from "@/common/constants/usersConstants";
+import { USER_STATUS_LABELS, USER_STATUS_STYLE } from "@/common/constants/usersConstants";
 import { usersExportColumns } from "@/common/exports";
 import { _get } from "@/common/httpClient";
 import { getAuthServerSideProps } from "@/common/SSR/getAuthServerSideProps";
@@ -29,6 +32,7 @@ import DownloadButton from "@/components/buttons/DownloadButton";
 import Page from "@/components/Page/Page";
 import withAuth from "@/components/withAuth";
 import UserForm from "@/modules/admin/UserForm";
+import UsersFiltersPanel from "@/modules/admin/users/UsersFiltersPanel";
 import NewTable from "@/modules/indicateurs/NewTable";
 import { ArrowRightLine } from "@/theme/components/icons";
 
@@ -111,7 +115,9 @@ const UsersColumns: AccessorKeyColumnDef<UserNormalized>[] = [
     accessorKey: "account_status",
     cell: ({ row }) => (
       <>
-        <Text fontSize="sm">{USER_STATUS_LABELS[row.original?.account_status] ?? row.original?.account_status}</Text>
+        <Text color={USER_STATUS_STYLE[row.original?.account_status] ?? "black"} fontSize="sm">
+          {USER_STATUS_LABELS[row.original?.account_status] ?? row.original?.account_status}
+        </Text>
       </>
     ),
   },
@@ -161,6 +167,8 @@ const Users = () => {
     });
   }, [data]);
 
+  console.log("users :>> ", users);
+
   const filteredUsers = useMemo(() => {
     if (!search) return users;
     return users?.filter((user) => {
@@ -208,80 +216,85 @@ const Users = () => {
         </ModalContent>
       </Modal>
 
-      <VStack alignItems="baseline" width="100%">
-        <HStack justifyContent="space-between" alignItems="baseline" width="100%">
-          <Heading as="h1" mb={8} mt={6}>
-            {title}
-          </Heading>
-          {/** désactivé tant que formulaire de création pas complet */}
-          {/* {!isLoading && (
-            <Button as={NavLink} href="?new=1" bg="bluefrance" color="white" _hover={{ bg: "blue.700" }}>
-              Créer un utilisateur
-            </Button>
-          )} */}
-        </HStack>
-        <Stack spacing={2} width="100%">
-          <HStack gap={0}>
+      <Heading as="h1" mb={8} mt={6}>
+        {title}
+      </Heading>
+
+      <Box border="1px solid" borderColor="openbluefrance" p={4}>
+        <HStack mb="4" spacing="8">
+          <InputGroup>
             <Input
               placeholder="Rechercher un utilisateur par nom, prénom, email, siret, établissement, etc."
               type="search"
               name="q"
               defaultValue={search}
               onChange={(e) => setSearch(e.target.value)}
+              flex="1"
+              mr="2"
             />
-          </HStack>
-          <HStack>
-            <DownloadButton
-              mr="4"
-              variant="secondary"
-              action={async () => {
-                exportDataAsXlsx(
-                  `users.xlsx`,
-                  filteredUsers.map((e) => {
-                    return {
-                      account_status: e.account_status,
-                      civility: e.civility,
-                      created_at: e.created_at,
-                      nom: e.nom,
-                      prenom: e.prenom,
-                      email: e.email,
-                      telephone: e.telephone,
-                      fonction: e.fonction,
-                      "organisation.type": e.organisation.type,
-                      "organisation.siret": e.organisation.siret,
-                      "organisation.uai": e.organisation.uai,
-                      "organisation.label": e.organisation.label,
-                      "organisation.organisme.nature": e.organisation.organisme?.nature,
-                      "organisation.organisme.nom": e.organisation.organisme?.nom,
-                      "organisation.organisme.raison_sociale": e.organisation.organisme?.raison_sociale,
-                      "organisation.organisme.reseaux": e.organisation.organisme?.reseaux?.join(", "),
-                      password_updated_at: e.password_updated_at,
-                      has_accept_cgu_version: e.has_accept_cgu_version,
-                      last_connection: e.last_connection,
-                      _id: e._id,
-                    };
-                  }),
-                  usersExportColumns
-                );
-              }}
-            >
-              Télécharger la liste
-            </DownloadButton>
-            <Text py="6" color="#777">
-              {Intl.NumberFormat().format(filteredUsers.length || 0)}{" "}
-              {filteredUsers.length > 1 ? "comptes utilisateurs" : "compte utilisateur"}
-              {filteredUsers.length < users.length ? ` (${users.length} au total)` : ""}
-            </Text>
-          </HStack>
-          <NewTable
-            data={filteredUsers || []}
-            loading={isLoading}
-            sortingState={sort}
-            onSortingChange={(state) => setSort(state)}
-            columns={UsersColumns}
-          />
-        </Stack>
-      </VStack>
+            <InputRightElement>
+              <Button backgroundColor="bluefrance" _hover={{ textDecoration: "none" }}>
+                <SearchIcon textColor="white" />
+              </Button>
+            </InputRightElement>
+          </InputGroup>
+          <DownloadButton
+            mr="4"
+            w="25%"
+            variant="secondary"
+            action={async () => {
+              exportDataAsXlsx(
+                `users.xlsx`,
+                filteredUsers.map((e) => {
+                  return {
+                    account_status: e.account_status,
+                    civility: e.civility,
+                    created_at: e.created_at,
+                    nom: e.nom,
+                    prenom: e.prenom,
+                    email: e.email,
+                    telephone: e.telephone,
+                    fonction: e.fonction,
+                    "organisation.type": e.organisation.type,
+                    "organisation.siret": e.organisation.siret,
+                    "organisation.uai": e.organisation.uai,
+                    "organisation.label": e.organisation.label,
+                    "organisation.organisme.nature": e.organisation.organisme?.nature,
+                    "organisation.organisme.nom": e.organisation.organisme?.nom,
+                    "organisation.organisme.raison_sociale": e.organisation.organisme?.raison_sociale,
+                    "organisation.organisme.reseaux": e.organisation.organisme?.reseaux?.join(", "),
+                    password_updated_at: e.password_updated_at,
+                    has_accept_cgu_version: e.has_accept_cgu_version,
+                    last_connection: e.last_connection,
+                    _id: e._id,
+                  };
+                }),
+                usersExportColumns
+              );
+            }}
+          >
+            Télécharger la liste
+          </DownloadButton>
+        </HStack>
+        <Divider mb="4" />
+        <HStack>
+          <UsersFiltersPanel />
+        </HStack>
+      </Box>
+
+      <Text py="6" color="#777">
+        {Intl.NumberFormat().format(filteredUsers.length || 0)}{" "}
+        {filteredUsers.length > 1 ? "comptes utilisateurs" : "compte utilisateur"}
+        {filteredUsers.length < users.length ? ` (${users.length} au total)` : ""}
+      </Text>
+
+      <NewTable
+        data={filteredUsers || []}
+        loading={isLoading}
+        sortingState={sort}
+        onSortingChange={(state) => setSort(state)}
+        columns={UsersColumns}
+      />
     </Page>
   );
 };


### PR DESCRIPTION
Ajout de filtres sur la page utilisateurs (admin)

Cf : https://tableaudebord-apprentissage.atlassian.net/browse/TM-440

Maquette : https://tableaudebord-apprentissage.atlassian.net/browse/TM-440

- J'ai un peu refacto le code (avec des hooks)
- Ajout des données utiles pour les filtres coté serveur (adresse -> région & dpt)
- Création d'un type UsersPaginated pour la récupération coté API des données paginées
- J'ai repris la logique des filtres organismes / indicateurs

Il manque le filtre périodes car il n'a pas été spécifié pour l'instant, on verra dans un prochain sprint.

