### PR TITLE
fix: récupération des relations organismes sur des formations du catalogue des années précédentes

### DIFF
--- a/server/src/common/actions/organismes/organismes.formations.actions.ts
+++ b/server/src/common/actions/organismes/organismes.formations.actions.ts
@@ -19,7 +19,6 @@ export const getFormationsTreeForOrganisme = async (uai: string | undefined) => 
 
   // Récupération des formations liés à l'organisme
   const catalogFormationsForOrganismeCursor = formationsCatalogueDb().find({
-    published: true,
     catalogue_published: true,
     $or: [{ etablissement_formateur_uai: uai }, { etablissement_gestionnaire_uai: uai }],
   });

--- a/server/src/jobs/hydrate/hydrate-formations-catalogue.ts
+++ b/server/src/jobs/hydrate/hydrate-formations-catalogue.ts
@@ -30,7 +30,6 @@ export const hydrateFormationsCatalogue = async () => {
     params: {
       limit: 150_000, // 150k pour tout avoir (91k total, 62k formations publiées)
       query: {
-        published: true,
         catalogue_published: true,
       },
     },


### PR DESCRIPTION
Le flag `published` définie une formation affichée sur la catalogue. Hors le catalogue n'affiche que les formations en cours, mais le tableau de bord a besoin de récupérer l'historique.