### PR TITLE
fix: apprenant avec deux dates de statuts identiques (apprenti+inscrit) pas pris en compte dans SIFA

### DIFF
--- a/server/src/common/actions/sifa.actions/sifa.actions.ts
+++ b/server/src/common/actions/sifa.actions/sifa.actions.ts
@@ -50,6 +50,13 @@ export const isEligibleSIFA = (historique_statut: Effectif["apprenant"]["histori
   const historiqueSorted = historique_statut
     .filter(({ date_statut }) => date_statut <= endOfyear)
     .sort((a, b) => {
+      // Si les dates sont identiques, on préfère mettre le statut "apprenti" (3) en premier
+      // pour éviter de sortir de la liste des apprenants qui sont en contrat (et en même temps inscrits)
+      // dans les résultats de SIFA
+      // cf: https://tableaudebord-apprentissage.atlassian.net/browse/TM-554
+      if (new Date(a.date_statut).getTime() === new Date(b.date_statut).getTime()) {
+        return a.valeur_statut === CODES_STATUT_APPRENANT.apprenti ? -1 : 1;
+      }
       return new Date(a.date_statut).getTime() - new Date(b.date_statut).getTime();
     });
 


### PR DESCRIPTION
cf: https://tableaudebord-apprentissage.atlassian.net/browse/TM-554

L'apprenant avait ces status (voir les dates) : 

```
[
      {
        "valeur_statut": 2,
        "date_statut": {
          "$date": "2023-09-25T00:00:00.000Z"
        },
        "date_reception": {
          "$date": "2023-10-18T13:53:48.645Z"
        }
      },
      {
        "valeur_statut": 3,
        "date_statut": {
          "$date": "2023-09-25T00:00:00.000Z"
        },
        "date_reception": {
          "$date": "2023-11-22T10:29:11.371Z"
        }
      }
    ]
```