### PR TITLE
feat: les effectifs envoyés sont fusionnés pour éviter d'effacer les valeurs ajoutées manuellement

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -121,6 +121,10 @@ fileignoreconfig:
   checksum: ecb4075e29596bc69091cf6a3a3836622cc0ccfa91359e6d96eaa026881886c6
 - filename: ui/modules/organismes/Televersement.tsx
   checksum: 2322283e936e6f4a419f27f60e1bae886adffc99a40a085131685f4ca77597e3
+- filename: server/tests/integration/jobs/ingestion/mergeEffectif.test.ts
+  checksum: 3d6f4bf51f463b07c6fb2b2c3cf68c0cd2a52b6fbd55fc60578c30e2d2a58b9b
+- filename: server/tests/integration/common/utils/mergeIgnoringNullPreferringNewArray.test.ts
+  checksum: 01dd4eb56cfade47b72f04d21381aac27a90fae3e3ea3e08372225b27f5fe8ad
 scopeconfig:
 - scope: node
 custom_patterns:

--- a/server/src/common/actions/effectifs.actions.ts
+++ b/server/src/common/actions/effectifs.actions.ts
@@ -219,16 +219,18 @@ export async function updateEffectifFromForm(effectifId: ObjectId, body: any): P
     dataToUpdate.apprenant.date_de_naissance = new Date(dataToUpdate.apprenant.date_de_naissance);
   }
 
-  dataToUpdate.apprenant.historique_statut = dataToUpdate.apprenant.historique_statut.map((s) => {
-    const statut = stripEmptyFields(s);
-    if (statut.date_statut) {
-      statut.date_statut = new Date(statut.date_statut);
-    }
-    if (statut.date_reception) {
-      statut.date_reception = new Date(statut.date_reception);
-    }
-    return statut;
-  });
+  dataToUpdate.apprenant.historique_statut = dataToUpdate.apprenant.historique_statut
+    .filter((e) => e)
+    .map((s) => {
+      const statut = stripEmptyFields(s);
+      if (statut.date_statut) {
+        statut.date_statut = new Date(statut.date_statut);
+      }
+      if (statut.date_reception) {
+        statut.date_reception = new Date(statut.date_reception);
+      }
+      return statut;
+    });
   if (nouveau_statut) {
     dataToUpdate.apprenant.historique_statut.push({
       valeur_statut: nouveau_statut.valeur_statut,
@@ -237,19 +239,21 @@ export async function updateEffectifFromForm(effectifId: ObjectId, body: any): P
     });
   }
 
-  dataToUpdate.contrats = dataToUpdate.contrats.map((c) => {
-    const contrat = stripEmptyFields(c);
-    if (contrat.date_debut) {
-      contrat.date_debut = new Date(contrat.date_debut);
-    }
-    if (contrat.date_fin) {
-      contrat.date_fin = new Date(contrat.date_fin);
-    }
-    if (contrat.date_rupture) {
-      contrat.date_rupture = new Date(contrat.date_rupture);
-    }
-    return contrat;
-  });
+  dataToUpdate.contrats = dataToUpdate.contrats
+    .filter((e) => e)
+    .map((c) => {
+      const contrat = stripEmptyFields(c);
+      if (contrat.date_debut) {
+        contrat.date_debut = new Date(contrat.date_debut);
+      }
+      if (contrat.date_fin) {
+        contrat.date_fin = new Date(contrat.date_fin);
+      }
+      if (contrat.date_rupture) {
+        contrat.date_rupture = new Date(contrat.date_rupture);
+      }
+      return contrat;
+    });
   if (nouveau_contrat) {
     dataToUpdate.contrats.push(nouveau_contrat);
   }

--- a/server/src/common/utils/mergeIgnoringNullPreferringNewArray.ts
+++ b/server/src/common/utils/mergeIgnoringNullPreferringNewArray.ts
@@ -1,0 +1,33 @@
+import { ObjectId } from "mongodb";
+
+/**
+ * Cette fonction a été créée initialement pour fusionner deux effectifs en respectant certaines règles:
+ * - Si un champ est null/undefined/"" dans le nouvel effectif, on garde la valeur de l'ancien effectif
+ * - Si un champ est un tableau dans le nouvel effectif, on remplace complètement le tableau de l'ancien effectif par celui du nouvel effectif
+ * - Si un champ est un objet dans le nouvel effectif, on fusionne récursivement les objets (sauf dans le cas d'une Date ou ObjectId, voir ci-dessous)
+ * @see mergeEffectif
+ */
+export function mergeIgnoringNullPreferringNewArray<GenericObject extends { [key: string]: any }>(
+  previousObject: GenericObject,
+  newObject: GenericObject
+): GenericObject {
+  let result: { [key: string]: any } = { ...previousObject };
+
+  Object.keys(newObject).forEach((key) => {
+    if (newObject[key] && Array.isArray(newObject[key])) {
+      // Remplace complètement le tableau avec celui de newObject
+      result[key] = newObject[key];
+    } else if (newObject[key] instanceof Date || newObject[key] instanceof ObjectId) {
+      // Remplace complètement la date ou l'ObjectId avec celui de newObject
+      result[key] = newObject[key];
+    } else if (newObject[key] && typeof newObject[key] === "object") {
+      // Fusionne récursivement les objets
+      result[key] = mergeIgnoringNullPreferringNewArray(result[key], newObject[key]);
+    } else if (newObject[key] !== undefined && newObject[key] !== null && newObject[key] !== "") {
+      // Utilise la valeur de newObject si elle n'est pas null/undefined
+      result[key] = newObject[key];
+    }
+  });
+
+  return result as GenericObject;
+}

--- a/server/tests/integration/common/utils/mergeIgnoringNullPreferringNewArray.test.ts
+++ b/server/tests/integration/common/utils/mergeIgnoringNullPreferringNewArray.test.ts
@@ -1,0 +1,110 @@
+import { ObjectId } from "mongodb";
+
+import { mergeIgnoringNullPreferringNewArray } from "@/common/utils/mergeIgnoringNullPreferringNewArray";
+
+describe("mergeIgnoringNullPreferringNewArray", () => {
+  it("returns an empty object when given an empty object", async () => {
+    const input: any = {};
+    const expectedResult: any = {};
+    const result = mergeIgnoringNullPreferringNewArray(input, {});
+
+    expect(result).toStrictEqual(expectedResult);
+  });
+
+  it("returns an object merged by given key", async () => {
+    const input: any = {
+      id: 123,
+      apples: 10,
+    };
+    const expectedResult = {
+      id: 123,
+      apples: 10,
+      oranges: 3,
+    };
+    const result = mergeIgnoringNullPreferringNewArray(input, { oranges: 3 });
+
+    expect(result).toStrictEqual(expectedResult);
+  });
+
+  it("should not merge null values", async () => {
+    const input: any = {
+      id: 123,
+      apples: 10,
+      kiwis: 90,
+    };
+    const expectedResult = {
+      id: 123,
+      apples: 10,
+      oranges: 3,
+      kiwis: 90,
+    };
+    const result = mergeIgnoringNullPreferringNewArray(input, { oranges: 3, apples: null, id: "", kiwis: undefined });
+
+    expect(result).toStrictEqual(expectedResult);
+  });
+
+  it("should work with Date and ObjectId", async () => {
+    const input: any = {
+      id: 123,
+      date: new Date("2021-09-28T04:05:47.647Z"),
+      oid: new ObjectId("6152d7d3e6b5a5a5a5a5a5a5"),
+    };
+    const expectedResult = {
+      id: 123,
+      date: new Date("2025-09-28T04:05:47.647Z"),
+      oid: new ObjectId("6152d7d3e6b5a5a5a5a5a5a5"),
+    };
+    const result = mergeIgnoringNullPreferringNewArray(input, {
+      date: new Date("2025-09-28T04:05:47.647Z"),
+    });
+
+    expect(result).toStrictEqual(expectedResult);
+  });
+
+  it("shoud work with nested objects", async () => {
+    const input: any = {
+      id: 123,
+      apples: 10,
+      nested: {
+        id: 123,
+        apples: 10,
+        kiwis: 90,
+      },
+    };
+    const expectedResult = {
+      id: 123,
+      apples: 10,
+      oranges: 3,
+      nested: {
+        id: 123,
+        apples: 10,
+        kiwis: 90,
+        oranges: 3,
+      },
+    };
+    const result = mergeIgnoringNullPreferringNewArray(input, { oranges: 3, nested: { oranges: 3 } });
+
+    expect(result).toStrictEqual(expectedResult);
+  });
+
+  it("should not merge array and prefer new one", async () => {
+    const input: any = {
+      id: 123,
+      apples: 10,
+      nested: {
+        fruits: ["apple", "kiwi"],
+      },
+    };
+    const expectedResult = {
+      id: 123,
+      apples: 10,
+      oranges: 3,
+      nested: {
+        fruits: ["orange"],
+      },
+    };
+    const result = mergeIgnoringNullPreferringNewArray(input, { oranges: 3, nested: { fruits: ["orange"] } });
+
+    expect(result).toStrictEqual(expectedResult);
+  });
+});

--- a/server/tests/integration/jobs/ingestion/mergeEffectif.test.ts
+++ b/server/tests/integration/jobs/ingestion/mergeEffectif.test.ts
@@ -1,0 +1,77 @@
+import { ObjectId } from "mongodb";
+
+import { Effectif } from "@/common/model/@types";
+import { mergeEffectif } from "@/jobs/ingestion/process-ingestion";
+
+describe("mergeEffectif", () => {
+  it("should merge effectif", async () => {
+    const previousEffectif: Effectif = {
+      source: "apiUser",
+      apprenant: {
+        nom: "FLEURY",
+        prenom: "Fortuné",
+        telephone: "0123456789",
+        historique_statut: [
+          {
+            valeur_statut: 3,
+            date_statut: new Date("2022-12-28T04:05:47.647Z"),
+            date_reception: expect.anything(),
+          },
+        ],
+        ine: "402957826QH",
+        date_de_naissance: new Date("1999-08-31T16:21:32"),
+        adresse: {
+          code_insee: "05109",
+          code_postal: "05109",
+          commune: "[NOM_DE_LA_COMMUNE]",
+          departement: "05",
+          academie: "2",
+          region: "93",
+        },
+      },
+      contrats: [],
+      formation: {
+        cfd: "50033610",
+        annee: 0,
+        periode: [2022, 2024],
+        libelle_long: "TEST",
+      },
+      id_erp_apprenant: "12345",
+
+      annee_scolaire: "2024-2025",
+      created_at: new Date("2021-09-28T04:05:47.647Z"),
+      updated_at: new Date("2021-09-28T04:05:47.647Z"),
+      organisme_id: new ObjectId("6152d7d3e6b5a5a5a5a5a5a5"),
+    };
+
+    const merged = mergeEffectif(previousEffectif, {
+      ...previousEffectif,
+      apprenant: {
+        ...previousEffectif.apprenant,
+        nom: "FLEURY 2",
+        prenom: "",
+        telephone: undefined,
+        historique_statut: [],
+        adresse: {
+          ...previousEffectif.apprenant.adresse,
+          commune: "remplacé",
+        },
+      },
+      contrats: [],
+    });
+    expect(merged).toStrictEqual({
+      ...previousEffectif,
+      apprenant: {
+        ...previousEffectif.apprenant,
+        nom: "FLEURY 2",
+        date_de_naissance: expect.any(Date),
+        adresse: {
+          ...previousEffectif.apprenant.adresse,
+          commune: "remplacé",
+        },
+      },
+      updated_at: expect.any(Date),
+      organisme_id: new ObjectId("6152d7d3e6b5a5a5a5a5a5a5"),
+    });
+  });
+});


### PR DESCRIPTION
J'ai essayé de bien commenter.

À chaque ingestion d'effectif : 

AVANT : on remplaçait totalement l'effectif
MAINTENANT : on fusionne avec l'effectif existant


https://mission-apprentissage.slack.com/archives/C02FR2L1VB8/p1702376081971259