### PR TITLE
Amélioration de l'affichage des noms des doublons d'organismes

### DIFF
--- a/server/src/common/actions/organismes/organismes.duplicates.actions.ts
+++ b/server/src/common/actions/organismes/organismes.duplicates.actions.ts
@@ -24,6 +24,7 @@ export const getDuplicatesOrganismes = async () => {
               uai: "$uai",
               siret: "$siret",
               raison_sociale: "$raison_sociale",
+              enseigne: "$enseigne",
               nature: "$nature",
               ferme: "$ferme",
               last_transmission_date: "$last_transmission_date",

--- a/ui/modules/admin/fusion-organismes/OrganismesDoublonsList.tsx
+++ b/ui/modules/admin/fusion-organismes/OrganismesDoublonsList.tsx
@@ -66,7 +66,7 @@ const RenderSubComponent = (row: Row<DuplicateOrganismeGroup>) => {
               <Stack>
                 <HStack spacing={4}>
                   <ArrowRightLine />
-                  <Text>{item.nom}</Text>
+                  <Text>{item.raison_sociale || item.enseigne || item.nom}</Text>
                 </HStack>
                 <HStack spacing={6}>
                   <Text color={item.uai ? "black" : "gray.500"}>UAI : {item.uai ?? "Inconnu"}</Text>

--- a/ui/modules/admin/fusion-organismes/models/DuplicateOrganismeDetail.ts
+++ b/ui/modules/admin/fusion-organismes/models/DuplicateOrganismeDetail.ts
@@ -4,6 +4,7 @@ export interface DuplicateOrganismeDetail {
   siret: string;
   nom: string;
   raison_sociale: string;
+  enseigne: string;
   nature: string;
   ferme: boolean;
   last_transmission_date: Date;


### PR DESCRIPTION
[TM-590](https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/TM/boards/1/backlog?assignee=712020%3Aa35d39f1-286a-43a4-8ad3-c1041b95d2a1&atlOrigin=eyJwIjoiaiIsImkiOiJlOGFiZTQ2MjYyZGQ0YmIzYTkxNmQwN2ExMDIxYzI4NyJ9&cloudId=fd0b3ea4-845f-441e-bce3-72c8a7dbd0a3&selectedIssue=TM-590)

**Description :**

Cette Pull Request vise à optimiser l'affichage de la liste des doublons d'organismes en mettant en priorité l'affichage des informations selon l'ordre suivant : la raison sociale, ensuite l'enseigne, et enfin le nom de l'organisme. Cette modification permet une identification plus précise et une meilleure compréhension des données pour les utilisateurs.

**Détails des changements :**

Modification du composant RenderSubComponent dans le fichier OrganismesDoublonsList.tsx pour intégrer la logique de priorisation.
Affichage du nom de l'organisme basé sur la disponibilité et la pertinence de la raison sociale, de l'enseigne ou du nom.

**Bénéfices attendus :**

Amélioration de la clarté et de la pertinence des informations présentées.
Facilitation du processus de reconnaissance et de gestion des doublons d'organismes.