### PR TITLE
feat: mise a jour design et champs cfd page duplicats effectifs

### DIFF
--- a/ui/modules/mon-espace/effectifs/doublons/EffectifsDoublonsList.tsx
+++ b/ui/modules/mon-espace/effectifs/doublons/EffectifsDoublonsList.tsx
@@ -62,20 +62,10 @@ const EffectifsDoublonsList = ({ data }) => {
           enableSorting: false,
         },
         {
-          header: () => "Code formation diplôme",
-          accessorKey: "_id",
-          cell: ({ row }) => (
-            <Text fontSize="1rem" pt={2} whiteSpace="nowrap">
-              {`CFD : ${row.original?._id?.formation_cfd}`}
-            </Text>
-          ),
-          enableSorting: false,
-        },
-        {
           header: () => "Nombre d'occurences",
           accessorKey: "_id",
           cell: ({ row }) => (
-            <HStack>
+            <HStack align="center" justify="center">
               <Alert mt={2} />
               <Text fontSize="1rem" pt={2} whiteSpace="nowrap">
                 {row?.original?.duplicates.length}
@@ -88,16 +78,14 @@ const EffectifsDoublonsList = ({ data }) => {
     />
   );
 };
-
 const RenderSubComponent = (row: Row<DuplicateEffectifGroup>) => {
   return (
-    <Stack spacing={1} mt={-2} ml={10}>
+    <Stack spacing={4} mt={-2} ml={10}>
       {row?.original?.duplicates
-        // Tri par date de création pour proposition de suppression du moins récent
         ?.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
         .map((item, index) => (
           <Fragment key={index}>
-            <HStack spacing={4}>
+            <HStack spacing={6}>
               <ArrowRightLine />
               <Text>
                 <b>{`${transformNomPrenomToPascalCase(row)}`}</b>
@@ -105,20 +93,25 @@ const RenderSubComponent = (row: Row<DuplicateEffectifGroup>) => {
               <Text>
                 <i>{`créé le ${prettyPrintDate(item.created_at)}`}</i>
               </Text>
-              <Text>
-                <i>
-                  ERP source : <b>{item.source}</b>
-                </i>
-              </Text>
-
               <EffectifDoublonDetailModalContainer index={index} duplicateDetail={item} />
-
               {index === 0 && (
                 <HStack color="warning">
                   <Alert boxSize={4} mt={1} />
                   <Text fontSize="0.7rem"> Duplicat le plus ancien (à supprimer éventuellement)</Text>
                 </HStack>
               )}
+            </HStack>
+            <HStack spacing={16}>
+              <Text>
+                <i>
+                  Source : <b>{item.source}</b>
+                </i>
+              </Text>
+              <Text>
+                <i>
+                  Code formation diplôme : <b>{item?.formation?.cfd || "Non spécifié"}</b>
+                </i>
+              </Text>
             </HStack>
           </Fragment>
         ))}


### PR DESCRIPTION
cf: [3523](https://github.com/mission-apprentissage/flux-retour-cfas/pull/3523)
Feature : [TM-723](https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/TM/boards/1/backlog?assignee=712020%3Aa35d39f1-286a-43a4-8ad3-c1041b95d2a1&selectedIssue=TM-723&text=doublon)

### Description :

Cette Pull Request apporte des modifications au design de la page de gestion des doublons d'effectifs.

**Intégration du Code CFD :** Chaque entrée de doublon affiche désormais clairement son code CFD associé. Cette addition vise à améliorer la précision et la facilité de référence pour les utilisateurs qui gèrent ces doublons.

**Refonte de l'affichage des doublons :** Le design de la liste de doublons a été repensé pour une meilleure lisibilité.

![Screenshot 2024-01-24 at 15 20 03](https://github.com/mission-apprentissage/flux-retour-cfas/assets/686395/905dbb9a-8f5e-4a49-ad0f-11c0282168a6)
