### PR TITLE
feat(server): download DREETS / DRAAF uniquement des rupturants

### DIFF
--- a/server/src/common/actions/helpers/permissions-organisme.ts
+++ b/server/src/common/actions/helpers/permissions-organisme.ts
@@ -63,7 +63,7 @@ export async function buildOrganismePermissions(
         viewContacts: true,
         infoTransmissionEffectifs: true,
         indicateursEffectifs: sameRegion,
-        effectifsNominatifs: sameRegion ? ["inscritSansContrat", "rupturant", "abandon"] : false,
+        effectifsNominatifs: sameRegion ? ["rupturant"] : false,
         manageEffectifs: false,
         configurerModeTransmission: false,
       };

--- a/server/tests/integration/http/organisme.routes.test.ts
+++ b/server/tests/integration/http/organisme.routes.test.ts
@@ -91,7 +91,7 @@ const permissionsByOrganisation: PermissionsTestConfig<PermissionsOrganisme> = {
     configurerModeTransmission: false,
   },
   "DREETS même région": {
-    effectifsNominatifs: ["inscritSansContrat", "rupturant", "abandon"],
+    effectifsNominatifs: ["rupturant"],
     indicateursEffectifs: true,
     infoTransmissionEffectifs: true,
     manageEffectifs: false,
@@ -107,7 +107,7 @@ const permissionsByOrganisation: PermissionsTestConfig<PermissionsOrganisme> = {
     configurerModeTransmission: false,
   },
   "DRAAF même région": {
-    effectifsNominatifs: ["inscritSansContrat", "rupturant", "abandon"],
+    effectifsNominatifs: ["rupturant"],
     indicateursEffectifs: true,
     infoTransmissionEffectifs: true,
     manageEffectifs: false,


### PR DESCRIPTION
Update des droits de téléchargement des listes nominatives cf. https://tableaudebord-apprentissage.atlassian.net/browse/TM-422