### PR TITLE
fix: dates de début-fin de formations en années dans l'export nominatif il ne faut pas le formater

### DIFF
--- a/ui/common/exports.ts
+++ b/ui/common/exports.ts
@@ -118,7 +118,6 @@ export const effectifsExportColumns = [
   {
     label: "formation_date_debut_formation",
     key: "formation_date_debut_formation",
-    xlsxType: "date",
     width: 20,
   },
   {


### PR DESCRIPTION
Ce n'étais pas clair, mais j'ai constaté que deux variables étaient en fait des années (bizarre d'ailleurs mais bon) alors que dans l'export je pensais que c'était des dates.

```
          formation_date_debut_formation: { $arrayElemAt: ["$formation.periode", 0] },
          formation_date_fin_formation: { $arrayElemAt: ["$formation.periode", 1] },
```

Donc j'ai corrigé. (https://tableaudebord-apprentissage.atlassian.net/browse/TM-516)