### PR TITLE
feat: ajout de l'organisme transmetteur dans l'encart admin

### DIFF
--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -175,7 +175,8 @@ export const updateOrganismeFromApis = async (organisme: WithId<Organisme>) => {
 export const updateOrganismeTransmission = async (
   organisme: Pick<WithId<Organisme>, "_id" | "first_transmission_date">,
   source?: string,
-  api_version?: string
+  api_version?: string,
+  source_organisme_id?: string
 ) => {
   const modifyResult = await organismesDb().findOneAndUpdate(
     { _id: organisme._id },
@@ -184,6 +185,7 @@ export const updateOrganismeTransmission = async (
         ...(organisme.first_transmission_date ? {} : { first_transmission_date: new Date() }),
         last_transmission_date: new Date(),
         ...(api_version ? { api_version } : {}),
+        ...(source_organisme_id ? { organisme_transmetteur_id: source_organisme_id } : {}),
         updated_at: new Date(),
       },
       ...(source ? { $addToSet: { erps: source } } : {}),

--- a/server/src/common/model/@types/Organisme.ts
+++ b/server/src/common/model/@types/Organisme.ts
@@ -1030,6 +1030,10 @@ export interface Organisme {
    */
   creation_statut?: "ORGANISME_LIEU_FORMATION";
   /**
+   * Identifiant de l'organisme qui transmet les effectifs de cet organisme
+   */
+  organisme_transmetteur_id?: string;
+  /**
    * Date de mise à jour en base de données
    */
   updated_at?: Date;

--- a/server/src/common/model/organismes.model.ts
+++ b/server/src/common/model/organismes.model.ts
@@ -5,6 +5,7 @@ import { SIRET_REGEX_PATTERN, UAI_REGEX_PATTERN } from "@/common/constants/valid
 
 import { NATURE_ORGANISME_DE_FORMATION, STATUT_PRESENCE_REFERENTIEL } from "../constants/organisme";
 
+import effectifsModel from "./effectifs.model/effectifs.model";
 import { adresseSchema } from "./json-schema/adresseSchema";
 import {
   arrayOf,
@@ -195,6 +196,9 @@ const schema = object(
     creation_statut: string({
       description: "Flag pour identifier que c'est un organisme créé à partir d'un lieu",
       enum: [STATUT_CREATION_ORGANISME.ORGANISME_LIEU_FORMATION],
+    }),
+    organisme_transmetteur_id: string({
+      description: effectifsModel.schema.properties.source_organisme_id.description,
     }),
     updated_at: date({ description: "Date de mise à jour en base de données" }),
     created_at: date({ description: "Date d'ajout en base de données" }),

--- a/server/src/http/routes/admin.routes/organismes.routes.ts
+++ b/server/src/http/routes/admin.routes/organismes.routes.ts
@@ -66,6 +66,7 @@ export default () => {
     }),
     async ({ params }, res) => {
       const { id } = params;
+
       const organisme = await findOrganismeById(id as string, {
         last_transmission_date: 1,
         erps: 1,
@@ -73,9 +74,17 @@ export default () => {
         mode_de_transmission: 1,
         mode_de_transmission_configuration_date: 1,
         api_version: 1,
+        organisme_transmetteur_id: 1,
       });
+
       if (!organisme) {
         throw Boom.notFound(`Organisme with id ${id} not found`);
+      }
+
+      let organismeTransmetteur;
+
+      if (organisme.organisme_transmetteur_id) {
+        organismeTransmetteur = await findOrganismeById(organisme.organisme_transmetteur_id);
       }
 
       res.json({
@@ -87,6 +96,16 @@ export default () => {
         parametrage_erp_active: !!organisme.mode_de_transmission_configuration_date,
         parametrage_erp_date: organisme.mode_de_transmission_configuration_date,
         erps: organisme.erps,
+        organisme_transmetteur_id: organisme.organisme_transmetteur_id,
+        ...(organismeTransmetteur
+          ? {
+              organisme_transmetteur: {
+                _id: organismeTransmetteur._id,
+                enseigne: organismeTransmetteur.enseigne,
+                raison_sociale: organismeTransmetteur.raison_sociale,
+              },
+            }
+          : {}),
       });
     }
   );

--- a/server/src/jobs/ingestion/process-ingestion.ts
+++ b/server/src/jobs/ingestion/process-ingestion.ts
@@ -132,7 +132,12 @@ async function processEffectifQueueItem(effectifQueue: WithId<EffectifsQueue>): 
       // création ou mise à jour de l'effectif
       const [{ effectifId, itemProcessingInfos }] = await Promise.all([
         createOrUpdateEffectif(effectif),
-        updateOrganismeTransmission(organisme, effectif.source, effectifQueue.api_version),
+        updateOrganismeTransmission(
+          organisme,
+          effectif.source,
+          effectifQueue.api_version,
+          effectifQueue.source_organisme_id
+        ),
       ]);
 
       // ajout des informations sur le traitement au logger

--- a/ui/modules/admin/InfosTransmissionEtParametrageOFA.tsx
+++ b/ui/modules/admin/InfosTransmissionEtParametrageOFA.tsx
@@ -122,7 +122,7 @@ const InfosTransmissionEtParametrageOFA = ({ organisme, ...props }) => {
       </HStack>
       {parametrage?.organisme_transmetteur ? (
         <HStack>
-          <Text>Organisme transmetteur des effectifs :</Text>
+          <Text>Dernier organisme transmetteur des effectifs :</Text>
           <Link
             key={parametrage?.organisme_transmetteur._id}
             href={`/organismes/${parametrage?.organisme_transmetteur._id}`}

--- a/ui/modules/admin/InfosTransmissionEtParametrageOFA.tsx
+++ b/ui/modules/admin/InfosTransmissionEtParametrageOFA.tsx
@@ -1,4 +1,4 @@
-import { Badge, Box, HStack, Stack, Text } from "@chakra-ui/react";
+import { Badge, Box, HStack, Stack, Text, Link } from "@chakra-ui/react";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/router";
 
@@ -14,6 +14,11 @@ interface InfosTransmissionParametrageOFAProps {
   api_key_active: boolean;
   parametrage_erp_date: Date;
   erps: string[];
+  organisme_transmetteur?: {
+    _id: string;
+    enseigne?: string;
+    raison_sociale?: string;
+  };
 }
 
 const InfosTransmissionEtParametrageOFA = ({ organisme, ...props }) => {
@@ -26,98 +31,115 @@ const InfosTransmissionEtParametrageOFA = ({ organisme, ...props }) => {
   );
 
   return (
-    <Box borderColor="#0063CB" borderWidth="2px" p="2w" w="50%" {...props}>
-      <Stack>
-        <HStack color="#0063CB">
-          <Box as="i" className="ri-eye-fill" />
-          <Box>
-            <Text fontSize="zeta" fontWeight="bold">
-              Encart réservé aux administrateurs
+    <Stack borderColor="#0063CB" borderWidth="2px" w="fit-content" p="2w" {...props}>
+      <HStack color="#0063CB">
+        <Box as="i" className="ri-eye-fill" />
+        <Box>
+          <Text fontSize="zeta" fontWeight="bold">
+            Encart réservé aux administrateurs
+          </Text>
+        </Box>
+      </HStack>
+      <HStack>
+        <Text>Transmission API :</Text>
+        {parametrage?.transmission_api_active ? (
+          <HStack spacing="1w">
+            <BadgeYes />
+            {parametrage.transmission_api_version && (
+              <Badge
+                fontSize="epsilon"
+                textColor="grey.800"
+                textTransform="none"
+                paddingX="1w"
+                paddingY="2px"
+                backgroundColor="#ECEAE3"
+              >
+                {parametrage.transmission_api_version}
+              </Badge>
+            )}
+            <Text>
+              (
+              {parametrage.transmission_date
+                ? new Date(parametrage.transmission_date).toLocaleDateString()
+                : "Date non disponible"}
+              )
             </Text>
-          </Box>
-        </HStack>
+          </HStack>
+        ) : (
+          <BadgeNo />
+        )}
+      </HStack>
+      <HStack>
+        <Text>Transmission manuelle :</Text>
+        {parametrage?.transmission_manuelle_active ? (
+          <HStack spacing="1w">
+            <BadgeYes />
+            <Text>
+              (
+              {parametrage.transmission_date
+                ? new Date(parametrage.transmission_date).toLocaleDateString()
+                : "Date non disponible"}
+              )
+            </Text>
+          </HStack>
+        ) : (
+          <BadgeNo />
+        )}
+      </HStack>
+      <HStack>
+        <Text>Paramétrage :</Text>
+        {parametrage?.parametrage_erp_active ? (
+          <HStack spacing="1w">
+            <BadgeYes />
+            {parametrage.erps?.map((erp, index) => (
+              <Badge
+                key={index}
+                fontSize="epsilon"
+                textColor="grey.800"
+                textTransform="none"
+                paddingX="1w"
+                paddingY="2px"
+                backgroundColor="#ECEAE3"
+              >
+                {erp.toUpperCase()}
+              </Badge>
+            ))}
+            <Text>
+              (
+              {parametrage.parametrage_erp_date
+                ? new Date(parametrage.parametrage_erp_date).toLocaleDateString()
+                : "Date non disponible"}
+              )
+            </Text>
+          </HStack>
+        ) : (
+          <BadgeNo />
+        )}
+      </HStack>
+      <HStack>
+        <Text>Clé d’API présente :</Text>
+        {parametrage?.api_key_active ? <BadgeYes /> : <BadgeNo />}
+      </HStack>
+      {parametrage?.organisme_transmetteur ? (
         <HStack>
-          <Text>Transmission API :</Text>
-          {parametrage?.transmission_api_active ? (
-            <HStack spacing="1w">
-              <BadgeYes />
-              {parametrage.transmission_api_version && (
-                <Badge
-                  fontSize="epsilon"
-                  textColor="grey.800"
-                  textTransform="none"
-                  paddingX="1w"
-                  paddingY="2px"
-                  backgroundColor="#ECEAE3"
-                >
-                  {parametrage.transmission_api_version}
-                </Badge>
-              )}
-              <Text>
-                (
-                {parametrage.transmission_date
-                  ? new Date(parametrage.transmission_date).toLocaleDateString()
-                  : "Date non disponible"}
-                )
-              </Text>
-            </HStack>
-          ) : (
-            <BadgeNo />
-          )}
+          <Text>Organisme transmetteur des effectifs :</Text>
+          <Link
+            key={parametrage?.organisme_transmetteur._id}
+            href={`/organismes/${parametrage?.organisme_transmetteur._id}`}
+            target="_blank"
+            borderBottom="1px"
+            color="action-high-blue-france"
+            _hover={{ textDecoration: "none" }}
+          >
+            {parametrage?.organisme_transmetteur.enseigne ??
+              parametrage?.organisme_transmetteur.raison_sociale ??
+              "Organisme inconnu"}
+          </Link>
         </HStack>
-        <HStack>
-          <Text>Transmission manuelle :</Text>
-          {parametrage?.transmission_manuelle_active ? (
-            <HStack spacing="1w">
-              <BadgeYes />
-              <Text>
-                (
-                {parametrage.transmission_date
-                  ? new Date(parametrage.transmission_date).toLocaleDateString()
-                  : "Date non disponible"}
-                )
-              </Text>
-            </HStack>
-          ) : (
-            <BadgeNo />
-          )}
-        </HStack>
-        <HStack>
-          <Text>Paramétrage :</Text>
-          {parametrage?.parametrage_erp_active ? (
-            <HStack spacing="1w">
-              <BadgeYes />
-              {parametrage.erps?.map((erp, index) => (
-                <Badge
-                  key={index}
-                  fontSize="epsilon"
-                  textColor="grey.800"
-                  textTransform="none"
-                  paddingX="1w"
-                  paddingY="2px"
-                  backgroundColor="#ECEAE3"
-                >
-                  {erp.toUpperCase()}
-                </Badge>
-              ))}
-              <Text>
-                (
-                {parametrage.parametrage_erp_date
-                  ? new Date(parametrage.parametrage_erp_date).toLocaleDateString()
-                  : "Date non disponible"}
-                )
-              </Text>
-            </HStack>
-          ) : (
-            <BadgeNo />
-          )}
-        </HStack>
-        <HStack>
-          <Text>Clé d’API présente :</Text>
-          {parametrage?.api_key_active ? <BadgeYes /> : <BadgeNo />}
-        </HStack>
-      </Stack>
-    </Box>
+      ) : (
+        <></>
+      )}
+    </Stack>
   );
 };
 


### PR DESCRIPTION
Ajout de l'information de l'OF transmetteur dans la collection organismes puis dans l'encart admin.

Testé en local mais je n'ai pas fait de migration, le champ va se remplir "tout seul" au fil de l'eau de l'ingestion.