### PR TITLE
fix: mise à jour des champs type_cfa, nom , prenom pour SIFA

### DIFF
--- a/server/src/common/actions/sifa.actions/sifaCsvFields.ts
+++ b/server/src/common/actions/sifa.actions/sifaCsvFields.ts
@@ -189,7 +189,42 @@ export const SIFA_FIELDS = [
   },
 ];
 
+// Detecter la durée de formation
 export const formatAN_FORM = (year: number | undefined) => {
   if (year == null) return year;
   return `${year}A`;
+};
+
+export const formatStringForSIFA = (str: string | undefined) => {
+  if (typeof str !== "string" || str.length === 0) return undefined;
+
+  const accentsMap = {
+    A: /[\300-\306]/g,
+    a: /[\340-\346]/g,
+    E: /[\310-\313]/g,
+    e: /[\350-\353]/g,
+    I: /[\314-\317]/g,
+    i: /[\354-\357]/g,
+    O: /[\322-\330]/g,
+    o: /[\362-\370]/g,
+    U: /[\331-\334]/g,
+    u: /[\371-\374]/g,
+    N: /[\321]/g,
+    n: /[\361]/g,
+    C: /[\307]/g,
+    c: /[\347]/g,
+  };
+
+  // Remplace chaque accent par son homologue non accentué
+  for (const [replacement, regex] of Object.entries(accentsMap)) {
+    str = str.replace(regex, replacement);
+  }
+
+  // Remplacez les traits d'union par des espaces et supprimez tous les caractères non alphanumériques (hors espaces)
+  return str.replace(/-/g, " ").replace(/[^0-9a-zA-Z ]/g, "");
+};
+
+export const wrapNumString = (str: string | number | null | undefined) => {
+  if (str === null || str === undefined) return str;
+  return `="${str}"`;
 };


### PR DESCRIPTION
fix: [TM-699](https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/TM/boards/1/backlog?assignee=712020%3Aa35d39f1-286a-43a4-8ad3-c1041b95d2a1&selectedIssue=TM-699)

**Description :**
Cette Pull Request a pour objectif de corriger les éléments suivants dans le fichier CSV SIFA destiné à la DEPP :

- Adaptation du format du champs TYPE_CFA sur 2 caractères. 1 -> 01
- Remplacement des traits d'union par des espaces dans le mom et prénom
- Limitation à 100 caractères du nom et prénom
- Limitation à 200 caractères de l'adresse

**Détails des changements :**
Mise à jour du fichier sifa.action.ts avec les éléments suivants :

- Mise a jour de la méthode formatStringForSIFA pour prendre en compte les traits d'union
- Ajout de la méthode slice pour limiter le nombre de caractères

**Bénéfices attendus :**
Cette mise à jour résout les problèmes liés au téléversement des effectifs des OF a partir du fichier SIFA, en direction de la DEPP.
