### PR TITLE
fix: Correction du faux message d'erreur quand tous les effectifs sont valides pour SIFA

### DIFF
--- a/ui/modules/mon-espace/SIFA/SIFAPage.tsx
+++ b/ui/modules/mon-espace/SIFA/SIFAPage.tsx
@@ -91,7 +91,7 @@ interface SIFAPageProps {
 
 const SIFAPage = (props: SIFAPageProps) => {
   const { trackPlausibleEvent } = usePlausibleTracking();
-  const { toastWarning } = useToaster();
+  const { toastWarning, toastSuccess } = useToaster();
   const organisme = useRecoilValue<any>(organismeAtom);
   const { isLoading, organismesEffectifs } = useOrganismesEffectifs(organisme._id);
 
@@ -110,6 +110,26 @@ const SIFAPage = (props: SIFAPageProps) => {
       setHasTrackedMissingSifa(true);
     }
     setShowOnlyMissingSifa(e.target.checked);
+  };
+
+  const handleToastOnSifaDownload = () => {
+    const nbEffectifsInvalides = organismesEffectifs.filter((effectif) => effectif.requiredSifa.length > 0).length;
+
+    nbEffectifsInvalides > 0
+      ? toastWarning(
+          `Parmi les ${organismesEffectifs.length} effectifs que vous avez déclarés, ${nbEffectifsInvalides} d'entre eux ne comportent pas l'ensemble des informations requises pour l'enquête SIFA. Si vous ne les corrigez/complétez pas, votre fichier risque d'être rejeté. Vous pouvez soit les éditer directement sur la plateforme soit modifier votre fichier sur votre ordinateur.`,
+          {
+            isClosable: true,
+            duration: 20000,
+          }
+        )
+      : toastSuccess(
+          `Avant de téléverser votre fichier SIFA sur la plateforme dédiée, veuillez supprimer la première ligne d'en-tête.`,
+          {
+            isClosable: true,
+            duration: 20000,
+          }
+        );
   };
 
   if (isLoading) {
@@ -137,16 +157,7 @@ const SIFAPage = (props: SIFAPageProps) => {
               }-${new Date().toLocaleDateString()}.csv`,
               "text/plain"
             );
-            const nbEffectifsInvalides = organismesEffectifs.filter(
-              (effectif) => effectif.requiredSifa.length > 0
-            ).length;
-            toastWarning(
-              `Parmi les ${organismesEffectifs.length} effectifs que vous avez déclarés, ${nbEffectifsInvalides} d'entre eux ne comportent pas l'ensemble des informations requises pour l'enquête SIFA. Si vous ne les corrigez/complétez pas, votre fichier risque d'être rejeté. Vous pouvez soit les éditer directement sur la plateforme soit modifier votre fichier sur votre ordinateur.`,
-              {
-                isClosable: true,
-                duration: 20000,
-              }
-            );
+            handleToastOnSifaDownload();
           }}
         >
           Télécharger le fichier SIFA


### PR DESCRIPTION
fix [tm-645](https://tableaudebord-apprentissage.atlassian.net/browse/TM-645)

**Description**

- Correction du faux message d'erreur quand tous les effectifs sont valides pour SIFA
- Ajout d'un toaster de succès avec un message spécifiant de supprimer le header du document pour SIFA

**Autres**
- Un bug a été détecté lors de la résolution de la tâche :  [tm-651](https://tableaudebord-apprentissage.atlassian.net/browse/TM-651). Le bug a volontairement été isolé car nécessite potentiellement une refacto de la page sur la récupération des effectifs/organismes 

