### PR TITLE
feat: ajout tracking page de doublon effectifs

### DIFF
--- a/shared/constants/plausible-goals.ts
+++ b/shared/constants/plausible-goals.ts
@@ -47,10 +47,10 @@ export const plausibleGoals = [
   "telechargement_fichier_instruction_sifa",
 
   // - Page SIFA ou Page Effectifs
-  "clic_vérifier_doublons_effectifs",
+  "clic_verifier_doublons_effectifs",
 
   // - Page Effectifs Doublons
-  "suppression_doublon_effectif",
+  "suppression_doublons_effectifs",
 ] as const;
 
 export type PlausibleGoalType = (typeof plausibleGoals)[number];

--- a/shared/constants/plausible-goals.ts
+++ b/shared/constants/plausible-goals.ts
@@ -45,6 +45,12 @@ export const plausibleGoals = [
   // - Page SIFA
   "telechargement_sifa",
   "telechargement_fichier_instruction_sifa",
+
+  // - Page SIFA ou Page Effectifs
+  "clic_vérifier_doublons_effectifs",
+
+  // - Page Effectifs Doublons
+  "suppression_doublon_effectif",
 ] as const;
 
 export type PlausibleGoalType = (typeof plausibleGoals)[number];

--- a/ui/components/Links/Link.tsx
+++ b/ui/components/Links/Link.tsx
@@ -1,5 +1,6 @@
 import { Link as ChakraLink, LinkProps as ChakraLinkProps, SystemProps } from "@chakra-ui/react";
 import NavLink from "next/link";
+import { useRouter } from "next/router";
 import { ReactNode } from "react";
 import { PlausibleGoalType } from "shared";
 
@@ -13,13 +14,18 @@ interface LinkProps extends ChakraLinkProps, SystemProps {
 }
 const Link = ({ children, href, shallow, plausibleGoal, ...rest }: LinkProps) => {
   const { trackPlausibleEvent } = usePlausibleTracking();
+  const router = useRouter();
+
   return (
     <ChakraLink
       as={NavLink}
       href={href}
       shallow={shallow ?? false}
       onClick={() => {
-        plausibleGoal && trackPlausibleEvent(plausibleGoal);
+        const currentPath = router.pathname;
+        if (plausibleGoal) {
+          trackPlausibleEvent(plausibleGoal, currentPath);
+        }
       }}
       {...rest}
     >

--- a/ui/hooks/plausible.ts
+++ b/ui/hooks/plausible.ts
@@ -5,20 +5,24 @@ import { getOrganisationLabel } from "@/common/internal/Organisation";
 
 import useAuth from "./useAuth";
 
-// track des actions via plausible avec l'organisation en propriétés
 export function usePlausibleTracking() {
   const { auth } = useAuth();
   const plausible = usePlausible();
 
   return {
-    trackPlausibleEvent(goal: PlausibleGoalType, props?: Record<string, string | number | boolean>) {
-      plausible(goal, {
-        props: {
-          organisationType: auth?.organisation?.type,
-          organisationNom: auth?.organisation ? getOrganisationLabel(auth.organisation) : undefined,
-          ...props,
-        },
-      });
+    trackPlausibleEvent(
+      goal: PlausibleGoalType,
+      currentPath?: string,
+      props?: Record<string, string | number | boolean>
+    ) {
+      const eventProps: Record<string, string | number | boolean | undefined> = {
+        organisationType: auth?.organisation?.type,
+        organisationNom: auth?.organisation ? getOrganisationLabel(auth.organisation) : undefined,
+        ...(currentPath ? { currentPath: currentPath } : {}),
+        ...props,
+      };
+
+      plausible(goal, { props: eventProps });
     },
   };
 }

--- a/ui/modules/effectifs/EffectifsPage.tsx
+++ b/ui/modules/effectifs/EffectifsPage.tsx
@@ -137,7 +137,11 @@ function EffectifsPage(props: EffectifsPageProps) {
                 scolaire en cours.
               </Text>
 
-              <Link variant="whiteBg" href={`${router.asPath}/doublons`}>
+              <Link
+                variant="whiteBg"
+                href={`${router.asPath}/doublons`}
+                plausibleGoal="clic_vérifier_doublons_effectifs"
+              >
                 Vérifier
               </Link>
             </Box>

--- a/ui/modules/effectifs/EffectifsPage.tsx
+++ b/ui/modules/effectifs/EffectifsPage.tsx
@@ -140,7 +140,7 @@ function EffectifsPage(props: EffectifsPageProps) {
               <Link
                 variant="whiteBg"
                 href={`${router.asPath}/doublons`}
-                plausibleGoal="clic_vérifier_doublons_effectifs"
+                plausibleGoal="clic_verifier_doublons_effectifs"
               >
                 Vérifier
               </Link>

--- a/ui/modules/mon-espace/SIFA/SIFAPage.tsx
+++ b/ui/modules/mon-espace/SIFA/SIFAPage.tsx
@@ -272,7 +272,11 @@ const SIFAPage = (props: SIFAPageProps) => {
               en cours.
             </Text>
 
-            <Link variant="whiteBg" href={`${router.asPath.replace("enquete-sifa", "effectifs")}/doublons`}>
+            <Link
+              variant="whiteBg"
+              href={`${router.asPath.replace("enquete-sifa", "effectifs")}/doublons`}
+              plausibleGoal="clic_vérifier_doublons_effectifs"
+            >
               Vérifier
             </Link>
           </Box>

--- a/ui/modules/mon-espace/SIFA/SIFAPage.tsx
+++ b/ui/modules/mon-espace/SIFA/SIFAPage.tsx
@@ -275,7 +275,7 @@ const SIFAPage = (props: SIFAPageProps) => {
             <Link
               variant="whiteBg"
               href={`${router.asPath.replace("enquete-sifa", "effectifs")}/doublons`}
-              plausibleGoal="clic_vérifier_doublons_effectifs"
+              plausibleGoal="clic_verifier_doublons_effectifs"
             >
               Vérifier
             </Link>

--- a/ui/modules/mon-espace/effectifs/doublons/EffectifDoublonDetailModal.tsx
+++ b/ui/modules/mon-espace/effectifs/doublons/EffectifDoublonDetailModal.tsx
@@ -25,6 +25,7 @@ import { getStatutApprenantNameFromCode } from "shared";
 import { _get } from "@/common/httpClient";
 import { formatDateDayMonthYear, prettyPrintDate } from "@/common/utils/dateUtils";
 import { toPascalCase } from "@/common/utils/stringUtils";
+import { usePlausibleTracking } from "@/hooks/plausible";
 import { Close } from "@/theme/components/icons";
 
 import EffectifDoublonDeleteAlertDialog from "./EffectifDoublonDeleteAlertDialog";
@@ -41,6 +42,7 @@ const EffectifDoublonDetailModal = ({
 }) => {
   const { isOpen: isOpenAlertDialog, onOpen: onOpenAlertDialog, onClose: onCloseAlertDialog } = useDisclosure();
   const cancelRef = React.useRef();
+  const { trackPlausibleEvent } = usePlausibleTracking();
 
   return (
     <>
@@ -356,6 +358,7 @@ const EffectifDoublonDetailModal = ({
               <Button
                 variant="primary"
                 onClick={() => {
+                  trackPlausibleEvent("suppression_doublon_effectif");
                   onClose?.();
                   onOpenAlertDialog?.();
                 }}

--- a/ui/modules/mon-espace/effectifs/doublons/EffectifDoublonDetailModal.tsx
+++ b/ui/modules/mon-espace/effectifs/doublons/EffectifDoublonDetailModal.tsx
@@ -358,7 +358,7 @@ const EffectifDoublonDetailModal = ({
               <Button
                 variant="primary"
                 onClick={() => {
-                  trackPlausibleEvent("suppression_doublon_effectif");
+                  trackPlausibleEvent("suppression_doublons_effectifs");
                   onClose?.();
                   onOpenAlertDialog?.();
                 }}


### PR DESCRIPTION
Feat: [TM-735](https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/TM/boards/1/backlog?selectedIssue=TM-735)

### Description :
Cette PR introduit un suivi analytique amélioré pour les actions liées à la gestion des doublons d'effectifs par les organismes de formation. Elle permet de suivre les interactions des utilisateurs sur la page de gestion des doublons, notamment lors de la vérification et de la suppression des effectifs en double.

### Détails des Changements :
**Tracking du Clic sur le Bouton “Vérifier” :**

**Goal Plausible :** clic_vérifier_doublons_effectifs.
**Propriétés :**
uai : Identifiant unique de l'établissement.
siret : Numéro SIRET de l'organisme.
currentPath : Source de l'action (peut être enquete-sifa ou effectifs).

**Tracking de la Suppression des Doublons :**

**Goal Plausible :** suppression_doublon_effectif.
**Propriétés :**
uai : Identifiant unique de l'établissement.
siret : Numéro SIRET de l'organisme.

Les modifications incluent la mise à jour du hook **usePlausibleTracking** afin d'ajouter la prise en compte du **currentPath** de la route où un clic est effectué.

### **Bénéfices Attendus :**
**Contextualisation Améliorée des Actions :** L'inclusion du currentPath dans le tracking offre une meilleure compréhension de l'origine et du contexte des actions des utilisateurs.
**Analyse Plus Précise :** Ces informations supplémentaires permettent une analyse plus détaillée des comportements utilisateurs, facilitant l'identification de tendances ou de problèmes spécifiques à la gestion des doublons.
