### PR TITLE
fix: Transformation des inscrits sans contrat en abandon après 90 jours

### DIFF
--- a/server/src/commands.ts
+++ b/server/src/commands.ts
@@ -583,11 +583,11 @@ program
  * Job de suppression des inscrits sans contrats dans ce statut depuis un nb de jours donné
  */
 program
-  .command("fiabilisation:effectifs:remove-inscritsSansContrats-depuis-nbJours")
+  .command("fiabilisation:effectifs:transform-inscritsSansContrats-en-abandons-depuis")
   .description("Suppression des inscrits sans contrats dans ce statut depuis un nombre de jours donné")
   .option("--nbJours <number>", "Nombre de jours dans le statut", (n) => parseInt(n, 10), 90)
   .option("-q, --queued", "Run job asynchronously", false)
-  .action(createJobAction("fiabilisation:effectifs:remove-inscritsSansContrats-depuis-nbJours"));
+  .action(createJobAction("fiabilisation:effectifs:transform-inscritsSansContrats-en-abandons-depuis"));
 
 /**
  * Job de transformation des rupturants en abandon dans ce statut depuis un nombre de jours donné

--- a/server/src/common/model/effectifs.model/parts/apprenant.part.ts
+++ b/server/src/common/model/effectifs.model/parts/apprenant.part.ts
@@ -107,6 +107,9 @@ export const apprenantSchema = object(
           }),
           date_statut: date(),
           date_reception: date(),
+          abandon_forced: boolean({
+            description: "Le statut a été forcé en abandon",
+          }),
         },
         {
           required: ["valeur_statut", "date_statut"],
@@ -182,9 +185,6 @@ export const apprenantSchema = object(
     }),
     responsable_mail2: string({
       description: "Adresse mail du responsable 2",
-    }),
-    abandon_forced: boolean({
-      description: "Le statut a été forcé en abandon",
     }),
   },
   {

--- a/server/src/common/model/effectifs.model/parts/apprenant.part.ts
+++ b/server/src/common/model/effectifs.model/parts/apprenant.part.ts
@@ -107,9 +107,6 @@ export const apprenantSchema = object(
           }),
           date_statut: date(),
           date_reception: date(),
-          abandon_forced: boolean({
-            description: "Le statut a été forcé en abandon",
-          }),
         },
         {
           required: ["valeur_statut", "date_statut"],
@@ -185,6 +182,9 @@ export const apprenantSchema = object(
     }),
     responsable_mail2: string({
       description: "Adresse mail du responsable 2",
+    }),
+    abandon_forced: boolean({
+      description: "Le statut a été forcé en abandon",
     }),
   },
   {

--- a/server/src/common/model/effectifs.model/parts/apprenant.part.ts
+++ b/server/src/common/model/effectifs.model/parts/apprenant.part.ts
@@ -107,6 +107,9 @@ export const apprenantSchema = object(
           }),
           date_statut: date(),
           date_reception: date(),
+          abandon_forced: boolean({
+            description: "Le statut a été forcé en abandon",
+          }),
         },
         {
           required: ["valeur_statut", "date_statut"],

--- a/server/src/jobs/fiabilisation/effectifs/index.ts
+++ b/server/src/jobs/fiabilisation/effectifs/index.ts
@@ -121,10 +121,8 @@ const updateEffectifToAbandon = async (effectif, abandonDate) => {
       valeur_statut: CODES_STATUT_APPRENANT.abandon,
       date_statut: abandonDate,
       date_reception: abandonDate,
+      abandon_forced: true,
     });
-
-    // Ajout du champ abandon_forced dans apprenant
-    effectif.apprenant.abandon_forced = true;
 
     await effectifsDb().findOneAndUpdate(
       { _id: effectif._id },

--- a/server/src/jobs/fiabilisation/effectifs/index.ts
+++ b/server/src/jobs/fiabilisation/effectifs/index.ts
@@ -125,6 +125,7 @@ const updateEffectifToAbandon = async (effectif, abandonDate) => {
       valeur_statut: CODES_STATUT_APPRENANT.abandon,
       date_statut: abandonDate,
       date_reception: abandonDate,
+      abandon_forced: true,
     });
 
     await effectifsDb().findOneAndUpdate(

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -92,7 +92,7 @@ export const CronsMap = {
       // # Mise a jour du nb d'effectifs
       await addJob({ name: "hydrate:organismes-effectifs-count", queued: true });
 
-      // # Fiabilisation des effectifs : suppression des inscrits sans contrats depuis 90 jours & transformation des rupturants en abandon > 180 jours
+      // # Fiabilisation des effectifs : transformation des inscrits sans contrats en abandon > 90 jours & transformation des rupturants en abandon > 180 jours
       await addJob({ name: "fiabilisation:effectifs:transform-inscritsSansContrats-en-abandons-depuis", queued: true });
       await addJob({ name: "fiabilisation:effectifs:transform-rupturants-en-abandons-depuis", queued: true });
 

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -10,7 +10,7 @@ import { findInvalidDocuments } from "./db/findInvalidDocuments";
 import { recreateIndexes } from "./db/recreateIndexes";
 import { validateModels } from "./db/schemaValidation";
 import { sendReminderEmails } from "./emails/reminder";
-import { removeInscritsSansContratsDepuis, transformRupturantsToAbandonsDepuis } from "./fiabilisation/effectifs";
+import { transformSansContratsToAbandonsDepuis, transformRupturantsToAbandonsDepuis } from "./fiabilisation/effectifs";
 import { hydrateRaisonSocialeEtEnseigneOFAInconnus } from "./fiabilisation/ofa-inconnus";
 import { getStats } from "./fiabilisation/stats";
 import { buildFiabilisationUaiSiret } from "./fiabilisation/uai-siret/build";
@@ -93,7 +93,7 @@ export const CronsMap = {
       await addJob({ name: "hydrate:organismes-effectifs-count", queued: true });
 
       // # Fiabilisation des effectifs : suppression des inscrits sans contrats depuis 90 jours & transformation des rupturants en abandon > 180 jours
-      await addJob({ name: "fiabilisation:effectifs:remove-inscritsSansContrats-depuis-nbJours", queued: true });
+      await addJob({ name: "fiabilisation:effectifs:transform-inscritsSansContrats-en-abandons-depuis", queued: true });
       await addJob({ name: "fiabilisation:effectifs:transform-rupturants-en-abandons-depuis", queued: true });
 
       return 0;
@@ -231,8 +231,8 @@ export async function runJob(job: IJobsCronTask | IJobsSimple): Promise<number> 
 
         return { buildResults, updateResults };
       }
-      case "fiabilisation:effectifs:remove-inscritsSansContrats-depuis-nbJours":
-        return removeInscritsSansContratsDepuis((job.payload as any)?.nbJours);
+      case "fiabilisation:effectifs:transform-inscritsSansContrats-en-abandons-depuis":
+        return transformSansContratsToAbandonsDepuis((job.payload as any)?.nbJours);
       case "fiabilisation:effectifs:transform-rupturants-en-abandons-depuis":
         return transformRupturantsToAbandonsDepuis((job.payload as any)?.nbJours);
       case "fiabilisation:stats":


### PR DESCRIPTION
fix: [TM-655](https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/TM/boards/1/backlog?assignee=712020%3Aa35d39f1-286a-43a4-8ad3-c1041b95d2a1&cloudId=fd0b3ea4-845f-441e-bce3-72c8a7dbd0a3&selectedIssue=TM-655) & [TM-656](https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/TM/boards/1/backlog?assignee=712020%3Aa35d39f1-286a-43a4-8ad3-c1041b95d2a1&cloudId=fd0b3ea4-845f-441e-bce3-72c8a7dbd0a3&selectedIssue=TM-656)


**Description :**

Cette Pull Request apporte plusieurs correctifs importants liés à la gestion des inscrits sans contrat et au suivi des statuts d'abandon dans notre système. Les modifications assurent une meilleure cohérence des données.

**Détails des changements :**

Changement de la fonction removeInscritsSansContratsDepuis en transformSansContratsToAbandonsDepuis :
Cette modification vise à transformer les données des inscrits sans contrats depuis plus de 90 jours en abandon plutôt que de les supprimer. Cela permet une meilleure traçabilité et gestion des données.

Ajout du champ abandon_forced dans historique_statut :
Un nouveau champ abandon_forced a été ajouté à l'historique des statuts. Ceci est crucial pour suivre les cas où un abandon est initié de manière forcée par le système.

**Bénéfices attendus :**

Les changements apportés permettent une meilleure traçabilité et compréhension des parcours des apprenants, et un meilleur suivi des abandons forcés.
