### PR TITLE
fix: ajout d'un controle de toggle unique sur un ensemble de table

### DIFF
--- a/ui/components/Table/Table.tsx
+++ b/ui/components/Table/Table.tsx
@@ -43,6 +43,8 @@ export default function Table({
   onSortingChange = null,
   sorting = undefined,
   pageSizes = [5, 10, 20, 30, 40, 50],
+  triggerExpand = undefined,
+  tableId = null,
   ...props
 }: any) {
   const data: any[] = useMemo(() => defaultData, [defaultData]); // TODO TO CHECK RE-RENDERER WITH [defaultData] instead of []
@@ -117,6 +119,16 @@ export default function Table({
     },
     // initialState: {},
   });
+
+  // In order to manage multi table with same toggle state
+  useEffect(() => {
+    triggerExpand &&
+      table.getRowModel().rows.forEach((row) => {
+        row.id === triggerExpand.rowId && tableId === triggerExpand.tableId
+          ? row.toggleExpanded()
+          : row.toggleExpanded(false);
+      });
+  }, [triggerExpand]);
 
   useEffect(() => {
     if (countItems.current !== table.getPrePaginationRowModel().rows.length) {

--- a/ui/modules/effectifs/EffectifsPage.tsx
+++ b/ui/modules/effectifs/EffectifsPage.tsx
@@ -28,10 +28,9 @@ import Link from "@/components/Links/Link";
 import SupportLink from "@/components/Links/SupportLink";
 import SimplePage from "@/components/Page/SimplePage";
 import Ribbons from "@/components/Ribbons/Ribbons";
-import { DoubleChevrons } from "@/theme/components/icons/DoubleChevrons";
 
 import { effectifsStateAtom } from "../mon-espace/effectifs/engine/atoms";
-import EffectifsTable from "../mon-espace/effectifs/engine/EffectifsTable";
+import EffectifsTableContainer from "../mon-espace/effectifs/engine/EffectifTableContainer";
 import { Input } from "../mon-espace/effectifs/engine/formEngine/components/Input/Input";
 import BandeauTransmission from "../organismes/BandeauTransmission";
 
@@ -49,6 +48,8 @@ function EffectifsPage(props: EffectifsPageProps) {
   const [searchValue, setSearchValue] = useState("");
   const [showOnlyErrors, setShowOnlyErrors] = useState(false);
   const [filtreAnneeScolaire, setFiltreAnneeScolaire] = useState("all");
+
+  const [triggerExpand, setTriggerExpand] = useState({} as { tableId: string; rowId: string });
 
   const { data: organismesEffectifs, isLoading } = useQuery(
     ["organismes", props.organisme._id, "effectifs"],
@@ -233,16 +234,18 @@ function EffectifsPage(props: EffectifsPageProps) {
                   {anneeScolaire} {!searchValue ? `- ${orgaEffectifs.length} apprenant(es) total` : ""}
                 </Text>
                 <Box p={4} borderColor="dgalt" borderWidth="1px">
-                  {Object.entries(effectifsByCfd).map(([cfd, effectifs], i) => {
+                  {Object.entries(effectifsByCfd).map(([cfd, effectifs]) => {
                     const { formation } = effectifs[0];
                     return (
                       <EffectifsTableContainer
                         key={`${anneeScolaire}${cfd}`}
+                        tableId={`${anneeScolaire}${cfd}`}
                         canEdit={true}
                         effectifs={effectifs}
                         formation={formation}
                         searchValue={searchValue}
-                        mt={i === 0 ? 0 : 14}
+                        triggerExpand={triggerExpand}
+                        onTriggerExpand={setTriggerExpand}
                       />
                     );
                   })}
@@ -268,30 +271,5 @@ const BadgeButton = ({ onClick, active = false, children, ...props }) => {
         </Circle>
       )}
     </Button>
-  );
-};
-
-const EffectifsTableContainer = ({ effectifs, formation, canEdit, searchValue, ...props }) => {
-  const [count, setCount] = useState(effectifs.length);
-  return (
-    <Box {...props}>
-      {count !== 0 && (
-        <HStack>
-          <DoubleChevrons />
-          <Text fontWeight="bold" textDecoration="underline">
-            {formation.libelle_long}
-          </Text>
-          <Text>
-            [Code diplôme {formation.cfd}] - [Code RNCP {formation.rncp}]
-          </Text>
-        </HStack>
-      )}
-      <EffectifsTable
-        canEdit={canEdit}
-        organismesEffectifs={effectifs}
-        searchValue={searchValue}
-        onCountItemsChange={(count) => setCount(count)}
-      />
-    </Box>
   );
 };

--- a/ui/modules/mon-espace/SIFA/SIFAPage.tsx
+++ b/ui/modules/mon-espace/SIFA/SIFAPage.tsx
@@ -34,10 +34,9 @@ import { organismeAtom } from "@/hooks/organismeAtoms";
 import { usePlausibleTracking } from "@/hooks/plausible";
 import useToaster from "@/hooks/useToaster";
 import { effectifsStateAtom } from "@/modules/mon-espace/effectifs/engine/atoms";
-import EffectifsTable from "@/modules/mon-espace/effectifs/engine/EffectifsTable";
+import EffectifTableContainer from "@/modules/mon-espace/effectifs/engine/EffectifTableContainer";
 import { Input } from "@/modules/mon-espace/effectifs/engine/formEngine/components/Input/Input";
 import { DownloadLine, ExternalLinkLine } from "@/theme/components/icons";
-import { DoubleChevrons } from "@/theme/components/icons/DoubleChevrons";
 
 function useOrganismesEffectifs(organismeId: string) {
   const setCurrentEffectifsState = useSetRecoilState(effectifsStateAtom);
@@ -65,32 +64,6 @@ function useOrganismesEffectifs(organismeId: string) {
   return { isLoading: isFetching || isLoading, organismesEffectifs: data || [] };
 }
 
-const EffectifsTableContainer = ({ effectifs, formation, canEdit, searchValue, ...props }) => {
-  const [count, setCount] = useState(effectifs.length);
-  return (
-    <Box {...props}>
-      {count !== 0 && (
-        <HStack>
-          <DoubleChevrons />
-          <Text fontWeight="bold" textDecoration="underline">
-            {formation.libelle_long}
-          </Text>
-          <Text>
-            [Code diplôme {formation.cfd}] - [Code RNCP {formation.rncp}]
-          </Text>
-        </HStack>
-      )}
-      <EffectifsTable
-        canEdit={canEdit}
-        organismesEffectifs={effectifs}
-        searchValue={searchValue}
-        onCountItemsChange={(count) => setCount(count)}
-        modeSifa
-      />
-    </Box>
-  );
-};
-
 interface SIFAPageProps {
   organisme: Organisme;
   modePublique: boolean;
@@ -103,6 +76,7 @@ const SIFAPage = (props: SIFAPageProps) => {
   const { isLoading, organismesEffectifs } = useOrganismesEffectifs(organisme._id);
 
   const [searchValue, setSearchValue] = useState("");
+  const [triggerExpand, setTriggerExpand] = useState({} as { tableId: string; rowId: string });
 
   const organismesEffectifsGroupedBySco: any = useMemo(
     () => groupBy(organismesEffectifs, "annee_scolaire"),
@@ -328,16 +302,19 @@ const SIFAPage = (props: SIFAPageProps) => {
                 {anneSco} {!searchValue ? `- ${orgaEffectifs.length} apprenant(es) total` : ""}
               </Text>
               <Box p={4} style={{ borderColor: "dgalt", borderWidth: 1 }}>
-                {Object.entries(effectifsByCfd).map(([cfd, effectifs]: [string, any[]], i) => {
+                {Object.entries(effectifsByCfd).map(([cfd, effectifs]: [string, any[]]) => {
                   const { formation } = effectifs[0];
                   return (
-                    <EffectifsTableContainer
+                    <EffectifTableContainer
                       key={anneSco + cfd}
+                      tableId={anneSco + cfd}
                       canEdit={true}
                       effectifs={effectifs}
                       formation={formation}
                       searchValue={searchValue}
-                      {...(i === 0 ? {} : { mt: 14 })}
+                      modeSifa={true}
+                      triggerExpand={triggerExpand}
+                      onTriggerExpand={setTriggerExpand}
                     />
                   );
                 })}

--- a/ui/modules/mon-espace/effectifs/engine/EffectifTableContainer.tsx
+++ b/ui/modules/mon-espace/effectifs/engine/EffectifTableContainer.tsx
@@ -1,0 +1,57 @@
+import { Box, HStack, Text } from "@chakra-ui/react";
+import { Dispatch, SetStateAction, useState } from "react";
+
+import { DoubleChevrons } from "@/theme/components/icons/DoubleChevrons";
+
+import EffectifsTable from "./EffectifsTable";
+
+interface EffectifsTableContainerProps {
+  effectifs: any[];
+  modeSifa?: boolean;
+  canEdit?: boolean;
+  searchValue?: string;
+  triggerExpand: object;
+  onTriggerExpand: Dispatch<SetStateAction<{ tableId: string; rowId: string }>>;
+  tableId: string;
+  formation: any;
+}
+const EffectifsTableContainer = ({
+  effectifs,
+  formation,
+  canEdit,
+  searchValue,
+  triggerExpand,
+  onTriggerExpand,
+  tableId,
+  modeSifa,
+  ...props
+}: EffectifsTableContainerProps) => {
+  const [count, setCount] = useState(effectifs.length);
+  return (
+    <Box {...props}>
+      {count !== 0 && (
+        <HStack>
+          <DoubleChevrons />
+          <Text fontWeight="bold" textDecoration="underline">
+            {formation.libelle_long}
+          </Text>
+          <Text>
+            [Code diplôme {formation.cfd}] - [Code RNCP {formation.rncp}]
+          </Text>
+        </HStack>
+      )}
+      <EffectifsTable
+        tableId={tableId}
+        canEdit={canEdit}
+        organismesEffectifs={effectifs}
+        searchValue={searchValue}
+        onCountItemsChange={(count) => setCount(count)}
+        triggerExpand={triggerExpand}
+        onTriggerExpand={onTriggerExpand}
+        modeSifa={modeSifa}
+      />
+    </Box>
+  );
+};
+
+export default EffectifsTableContainer;

--- a/ui/modules/mon-espace/effectifs/engine/EffectifsTable.tsx
+++ b/ui/modules/mon-espace/effectifs/engine/EffectifsTable.tsx
@@ -59,6 +59,9 @@ interface EffectifsTableProps {
   searchValue?: string;
   RenderErrorImport?: (data: any) => any;
   onCountItemsChange?: (count: number) => any;
+  triggerExpand: any;
+  onTriggerExpand: any;
+  tableId: string;
 }
 
 const EffectifsTable = ({
@@ -70,6 +73,9 @@ const EffectifsTable = ({
   searchValue,
   RenderErrorImport = () => {},
   onCountItemsChange = () => {},
+  triggerExpand,
+  onTriggerExpand,
+  tableId,
 }: EffectifsTableProps) => {
   const [count, setCount] = useState(organismesEffectifs.length);
 
@@ -78,24 +84,25 @@ const EffectifsTable = ({
       {count > 0 && <Text>{count} apprenant(es)</Text>}
       <Table
         mt={4}
+        tableId={tableId}
         data={organismesEffectifs}
         searchValue={searchValue}
         onCountItemsChange={(count) => {
           setCount(count);
           onCountItemsChange(count);
         }}
+        triggerExpand={triggerExpand}
         columns={{
           ...(columns.includes("expander")
             ? {
                 expander: {
                   size: 25,
                   header: () => " ",
-                  cell: ({ row, table }) => {
+                  cell: ({ row }) => {
                     return row.getCanExpand() ? (
                       <Button
                         onClick={() => {
-                          if (table.getIsSomeRowsExpanded() && !row.getIsExpanded()) table.resetExpanded();
-                          row.toggleExpanded();
+                          onTriggerExpand({ tableId: tableId, rowId: row.id });
                         }}
                         cursor="pointer"
                       >


### PR DESCRIPTION
fix [TM-777](https://tableaudebord-apprentissage.atlassian.net/browse/TM-777)

**Description**

- L'implémentation actuelle utilise un store recoil unique pour le formulaire de l'effectif ( mauvaise pratique )
- En guise de première correction, j'ai choisi de restreindre l'ouverture d'un subComponent d'un tableau à un seul element, et ce sur un ensemble de Table
- Les modifications de Table sont temporaire, dans la mesure ou ce composant va disparaitre suite à la création d'un nouveau Tableau
- Il est nécessaire de refacto l'implémentation de store unique pour le formulaire , tâche : https://tableaudebord-apprentissage.atlassian.net/browse/TM-807