### PR TITLE
feat: ajout d'api de visualisation de transmissions

### DIFF
--- a/server/src/common/actions/indicateurs/transmissions/transmission.action.ts
+++ b/server/src/common/actions/indicateurs/transmissions/transmission.action.ts
@@ -1,8 +1,10 @@
+import { startOfDay, endOfDay } from "date-fns";
+
 import { effectifsQueueDb } from "@/common/model/collections";
 
 export const getTransmissionStatusByOrganismeGroupedByDate = async (
   organismeId: string,
-  page: number = 0,
+  page: number = 1,
   limit: number = 20
 ) => {
   const transmissions = await effectifsQueueDb()
@@ -91,8 +93,77 @@ export const getTransmissionStatusByOrganismeGroupedByDate = async (
       { $unwind: { path: "$pagination" } },
     ])
     .next();
+
+  if (!transmissions) {
+    return {
+      pagination: {
+        page,
+        limit,
+        lastPage: page,
+        total: 0,
+      },
+      data: [],
+    };
+  }
   if (transmissions?.pagination) {
     transmissions.pagination.lastPage = Math.ceil(transmissions.pagination.total / limit);
   }
   return transmissions;
+};
+
+export const getTransmissionStatusDetailsForAGivenDay = async (
+  organismeId: string,
+  day: string,
+  page: number = 1,
+  limit: number = 20
+) => {
+  const selectedDay = new Date(day);
+  const start = startOfDay(selectedDay);
+  const end = endOfDay(selectedDay);
+
+  const transmissionsDetails = await effectifsQueueDb()
+    .aggregate([
+      {
+        $match: {
+          source_organisme_id: organismeId,
+          processed_at: {
+            $gte: start,
+            $lte: end,
+          },
+          validation_errors: {
+            $exists: true,
+          },
+        },
+      },
+      {
+        $sort: {
+          processed_at: 1,
+        },
+      },
+      {
+        $facet: {
+          pagination: [{ $count: "total" }, { $addFields: { page, limit } }],
+          data: [{ $skip: (page - 1) * limit }, { $limit: limit }],
+        },
+      },
+      { $unwind: { path: "$pagination" } },
+    ])
+    .next();
+
+  if (!transmissionsDetails) {
+    return {
+      pagination: {
+        page,
+        limit,
+        lastPage: page,
+        total: 0,
+      },
+      data: [],
+    };
+  }
+
+  if (transmissionsDetails?.pagination) {
+    transmissionsDetails.pagination.lastPage = Math.ceil(transmissionsDetails.pagination.total / limit);
+  }
+  return transmissionsDetails;
 };

--- a/server/src/common/actions/indicateurs/transmissions/transmission.action.ts
+++ b/server/src/common/actions/indicateurs/transmissions/transmission.action.ts
@@ -1,0 +1,98 @@
+import { effectifsQueueDb } from "@/common/model/collections";
+
+export const getTransmissionStatusByOrganismeGroupedByDate = async (
+  organismeId: string,
+  page: number = 0,
+  limit: number = 20
+) => {
+  const transmissions = await effectifsQueueDb()
+    .aggregate([
+      {
+        $match: {
+          source_organisme_id: organismeId,
+        },
+      },
+      {
+        $group: {
+          _id: {
+            $dateToString: {
+              format: "%Y-%m-%d",
+              date: "$processed_at",
+            },
+          },
+          total: {
+            $sum: 1,
+          },
+          error: {
+            $sum: {
+              $cond: {
+                if: {
+                  $and: [
+                    {
+                      $ifNull: ["$validation_errors", false],
+                    },
+                  ],
+                },
+                then: 1,
+                else: 0,
+              },
+            },
+          },
+          success: {
+            $sum: {
+              $cond: {
+                if: {
+                  $and: [
+                    {
+                      $eq: [
+                        {
+                          $type: "$error",
+                        },
+                        "missing",
+                      ],
+                    },
+                    {
+                      $eq: [
+                        {
+                          $type: "$validation_errors",
+                        },
+                        "missing",
+                      ],
+                    },
+                  ],
+                },
+                then: 1,
+                else: 0,
+              },
+            },
+          },
+        },
+      },
+      {
+        $sort: {
+          _id: -1,
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          day: "$_id",
+          success: "$success",
+          error: "$error",
+          total: "$total",
+        },
+      },
+      {
+        $facet: {
+          pagination: [{ $count: "total" }, { $addFields: { page, limit } }],
+          data: [{ $skip: (page - 1) * limit }, { $limit: limit }],
+        },
+      },
+      { $unwind: { path: "$pagination" } },
+    ])
+    .next();
+  if (transmissions?.pagination) {
+    transmissions.pagination.lastPage = Math.ceil(transmissions.pagination.total / limit);
+  }
+  return transmissions;
+};

--- a/server/src/http/routes/specific.routes/transmission.routes.ts
+++ b/server/src/http/routes/specific.routes/transmission.routes.ts
@@ -1,0 +1,36 @@
+import { ObjectId } from "bson";
+import express from "express";
+import { z } from "zod";
+
+import { getTransmissionStatusByOrganismeGroupedByDate } from "@/common/actions/indicateurs/transmissions/transmission.action";
+import paginationSchema from "@/common/validation/paginationSchema";
+import { returnResult, requireOrganismePermission } from "@/http/middlewares/helpers";
+import validateRequestMiddleware from "@/http/middlewares/validateRequestMiddleware";
+
+const pagination = paginationSchema({ defaultSort: "processed_at:-1" }).strict();
+type Pagination = z.infer<typeof pagination>;
+
+export default () => {
+  const router = express.Router();
+
+  router.get(
+    "/",
+    requireOrganismePermission("configurerModeTransmission"),
+    validateRequestMiddleware({ query: pagination }),
+    returnResult(getAllTransmissionsByDate)
+  );
+  router.get("/:id", getTransmissionByDate);
+
+  return router;
+};
+
+const getAllTransmissionsByDate = async (req, res) => {
+  const { page, limit } = req.query as Pagination;
+  const organismeId = res.locals.organismeId as ObjectId;
+  const organismeIdString = organismeId.toString();
+  return await getTransmissionStatusByOrganismeGroupedByDate(organismeIdString, page, limit);
+};
+
+const getTransmissionByDate = () => {
+  return returnResult(async () => {});
+};

--- a/server/src/http/server.ts
+++ b/server/src/http/server.ts
@@ -132,6 +132,7 @@ import emails from "./routes/emails.routes";
 import dossierApprenantRouter from "./routes/specific.routes/dossiers-apprenants.routes";
 import { getOrganismeEffectifs, updateOrganismeEffectifs } from "./routes/specific.routes/organisme.routes";
 import organismesRouter from "./routes/specific.routes/organismes.routes";
+import transmissionRoutes from "./routes/specific.routes/transmission.routes";
 
 const openapiSpecs = JSON.parse(fs.readFileSync(openApiFilePath, "utf8"));
 
@@ -619,6 +620,7 @@ function setupRoutes(app: Application) {
             })
           )
       )
+      .use("/transmission", transmissionRoutes())
   );
 
   /********************************


### PR DESCRIPTION
fix: [TM-719](https://tableaudebord-apprentissage.atlassian.net/browse/TM-719)

**Description**
- Ajout d'une API indiquant le nombre de transmissions par jour, ainsi que leur statut ( échec ou non )
- Ajout d'une API permettant la visualisation détaillé des erreurs de transmissions