### PR TITLE
feat: Ajout du tracking Plausible SIFA

### DIFF
--- a/shared/constants/plausible-goals.ts
+++ b/shared/constants/plausible-goals.ts
@@ -25,6 +25,10 @@ export const plausibleGoals = [
   "clic_homepage_page_aide",
   "clic_homepage_envoi_message",
 
+  // Page SIFA
+  "clic_depot_plateforme_sifa",
+  "clic_toggle_sifa_données_manquantes",
+
   // Téléchargements
   // - Page indicateurs
   "telechargement_liste_sans_contrats",
@@ -38,8 +42,9 @@ export const plausibleGoals = [
   "telechargement_liste_of_a_fiabiliser",
   "telechargement_liste_of_fiables",
 
-  // Anciens goals
+  // - Page SIFA
   "telechargement_sifa",
+  "telechargement_fichier_instruction_sifa",
 ] as const;
 
 export type PlausibleGoalType = (typeof plausibleGoals)[number];

--- a/ui/modules/mon-espace/SIFA/SIFAPage.tsx
+++ b/ui/modules/mon-espace/SIFA/SIFAPage.tsx
@@ -15,7 +15,7 @@ import {
 } from "@chakra-ui/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import groupBy from "lodash.groupby";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { getSIFADate } from "shared";
 
@@ -102,6 +102,15 @@ const SIFAPage = (props: SIFAPageProps) => {
     [organismesEffectifs]
   );
   const [showOnlyMissingSifa, setShowOnlyMissingSifa] = useState(false);
+  const [hasTrackedMissingSifa, setHasTrackedMissingSifa] = useState(false);
+
+  const handleToggleMissingSifaChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!hasTrackedMissingSifa) {
+      trackPlausibleEvent("clic_toggle_sifa_données_manquantes");
+      setHasTrackedMissingSifa(true);
+    }
+    setShowOnlyMissingSifa(e.target.checked);
+  };
 
   if (isLoading) {
     return (
@@ -153,7 +162,12 @@ const SIFAPage = (props: SIFAPageProps) => {
                   Pour <strong>faciliter</strong> la remontée d’information avec les données demandées par l’enquête
                   SIFA, le tableau de bord vous permet de réaliser les contrôles, compléter les éventuelles données
                   manquantes et générer un fichier compatible à déposer sur la{" "}
-                  <Link variant="link" href="https://dep.adc.education.fr/sifa2/login" isExternal>
+                  <Link
+                    variant="link"
+                    href="https://dep.adc.education.fr/sifa2/login"
+                    isExternal
+                    plausibleGoal="clic_depot_plateforme_sifa"
+                  >
                     plateforme SIFA
                     <ExternalLinkLine w=".7rem" h=".7rem" ml={1} />
                   </Link>
@@ -166,7 +180,13 @@ const SIFAPage = (props: SIFAPageProps) => {
                 </ListItem>
               </UnorderedList>
             </Text>
-            <Link variant="link" href="/InstructionsSIFA_31122023.pdf" mt={4} isExternal>
+            <Link
+              variant="link"
+              href="/InstructionsSIFA_31122023.pdf"
+              mt={4}
+              isExternal
+              plausibleGoal="telechargement_fichier_instruction_sifa"
+            >
               Fichier d’instruction SIFA (2023)
               <DownloadLine mb={1} ml={2} fontSize="xs" />
             </Link>
@@ -214,9 +234,7 @@ const SIFAPage = (props: SIFAPageProps) => {
               id="show-only-incomplete-toggle"
               variant="icon"
               isChecked={showOnlyMissingSifa}
-              onChange={(e) => {
-                setShowOnlyMissingSifa(e.target.checked);
-              }}
+              onChange={handleToggleMissingSifaChange}
               mr={2}
             />
             <FormLabel htmlFor="show-only-incomplete-toggle" mb="0" mr="0" cursor="pointer">


### PR DESCRIPTION
cf: [TM-623](https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/TM/boards/1/backlog?assignee=712020%3Aa35d39f1-286a-43a4-8ad3-c1041b95d2a1&atlOrigin=eyJwIjoiaiIsImkiOiJlOGFiZTQ2MjYyZGQ0YmIzYTkxNmQwN2ExMDIxYzI4NyJ9&cloudId=fd0b3ea4-845f-441e-bce3-72c8a7dbd0a3&selectedIssue=TM-623)

Ajout des événement de tracking de la page SIFA suivant : 


Nom événement | Action à tracker | Propriétés associées | Emplacement de l’action | Statut tracking
-- | -- | -- | -- | --
clic_toggle_sifa_données_manquantes | clic sur le toggle afficher les données manquantes |   | page sifa  | to do
téléchargement_fichier_instruction_sifa | téléchargement du fichier d’instruction sifa |   | page sifa | to do
clic_depot_plateforme_sifa | clic sur le lien vers le dépot sur la plateforme sifa | organisationType : type d’utilisateurorganisationNom : UAI + Siret de l’OF | page sifa | to do

https://www.notion.so/mission-apprentissage/Tracking-Plausible-TDB-86c1845affea4d759fc022093af95837