### PR TITLE
feat: tete de réseau compagnon du devoir peut gérer les effectifs et l'enquete SIFA

### DIFF
--- a/server/src/common/actions/helpers/permissions-organisation.ts
+++ b/server/src/common/actions/helpers/permissions-organisation.ts
@@ -152,7 +152,15 @@ const permissionsOrganisation: Record<PermissionOrganisation, PermissionConfig> 
             }
           : false;
       },
-      TETE_DE_RESEAU: false,
+      TETE_DE_RESEAU: async (organisation) => {
+        if (organisation.reseau !== "COMP_DU_DEVOIR") {
+          return false;
+        }
+
+        return {
+          "_computed.organisme.reseaux": organisation.reseau,
+        };
+      },
       DREETS: (organisation) => ({
         "_computed.organisme.region": organisation.code_region,
       }),

--- a/server/src/common/actions/helpers/permissions-organisme.ts
+++ b/server/src/common/actions/helpers/permissions-organisme.ts
@@ -46,11 +46,12 @@ export async function buildOrganismePermissions(
 
     case "TETE_DE_RESEAU": {
       const sameReseau = (organisme.reseaux as string[])?.includes(organisation.reseau);
+      const compDuDevoir = organisation.reseau === "COMP_DU_DEVOIR";
       return {
         viewContacts: sameReseau,
         infoTransmissionEffectifs: sameReseau,
         indicateursEffectifs: sameReseau,
-        effectifsNominatifs: false,
+        effectifsNominatifs: sameReseau && compDuDevoir,
         manageEffectifs: false,
         configurerModeTransmission: false,
       };

--- a/server/src/common/actions/helpers/permissions-organisme.ts
+++ b/server/src/common/actions/helpers/permissions-organisme.ts
@@ -52,7 +52,7 @@ export async function buildOrganismePermissions(
         infoTransmissionEffectifs: sameReseau,
         indicateursEffectifs: sameReseau,
         effectifsNominatifs: sameReseau && compDuDevoir,
-        manageEffectifs: false,
+        manageEffectifs: sameReseau && compDuDevoir,
         configurerModeTransmission: false,
       };
     }

--- a/ui/pages/organismes/[organismeId]/enquete-sifa.tsx
+++ b/ui/pages/organismes/[organismeId]/enquete-sifa.tsx
@@ -15,4 +15,4 @@ const PageEnqueteSIFADeSonOrganisme = () => {
   return <SimplePage title="Son enquête SIFA">{organisme && <SIFAPage modePublique={true} />}</SimplePage>;
 };
 
-export default withAuth(PageEnqueteSIFADeSonOrganisme, ["ORGANISME_FORMATION", "ADMINISTRATEUR"]);
+export default withAuth(PageEnqueteSIFADeSonOrganisme, ["ORGANISME_FORMATION", "ADMINISTRATEUR", "TETE_DE_RESEAU"]);


### PR DESCRIPTION
Deuxième partie du ticket https://tableaudebord-apprentissage.atlassian.net/browse/TM-438