### PR TITLE
fix: renvoyer une erreur 403 quand la clé API n'est pas bonne

### DIFF
--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -492,7 +492,7 @@ export async function getOrganismeDetails(ctx: AuthContext, organismeId: ObjectI
 export async function getOrganismeByAPIKey(api_key: string) {
   const organisme = await organismesDb().findOne({ api_key });
   if (!organisme) {
-    throw Boom.forbidden("API key isn't valid");
+    throw Boom.forbidden("La clé API n'est pas valide");
   }
   return organisme as WithId<Organisme>;
 }

--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -492,7 +492,7 @@ export async function getOrganismeDetails(ctx: AuthContext, organismeId: ObjectI
 export async function getOrganismeByAPIKey(api_key: string) {
   const organisme = await organismesDb().findOne({ api_key });
   if (!organisme) {
-    throw Boom.notFound("Organisme not found with this api key");
+    throw Boom.forbidden("API key isn't valid");
   }
   return organisme as WithId<Organisme>;
 }

--- a/server/src/http/middlewares/requireBearerAuthentication.ts
+++ b/server/src/http/middlewares/requireBearerAuthentication.ts
@@ -9,13 +9,13 @@ export default function requireBearerAuthentication() {
     try {
       let token: string | undefined = req.headers.authorization;
       if (!token) {
-        throw Boom.forbidden("Missing API key");
+        throw Boom.forbidden("Clé API manquante");
       }
 
       if (token.startsWith("Bearer ")) {
         token = token.substring(7, token.length);
       } else {
-        throw Boom.forbidden("API key isn't valid");
+        throw Boom.forbidden("La clé API n'est pas valide");
       }
 
       res.locals.token = token;

--- a/server/src/http/middlewares/requireBearerAuthentication.ts
+++ b/server/src/http/middlewares/requireBearerAuthentication.ts
@@ -1,3 +1,4 @@
+import Boom from "boom";
 import { NextFunction, Response } from "express";
 
 // Bearer API_KEY
@@ -8,13 +9,13 @@ export default function requireBearerAuthentication() {
     try {
       let token: string | undefined = req.headers.authorization;
       if (!token) {
-        throw new Error("Jeton manquant");
+        throw Boom.forbidden("Missing API key");
       }
 
       if (token.startsWith("Bearer ")) {
         token = token.substring(7, token.length);
       } else {
-        throw new Error("Jeton invalide");
+        throw Boom.forbidden("API key isn't valid");
       }
 
       res.locals.token = token;

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -368,9 +368,6 @@ function setupRoutes(app: Application) {
     requireBearerAuthentication(),
     async (req, res, next) => {
       const organisme = (await getOrganismeByAPIKey(res.locals.token)) as WithId<Organisme>;
-      if (!organisme) {
-        throw new Error("Unauthorized");
-      }
 
       let erpSource = "INCONNU";
       if (organisme.erps?.length) {


### PR DESCRIPTION
cf : [TM-612](https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/TM/boards/1/backlog?assignee=712020%3Aa35d39f1-286a-43a4-8ad3-c1041b95d2a1&atlOrigin=eyJwIjoiaiIsImkiOiJlOGFiZTQ2MjYyZGQ0YmIzYTkxNmQwN2ExMDIxYzI4NyJ9&cloudId=fd0b3ea4-845f-441e-bce3-72c8a7dbd0a3&selectedIssue=TM-612)

**Description :**
Cette Pull Request vise à optimiser la gestion des messages d'erreur en les ajustant à des codes 403 concernant à l'API key  lorsque celle-ci est incorrecte ou inexistante.

**Détails des changements :**
Remplacement des blocs de gestion d'exception existants par l'utilisation de la bibliothèque hapi.boom.
Modification des messages d'erreur pour les rendre plus explicites et en Français.

**Bénéfices attendus :**
Cette mise à jour vise à permettre aux ERP une meilleure gestion des retours d'erreur lors des appels à l'API. En améliorant la clarté et la précision des messages d'erreur, nous facilitons le processus de débogage et d'intégration pour les utilisateurs finaux.