### PR TITLE
fix(server): condition de reset de la fiab

### DIFF
--- a/server/src/jobs/fiabilisation/uai-siret/build.utils.ts
+++ b/server/src/jobs/fiabilisation/uai-siret/build.utils.ts
@@ -7,6 +7,9 @@ import { organismesDb } from "@/common/model/collections";
  * Reset du flag statut de fiabilisation pour tous les organismes
  */
 export const resetOrganismesFiabilisationStatut = async () => {
-  logger.info("Remise à 0 des organismes comme ayant une fiabilisation inconnue...");
-  await organismesDb().updateMany({}, { $set: { fiabilisation_statut: STATUT_FIABILISATION_ORGANISME.INCONNU } });
+  logger.info("Remise à 0 des organismes hors référentiel comme ayant une fiabilisation inconnue...");
+  await organismesDb().updateMany(
+    { est_dans_le_referentiel: "absent" },
+    { $set: { fiabilisation_statut: STATUT_FIABILISATION_ORGANISME.INCONNU } }
+  );
 };


### PR DESCRIPTION
Il y a un petit trou dans la raquette, les OF qui ne transmettent pas mais qui sont dans le référentiel ne sont pas bien identifié dans la bdd.

En updatant la condition on devrait corriger tout ça et du coup ne plus avoir le souci des OFA fiables qui apparaissent comme non fiable sur l'UI