### PR TITLE
fix(ui): filtres région / dpt sur organisation + format date

### DIFF
--- a/ui/common/internal/User.ts
+++ b/ui/common/internal/User.ts
@@ -26,6 +26,8 @@ export interface UserOrganisation {
   type: string;
   uai: string;
   siret: string;
+  code_departement: string;
+  code_region: string;
   organisme: UserOrganisme;
   label: string;
 }

--- a/ui/modules/admin/users/models/users-filters.ts
+++ b/ui/modules/admin/users/models/users-filters.ts
@@ -58,10 +58,15 @@ export function filterUsersArrayFromUsersFilters(
     );
 
   if (usersFilters.departements?.length && usersFilters.departements?.length > 0)
-    filteredUsers = filteredUsers?.filter((item) => usersFilters.departements?.includes(item.organismeDepartement));
+    filteredUsers = filteredUsers?.filter(
+      (item) => usersFilters.departements?.includes(item.organismeDepartement || item.organisationDepartement)
+    );
 
-  if (usersFilters.regions?.length && usersFilters.regions?.length > 0)
-    filteredUsers = filteredUsers?.filter((item) => usersFilters.regions?.includes(item.organismeRegion));
+  if (usersFilters.regions?.length && usersFilters.regions?.length > 0) {
+    filteredUsers = filteredUsers?.filter(
+      (item) => usersFilters.regions?.includes(item.organismeRegion || item.organisationRegion)
+    );
+  }
 
   return filteredUsers;
 }

--- a/ui/modules/admin/users/models/users.ts
+++ b/ui/modules/admin/users/models/users.ts
@@ -1,5 +1,4 @@
 import { User, UserOrganisation } from "@/common/internal/User";
-import { formatDateDayMonthYear } from "@/common/utils/dateUtils";
 
 export type UserNormalized = {
   _id: string;
@@ -19,6 +18,8 @@ export type UserNormalized = {
   organismeReseaux: string[];
   organismeDepartement: string;
   organismeRegion: string;
+  organisationDepartement: string;
+  organisationRegion: string;
   nom: string;
   prenom: string;
   account_status: string;
@@ -34,6 +35,8 @@ export const toUserNormalized = (user: User): UserNormalized => {
   const organismeReseaux = user?.organisation?.organisme?.reseaux || [];
   const organismeDepartement = user?.organisation?.organisme?.adresse?.departement || "";
   const organismeRegion = user?.organisation?.organisme?.adresse?.region || "";
+  const organisationDepartement = user?.organisation?.code_departement || "";
+  const organisationRegion = user?.organisation?.code_region || "";
 
   return {
     ...user,
@@ -42,7 +45,9 @@ export const toUserNormalized = (user: User): UserNormalized => {
     organismeReseaux,
     organismeDepartement,
     organismeRegion,
-    created_at: formatDateDayMonthYear(user.created_at),
+    organisationDepartement,
+    organisationRegion,
+    created_at: user.created_at.toLocaleString(),
     organisationType: user?.organisation?.label || "",
     userType: user?.organisation?.type || "",
     normalizedOrganismeNom: organismeNom.toLowerCase(),


### PR DESCRIPTION
2 petites anomalies sur les filtres utilisateurs : 

- J'avais oublié de filtrer sur le dpt / région de l'organisation quand il y en a
- Pb de format de date

Cf https://tableaudebord-apprentissage.atlassian.net/browse/TM-501