### PR TITLE
feat: ajout de pr-title-checker dans le workflow github

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,15 @@
+{
+  "LABEL": {
+    "name": ":warning: Pull request title needs formatting",
+    "color": "D93F0B"
+  },
+  "CHECKS": {
+    "prefixes": ["fix: ", "feat: ", "refactor: ", "chore: "],
+    "regexp": "docs\\(v[0-9]\\): "
+  },
+  "MESSAGES": {
+    "success": "PR title OK",
+    "failure": "Failing CI test",
+    "notice": ""
+  }
+}

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,20 @@
+name: "PR Title Checker"
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  pr-title-check:
+    runs-on: ubuntu-latest
+    name: Control pull request title
+    steps:
+      - uses: thehanimo/pr-title-checker@v1.4.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pass_on_octokit_error: false
+          configuration_path: .github/pr-title-checker-config.json #(optional. defaults to .github/pr-title-checker-config.json)


### PR DESCRIPTION
Cette action vérifie si les titres PR sont conformes aux directives de contribution ☑️