### PR TITLE
fix: mise en stand-by des e-mails de relance

### DIFF
--- a/server/src/jobs/emails/reminder.ts
+++ b/server/src/jobs/emails/reminder.ts
@@ -1,5 +1,5 @@
 import { differenceInDays } from "date-fns";
-import { ERPS_BY_ID } from "shared";
+// import { ERPS_BY_ID } from "shared";
 
 import parentLogger from "@/common/logger";
 import { usersMigrationDb } from "@/common/model/collections";
@@ -120,46 +120,49 @@ export async function sendReminderEmails() {
       );
     }
 
+    // TODO: A réactiver prochainement quand les transmissions se feront correctement.
+    // NOTE: Ne pas oublier de remettre les tests unitaires en place reminder.test.ts
+
     // relance après 7 jours si organisme configuré mais pas de données
-    else if (
-      organisme.mode_de_transmission &&
-      !organisme.last_transmission_date &&
-      !user.reminder_missing_data_sent_date &&
-      differenceInDays(new Date(), organisme.mode_de_transmission_configuration_date) >= 7
-    ) {
-      logger.info(
-        {
-          user_id: user._id,
-          organisme_id: organisme._id,
-          siret: organisme.siret,
-          uai: organisme.uai,
-          mode_de_transmission: organisme.mode_de_transmission,
-          mode_de_transmission_configuration_date: organisme.mode_de_transmission_configuration_date,
-          erp: organisme.erps?.[0],
-          erp_unsupported: organisme.erp_unsupported,
-        },
-        "send email reminder_missing_data"
-      );
-      await sendEmail(user.email, "reminder_missing_data", {
-        recipient: {
-          civility: user.civility,
-          nom: user.nom,
-          prenom: user.prenom,
-        },
-        mode_de_transmission: organisme.mode_de_transmission,
-        erp: ERPS_BY_ID[organisme.erps?.[0]]?.name ?? "",
-        erp_unsupported: organisme.erp_unsupported,
-      });
-      await usersMigrationDb().updateOne(
-        {
-          _id: user._id,
-        },
-        {
-          $set: {
-            reminder_missing_data_sent_date: new Date(),
-          },
-        }
-      );
-    }
+    // else if (
+    //   organisme.mode_de_transmission &&
+    //   !organisme.last_transmission_date &&
+    //   !user.reminder_missing_data_sent_date &&
+    //   differenceInDays(new Date(), organisme.mode_de_transmission_configuration_date) >= 7
+    // ) {
+    //   logger.info(
+    //     {
+    //       user_id: user._id,
+    //       organisme_id: organisme._id,
+    //       siret: organisme.siret,
+    //       uai: organisme.uai,
+    //       mode_de_transmission: organisme.mode_de_transmission,
+    //       mode_de_transmission_configuration_date: organisme.mode_de_transmission_configuration_date,
+    //       erp: organisme.erps?.[0],
+    //       erp_unsupported: organisme.erp_unsupported,
+    //     },
+    //     "send email reminder_missing_data"
+    //   );
+    //   await sendEmail(user.email, "reminder_missing_data", {
+    //     recipient: {
+    //       civility: user.civility,
+    //       nom: user.nom,
+    //       prenom: user.prenom,
+    //     },
+    //     mode_de_transmission: organisme.mode_de_transmission,
+    //     erp: ERPS_BY_ID[organisme.erps?.[0]]?.name ?? "",
+    //     erp_unsupported: organisme.erp_unsupported,
+    //   });
+    //   await usersMigrationDb().updateOne(
+    //     {
+    //       _id: user._id,
+    //     },
+    //     {
+    //       $set: {
+    //         reminder_missing_data_sent_date: new Date(),
+    //       },
+    //     }
+    //   );
+    // }
   }
 }

--- a/server/tests/integration/jobs/emails/reminder.test.ts
+++ b/server/tests/integration/jobs/emails/reminder.test.ts
@@ -83,13 +83,15 @@ describe("Job send-reminder-emails", () => {
     // 0 nouveau mail envoyé car < 7j
     expect(sendEmail).toHaveBeenCalledTimes(0);
 
-    advanceTo("2023-10-17T12:00z");
-    await sendReminderEmails();
+    // TODO: à remettre en place lors de la rèactivation de l'e-mail de relance après 7 jours si organisme configuré mais pas de données
+
+    // advanceTo("2023-10-17T12:00z");
+    // await sendReminderEmails();
     // 1 nouveau mail envoyé car >= 7j et 1ère relance
     // expect(sendEmail).toHaveBeenCalledTimes(1);
 
-    advanceTo("2023-10-17T12:00z");
-    await sendReminderEmails();
+    // advanceTo("2023-10-17T12:00z");
+    // await sendReminderEmails();
     // 0 nouveau mail envoyé car relance déjà envoyée
     // expect(sendEmail).toHaveBeenCalledTimes(1);
   });

--- a/server/tests/integration/jobs/emails/reminder.test.ts
+++ b/server/tests/integration/jobs/emails/reminder.test.ts
@@ -86,12 +86,12 @@ describe("Job send-reminder-emails", () => {
     advanceTo("2023-10-17T12:00z");
     await sendReminderEmails();
     // 1 nouveau mail envoyé car >= 7j et 1ère relance
-    expect(sendEmail).toHaveBeenCalledTimes(1);
+    // expect(sendEmail).toHaveBeenCalledTimes(1);
 
     advanceTo("2023-10-17T12:00z");
     await sendReminderEmails();
     // 0 nouveau mail envoyé car relance déjà envoyée
-    expect(sendEmail).toHaveBeenCalledTimes(1);
+    // expect(sendEmail).toHaveBeenCalledTimes(1);
   });
 
   /**


### PR DESCRIPTION
[TM-601](https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/TM/boards/1/backlog?selectedIssue=TM-601)

Mise en pause du service de relance par e-mail pour les organismes configurés mais qui n’ont pas de donnée. 
