### PR TITLE
feat: ajout configuration matomo

### DIFF
--- a/ui/config.public.ts
+++ b/ui/config.public.ts
@@ -4,6 +4,12 @@ export interface PublicConfig {
   host: string;
   env: "local" | "recette" | "production" | "preview";
   version: string;
+  matomo: {
+    url: string;
+    siteId: string;
+    jsTrackerFile: string;
+    disableCookies: boolean;
+  };
 }
 
 const SENTRY_DSN = "https://77feecd94eb54b3491f81e3c5aaa026c@sentry.apprentissage.beta.gouv.fr/6";
@@ -16,6 +22,12 @@ function getProductionPublicConfig(): PublicConfig {
     env: "production",
     host,
     baseUrl: `https://${host}`,
+    matomo: {
+      url: "https://stats.beta.gouv.fr",
+      siteId: "94",
+      jsTrackerFile: "js/container_s4n03ZE1.js",
+      disableCookies: true,
+    },
     version: getVersion(),
   };
 }
@@ -28,6 +40,12 @@ function getRecettePublicConfig(): PublicConfig {
     env: "recette",
     host,
     baseUrl: `https://${host}`,
+    matomo: {
+      url: "https://stats.beta.gouv.fr",
+      siteId: "",
+      jsTrackerFile: "",
+      disableCookies: true,
+    },
     version: getVersion(),
   };
 }
@@ -47,6 +65,12 @@ function getPreviewPublicConfig(): PublicConfig {
     env: "preview",
     host,
     baseUrl: `https://${host}`,
+    matomo: {
+      url: "https://stats.beta.gouv.fr",
+      siteId: "",
+      jsTrackerFile: "",
+      disableCookies: true,
+    },
     version: getVersion(),
   };
 }
@@ -59,6 +83,12 @@ function getLocalPublicConfig(): PublicConfig {
     env: "local",
     host,
     baseUrl: `http://${host}:${process.env.NEXT_PUBLIC_API_PORT}`,
+    matomo: {
+      url: "https://stats.beta.gouv.fr",
+      siteId: "",
+      jsTrackerFile: "",
+      disableCookies: true,
+    },
     version: getVersion(),
   };
 }

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -8,17 +8,19 @@ function inline(value) {
 
 const contentSecurityPolicy = `
       default-src 'self' https://plausible.io;
-      base-uri 'self';
+      base-uri 'self' https://stats.beta.gouv.fr;
       block-all-mixed-content;
       font-src 'self' https: data:;
       frame-ancestors 'self' https://cfas.apprentissage.beta.gouv.fr;
       frame-src 'self' https://plausible.io https://cfas.apprentissage.beta.gouv.fr https://cfas-recette.apprentissage.beta.gouv.fr;
-      img-src 'self' https://files.tableau-de-bord.apprentissage.beta.gouv.fr https://www.notion.so https://mission-apprentissage.notion.site data:;
+      img-src 'self' https://files.tableau-de-bord.apprentissage.beta.gouv.fr https://www.notion.so https://mission-apprentissage.notion.site https://stats.beta.gouv.fr data:;
       object-src 'none';
-      script-src 'self' https://plausible.io ${process.env.NEXT_PUBLIC_ENV === "local" ? "'unsafe-eval'" : ""};
+      script-src 'self' https://plausible.io https://stats.beta.gouv.fr ${
+        process.env.NEXT_PUBLIC_ENV === "local" ? "'unsafe-eval'" : ""
+      };
       script-src-attr 'none';
       style-src 'self' https: *.plausible.io 'unsafe-inline';
-      connect-src 'self' https://plausible.io  https://sentry.apprentissage.beta.gouv.fr ${
+      connect-src 'self' https://plausible.io https://stats.beta.gouv.fr https://sentry.apprentissage.beta.gouv.fr ${
         process.env.NEXT_PUBLIC_ENV === "local" ? "http://localhost:5001/" : ""
       };
       upgrade-insecure-requests;

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,6 +26,7 @@
     "@nivo/pie": "0.80.0",
     "@sentry/integrations": "^7.93.0",
     "@sentry/nextjs": "^7.93.0",
+    "@socialgouv/matomo-next": "^1.8.0",
     "@tanstack/match-sorter-utils": "8.7.6",
     "@tanstack/react-query": "4.26.1",
     "@tanstack/react-table": "8.7.9",

--- a/ui/pages/_app.tsx
+++ b/ui/pages/_app.tsx
@@ -4,11 +4,13 @@ import "remixicon/fonts/remixicon.css";
 import "react-phone-input-2/lib/style.css";
 import "react-datepicker/dist/react-datepicker.css";
 import { ChakraProvider } from "@chakra-ui/react";
+import { init } from "@socialgouv/matomo-next";
 import { QueryClientProvider } from "@tanstack/react-query";
 // besoin de date-fns 3 pour import esm, voir https://github.com/date-fns/date-fns/issues/2629
 import fr from "date-fns/locale/fr"; // eslint-disable-line import/no-duplicates
 import setDefaultOptions from "date-fns/setDefaultOptions"; // eslint-disable-line import/no-duplicates
 import PlausibleProvider from "next-plausible";
+import { useEffect } from "react";
 import { RecoilRoot } from "recoil";
 
 import { queryClient } from "@/common/queryClient";
@@ -21,6 +23,10 @@ import theme from "@/theme/index";
 setDefaultOptions({ locale: fr });
 
 function MyApp({ Component, pageProps }) {
+  useEffect(() => {
+    init(publicConfig.matomo);
+  }, []);
+
   return (
     <PlausibleProvider domain={publicConfig.host} trackLocalhost={false}>
       <RecoilRoot>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4412,6 +4412,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@socialgouv/matomo-next@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "@socialgouv/matomo-next@npm:1.8.0"
+  peerDependencies:
+    next: ">= 9.5.5"
+  checksum: 810fc35234ceb417c6ceecb125d048c77458b6c3b6890fd3271eaa13c2cc2e77a84f4debc92e3a1ac84c5eea02cf09c3e788efb850afc8d63b341a64e0b41071
+  languageName: node
+  linkType: hard
+
 "@supercharge/promise-pool@npm:2.4.0":
   version: 2.4.0
   resolution: "@supercharge/promise-pool@npm:2.4.0"
@@ -19995,6 +20004,7 @@ request-debug@latest:
     "@nivo/pie": 0.80.0
     "@sentry/integrations": ^7.93.0
     "@sentry/nextjs": ^7.93.0
+    "@socialgouv/matomo-next": ^1.8.0
     "@tanstack/match-sorter-utils": 8.7.6
     "@tanstack/react-query": 4.26.1
     "@tanstack/react-table": 8.7.9


### PR DESCRIPTION
### Description
**Intégration de Matomo pour le suivi analytique**

Cette Pull Request ajoute le suivi analytique Matomo à l'application, permettant une meilleure compréhension des interactions des utilisateurs avec l'application. 

### **Détails des Changements**

- **Configuration de Matomo:** Ajout des configurations spécifiques à Matomo dans ui/config.public.ts pour différents environnements (local, recette, production, preview), incluant l'URL du serveur Matomo, l'ID du site, le fichier du suiveur JavaScript, et la désactivation des cookies pour respecter la vie privée.
- **Mise à jour de la politique de sécurité:** Modification de ui/next.config.js pour ajouter stats.beta.gouv.fr aux directives CSP, permettant le chargement des scripts Matomo.
- **Dépendance Matomo:** Ajout de @socialgouv/matomo-next dans ui/package.json pour intégrer facilement Matomo avec Next.js.
- **Initialisation de Matomo:** Ajout de l'initialisation de Matomo dans _app.tsx pour démarrer le suivi des pages.

### Bénéfices Attendus

- **Analyse détaillée du comportement des utilisateurs:** Permet de comprendre comment les utilisateurs interagissent avec l'application, ce qui aide à identifier les zones à améliorer pour une meilleure expérience utilisateur.
- **Respect de la vie privée:** Matomo est configuré pour être conforme au RGPD, assurant que la vie privée des utilisateurs est respectée par la désactivation des cookies et le suivi anonyme.
- **Prise de décision basée sur les données:** Les insights collectés via Matomo aideront l'équipe à prendre des décisions éclairées concernant les futures améliorations de l'application.
