### PR TITLE
fix: SIFA - forcer le maintien de la colonne INE même si cette dernière est vide

### DIFF
--- a/server/src/common/actions/sifa.actions/sifa.actions.ts
+++ b/server/src/common/actions/sifa.actions/sifa.actions.ts
@@ -161,7 +161,7 @@ export const generateSifa = async (organisme_id: ObjectId) => {
     };
 
     const apprenantFields = {
-      INE: wrapNumString(effectif.apprenant.ine) ?? "",
+      INE: wrapNumString(effectif.apprenant.ine) ?? `=""`,
       TEL_JEUNE: wrapNumString(effectif.apprenant.telephone?.replace("+33", "0")),
       MAIL_JEUNE: effectif.apprenant.courriel,
       HANDI: effectif.apprenant.rqth ? "1" : "0",

--- a/server/src/common/actions/sifa.actions/sifa.actions.ts
+++ b/server/src/common/actions/sifa.actions/sifa.actions.ts
@@ -9,7 +9,7 @@ import { getCodePostalInfo } from "@/common/apis/apiTablesCorrespondances";
 import { Effectif } from "@/common/model/@types/Effectif";
 import { effectifsDb } from "@/common/model/collections";
 
-import { SIFA_FIELDS, formatAN_FORM, formatStringForSIFA, wrapNumString } from "./sifaCsvFields";
+import { SIFA_FIELDS, formatAN_FORM, formatINE, formatStringForSIFA, wrapNumString } from "./sifaCsvFields";
 
 export const isEligibleSIFA = (historique_statut: Effectif["apprenant"]["historique_statut"]) => {
   const endOfyear = getSIFADate(new Date());
@@ -161,7 +161,7 @@ export const generateSifa = async (organisme_id: ObjectId) => {
     };
 
     const apprenantFields = {
-      INE: wrapNumString(effectif.apprenant.ine) ?? `=""`,
+      INE: formatINE(effectif.apprenant.ine),
       TEL_JEUNE: wrapNumString(effectif.apprenant.telephone?.replace("+33", "0")),
       MAIL_JEUNE: effectif.apprenant.courriel,
       HANDI: effectif.apprenant.rqth ? "1" : "0",

--- a/server/src/common/actions/sifa.actions/sifaCsvFields.ts
+++ b/server/src/common/actions/sifa.actions/sifaCsvFields.ts
@@ -195,6 +195,16 @@ export const formatAN_FORM = (year: number | undefined) => {
   return `${year}A`;
 };
 
+/*
+  Formattage de l'INE
+  Si l'INE est vide, retourner une formule afin de ne pas générer de colonne vide
+  dans le cas de SIFA
+  Voir https://tableaudebord-apprentissage.atlassian.net/browse/TM-703
+*/
+export const formatINE = (ine: string | undefined) => {
+  return wrapNumString(ine) ?? `=""`;
+};
+
 export const formatStringForSIFA = (str: string | undefined) => {
   if (typeof str !== "string" || str.length === 0) return undefined;
 


### PR DESCRIPTION
fix [TM-703](https://tableaudebord-apprentissage.atlassian.net/browse/TM-703)

**Description**

- Mettre une formule vide plutôt qu'une chaine vide pour l'INE ( lors de la sauvegarde ultérieure, afin de supprimer l'entête, la colonne sera préservée )