### PR TITLE
fix: Ajustement des champs du fichier CSV SIFA

### DIFF
--- a/server/src/common/actions/sifa.actions/sifa.actions.ts
+++ b/server/src/common/actions/sifa.actions/sifa.actions.ts
@@ -173,7 +173,7 @@ export const generateSifa = async (organisme_id: ObjectId) => {
           ? effectif.apprenant.dernier_organisme_uai
           : wrapNumString(effectif.apprenant.dernier_organisme_uai.padStart(3, "0"))
         : undefined,
-      DIPLOME: wrapNumString(formationBcn?.cfd || effectif.formation.cfd),
+      DIPLOME: formatStringForSIFA(formationBcn?.libelle || effectif.formation.libelle_long || ""),
       DUR_FORM_THEO: effectif.formation.duree_theorique_mois
         ? effectif.formation.duree_theorique_mois
         : // Les ERPs (ou les anciens fichiers de téléversement) pouvaient envoyer duree_theorique_formation
@@ -192,8 +192,13 @@ export const generateSifa = async (organisme_id: ObjectId) => {
       NAT_STR_JUR: "NC", // Unknown for now
     };
 
+    const notRequiredFields = {
+      TYPE_CFA: wrapNumString(effectif.apprenant.type_cfa),
+      RNCP: effectif.formation.rncp || "",
+    };
+
     const apprenantFields = {
-      INE: wrapNumString(effectif.apprenant.ine) ?? "ine",
+      INE_RNIE: wrapNumString(effectif.apprenant.ine) ?? "ine",
       TEL_JEUNE: wrapNumString(effectif.apprenant.telephone?.replace("+33", "0")),
       MAIL_JEUNE: effectif.apprenant.courriel,
       HANDI: effectif.apprenant.rqth ? "1" : "0",
@@ -245,6 +250,7 @@ export const generateSifa = async (organisme_id: ObjectId) => {
 
     items.push({
       ...requiredFields,
+      ...notRequiredFields,
       ...apprenantFields,
       ...employeurFields,
       ...statutFields,

--- a/server/src/common/actions/sifa.actions/sifa.actions.ts
+++ b/server/src/common/actions/sifa.actions/sifa.actions.ts
@@ -173,7 +173,7 @@ export const generateSifa = async (organisme_id: ObjectId) => {
           ? effectif.apprenant.dernier_organisme_uai
           : wrapNumString(effectif.apprenant.dernier_organisme_uai.padStart(3, "0"))
         : undefined,
-      DIPLOME: formatStringForSIFA(formationBcn?.libelle || effectif.formation.libelle_long || ""),
+      DIPLOME: wrapNumString(formationBcn?.cfd || effectif.formation.cfd),
       DUR_FORM_THEO: effectif.formation.duree_theorique_mois
         ? effectif.formation.duree_theorique_mois
         : // Les ERPs (ou les anciens fichiers de téléversement) pouvaient envoyer duree_theorique_formation
@@ -198,7 +198,7 @@ export const generateSifa = async (organisme_id: ObjectId) => {
     };
 
     const apprenantFields = {
-      INE_RNIE: wrapNumString(effectif.apprenant.ine) ?? "ine",
+      INE: wrapNumString(effectif.apprenant.ine) ?? "",
       TEL_JEUNE: wrapNumString(effectif.apprenant.telephone?.replace("+33", "0")),
       MAIL_JEUNE: effectif.apprenant.courriel,
       HANDI: effectif.apprenant.rqth ? "1" : "0",

--- a/server/src/common/actions/sifa.actions/sifaCsvFields.ts
+++ b/server/src/common/actions/sifa.actions/sifaCsvFields.ts
@@ -1,7 +1,7 @@
 export const SIFA_FIELDS = [
   {
-    label: "INE",
-    value: "INE",
+    label: "INE_RNIE",
+    value: "INE_RNIE",
   },
   {
     label: "NUMERO_UAI",
@@ -30,6 +30,10 @@ export const SIFA_FIELDS = [
   {
     label: "DIPLOME",
     value: "DIPLOME",
+  },
+  {
+    label: "RNCP",
+    value: "RNCP",
   },
   {
     label: "DUR_FORM_THEO",

--- a/server/src/common/actions/sifa.actions/sifaCsvFields.ts
+++ b/server/src/common/actions/sifa.actions/sifaCsvFields.ts
@@ -1,7 +1,7 @@
 export const SIFA_FIELDS = [
   {
-    label: "INE_RNIE",
-    value: "INE_RNIE",
+    label: "INE",
+    value: "INE",
   },
   {
     label: "NUMERO_UAI",

--- a/ui/modules/mon-espace/SIFA/SIFAPage.tsx
+++ b/ui/modules/mon-espace/SIFA/SIFAPage.tsx
@@ -200,7 +200,8 @@ const SIFAPage = (props: SIFAPageProps) => {
               Attention
             </Text>
             <Text color="grey.800">
-              Vérifiez que tous vos apprentis soient bien présents dans le fichier. Sinon, complétez-le.
+              Avant de téléverser votre fichier SIFA sur le portail dédié de la DEPP, veuillez supprimer la première
+              ligne d’en-tête.
             </Text>
           </Ribbons>
         </HStack>


### PR DESCRIPTION
fix: [tm-644](https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/TM/boards/1/backlog?assignee=712020%3Aa35d39f1-286a-43a4-8ad3-c1041b95d2a1&atlOrigin=eyJwIjoiaiIsImkiOiJlOGFiZTQ2MjYyZGQ0YmIzYTkxNmQwN2ExMDIxYzI4NyJ9&cloudId=fd0b3ea4-845f-441e-bce3-72c8a7dbd0a3&selectedIssue=TM-644)


**Description :**
Cette Pull Request a pour objectif de corriger les éléments suivants dans le fichier CSV SIFA destiné à la DEPP :

- Adapter deux champs spécifiques conformément aux exigences de la DEPP.
- Vérifier l'ordre de tous les champs en se référant au Guide SIFA de la DEPP.
- Informer l'utilisateur sur le site de la nécessité de supprimer les champs d'en-tête du fichier avant de le transmettre à la DEPP.

**Détails des changements :**
Mise à jour du fichier sifa.action.ts avec les éléments suivants :

- Ajout du champ RNCP.
- Ajout sur l'interface d'un message d'alerte précisant de supprimer l'en-tête du fichier CSV

![Screenshot 2024-01-09 at 10 46 35](https://github.com/mission-apprentissage/flux-retour-cfas/assets/686395/215bec75-105f-45fa-9f4d-e7343f7d0989)


**Bénéfices attendus :**
Cette mise à jour résout les problèmes liés au téléversement des effectifs des OF a partir du fichier SIFA, en direction de la DEPP.
