### PR TITLE
fix: ajout de données optionnelles sur l'api v2 de dossier apprenant

### DIFF
--- a/server/src/common/validation/dossierApprenantSchemaV1V2.ts
+++ b/server/src/common/validation/dossierApprenantSchemaV1V2.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { primitivesV1 } from "@/common/validation/utils/zodPrimitives";
+import { primitivesV1, primitivesV3 } from "@/common/validation/utils/zodPrimitives";
 
 /**
  * Note: ce schema est seulement utilisé pour générer la documentation OpenAPI pour l'API v1.
@@ -37,6 +37,12 @@ const dossierApprenantSchemaV1V2 = () =>
     contrat_date_debut: primitivesV1.contrat.date_debut.optional(),
     contrat_date_fin: primitivesV1.contrat.date_fin.optional(),
     contrat_date_rupture: primitivesV1.contrat.date_rupture.optional(),
+
+    // OPTIONAL V2 BUT REQUIRED V3
+
+    date_inscription_formation: primitivesV3.formation.date_inscription.optional(),
+    date_entree_formation: primitivesV3.formation.date_entree.optional(),
+    date_fin_formation: primitivesV3.formation.date_fin.optional(),
   });
 
 export type DossierApprenantSchemaV1V2ZodType = z.input<ReturnType<typeof dossierApprenantSchemaV1V2>>;

--- a/server/src/http/routes/specific.routes/dossiers-apprenants.routes.ts
+++ b/server/src/http/routes/specific.routes/dossiers-apprenants.routes.ts
@@ -25,7 +25,9 @@ export default () => {
       await Joi.array().max(POST_DOSSIERS_APPRENANTS_MAX_INPUT_LENGTH).validateAsync(body, { abortEarly: false })
     ).map((e) => stripNullProperties(e));
     const isV3 = originalUrl.includes("/v3");
-    const validationSchema = isV3 ? dossierApprenantSchemaV3Input() : dossierApprenantSchemaV1V2();
+    const v2Schema = dossierApprenantSchemaV1V2();
+    const v3Schema = dossierApprenantSchemaV3Input();
+    const validationSchema = isV3 ? v3Schema : v2Schema;
 
     const source = user.username || user.source;
     const effectifsToQueue = bodyItems.map((dossierApprenant) => {


### PR DESCRIPTION
**Description**

- Ajout de champs optionnels dans l'API v2 dossiers-apprenant ( lié à la formation )
- L'ajout de champ permet d'intégrer certaines données envoyés par les erp en v2 ( alors qu'il s'agit de données v3 )