### PR TITLE
feat(server): migration de suppression de la raisonSociale - enseigne computed dans effectifs

### DIFF
--- a/server/src/db/migrations/20231128113006-delete-effectifs-computed-organisme-raisonSociale-enseigne.ts
+++ b/server/src/db/migrations/20231128113006-delete-effectifs-computed-organisme-raisonSociale-enseigne.ts
@@ -1,0 +1,7 @@
+import { Db } from "mongodb";
+
+export const up = async (db: Db) => {
+  await db
+    .collection("effectifs")
+    .updateMany({}, { $unset: { "_computed.organisme.enseigne": "", "_computed.organisme.raison_sociale": "" } });
+};


### PR DESCRIPTION
Une ancienne PR ajoutait au champ _computed des organismes la raison sociale et l'enseigne 👉🏼 https://github.com/mission-apprentissage/flux-retour-cfas/pull/3356

Finalement on est revenus en arrière 👉🏼 https://github.com/mission-apprentissage/flux-retour-cfas/pull/3361 en supprimant ces champs du modèle mais on a pas fait de revert des données.