### PR TITLE
feat(server): update droits téléchargement listes nominatives

### DIFF
--- a/server/src/common/actions/helpers/permissions-organisme.ts
+++ b/server/src/common/actions/helpers/permissions-organisme.ts
@@ -63,7 +63,7 @@ export async function buildOrganismePermissions(
         viewContacts: true,
         infoTransmissionEffectifs: true,
         indicateursEffectifs: sameRegion,
-        effectifsNominatifs: sameRegion ? ["rupturant"] : false,
+        effectifsNominatifs: sameRegion ? ["inscritSansContrat", "rupturant", "abandon"] : false,
         manageEffectifs: false,
         configurerModeTransmission: false,
       };
@@ -107,7 +107,7 @@ export async function buildOrganismePermissions(
         viewContacts: true,
         infoTransmissionEffectifs: true,
         indicateursEffectifs: sameAcademie,
-        effectifsNominatifs: false,
+        effectifsNominatifs: sameAcademie ? ["inscritSansContrat", "rupturant", "abandon"] : false,
         manageEffectifs: false,
         configurerModeTransmission: false,
       };

--- a/server/tests/integration/http/organisme.routes.test.ts
+++ b/server/tests/integration/http/organisme.routes.test.ts
@@ -91,7 +91,7 @@ const permissionsByOrganisation: PermissionsTestConfig<PermissionsOrganisme> = {
     configurerModeTransmission: false,
   },
   "DREETS même région": {
-    effectifsNominatifs: ["rupturant"],
+    effectifsNominatifs: ["inscritSansContrat", "rupturant", "abandon"],
     indicateursEffectifs: true,
     infoTransmissionEffectifs: true,
     manageEffectifs: false,
@@ -107,7 +107,7 @@ const permissionsByOrganisation: PermissionsTestConfig<PermissionsOrganisme> = {
     configurerModeTransmission: false,
   },
   "DRAAF même région": {
-    effectifsNominatifs: ["rupturant"],
+    effectifsNominatifs: ["inscritSansContrat", "rupturant", "abandon"],
     indicateursEffectifs: true,
     infoTransmissionEffectifs: true,
     manageEffectifs: false,
@@ -171,7 +171,7 @@ const permissionsByOrganisation: PermissionsTestConfig<PermissionsOrganisme> = {
     configurerModeTransmission: false,
   },
   "Académie même académie": {
-    effectifsNominatifs: false,
+    effectifsNominatifs: ["inscritSansContrat", "rupturant", "abandon"],
     indicateursEffectifs: true,
     infoTransmissionEffectifs: true,
     manageEffectifs: false,


### PR DESCRIPTION
MAJ des droits de téléchargements des listes nominatives (la carte n'était pas à jour) cf https://tableaudebord-apprentissage.atlassian.net/browse/TM-422