### PR TITLE
fix: changement du type zod ObjectId pour le front

### DIFF
--- a/shared/models/data/auditLogs.model.ts
+++ b/shared/models/data/auditLogs.model.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 import { IModelDescriptor } from "./common";
 
@@ -16,5 +15,5 @@ export type IAuditLog = z.output<typeof auditLogSchema>;
 export default {
   collectionName: "auditLogs",
   indexes: [],
-  zod: auditLogSchema.extend({ _id: zObjectId }).strict(),
+  zod: auditLogSchema.extend({ _id: z.any() }).strict(),
 } as IModelDescriptor;

--- a/shared/models/data/contratsDeca.model.ts
+++ b/shared/models/data/contratsDeca.model.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 import { zContratsDecaApprenantSchema } from "./contratsDeca/contratsDeca.apprenant.part";
 import { zContratsDecaDetailsContratSchema } from "./contratsDeca/contratsDeca.detailsContrat.part";
@@ -13,7 +12,7 @@ const collectionName = "contratsDeca";
 
 const zContratsDeca = z
   .object({
-    _id: zObjectId,
+    _id: z.any(),
     alternant: zContratsDecaApprenantSchema,
     formation: zContratsDecaFormationSchema,
     etablissementFormation: zContratsDecaEtablissementFormationSchema,

--- a/shared/models/data/effectifs.model.ts
+++ b/shared/models/data/effectifs.model.ts
@@ -1,6 +1,5 @@
 import type { CreateIndexesOptions, IndexSpecification } from "mongodb";
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 import {
   SIRET_REGEX,
@@ -104,10 +103,10 @@ const zEffectifComputedStatut = z.object({
 });
 
 export const zEffectif = z.object({
-  _id: zObjectId.describe("Identifiant MongoDB de l'effectif"),
-  organisme_id: zObjectId.describe("Organisme id (lieu de formation de l'apprenant pour la v3)"),
-  organisme_responsable_id: zObjectId.describe("Organisme responsable id").nullish(),
-  organisme_formateur_id: zObjectId.describe("Organisme formateur id").nullish(),
+  _id: z.any().describe("Identifiant MongoDB de l'effectif"),
+  organisme_id: z.any().describe("Organisme id (lieu de formation de l'apprenant pour la v3)"),
+  organisme_responsable_id: z.any().describe("Organisme responsable id").nullish(),
+  organisme_formateur_id: z.any().describe("Organisme formateur id").nullish(),
 
   id_erp_apprenant: z.string({ description: "Identifiant de l'apprenant dans l'erp" }),
   source: z.string({ description: "Source du dossier apprenant (Ymag, Gesti, TDB_MANUEL, TDB_FILE...)" }),

--- a/shared/models/data/effectifs/formation.part.ts
+++ b/shared/models/data/effectifs/formation.part.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 import { RNCP_REGEX } from "../../../constants";
 import formationsModel from "../formations.model";
@@ -8,7 +7,7 @@ const formationsProps = formationsModel.zod.shape;
 
 export const zFormationEffectif = z.object({
   // TODO formation_id devrait être un objectId pointant vers la collection formations (à remplir au moment de l'import)
-  formation_id: zObjectId.describe("ID de la formation").nullish(),
+  formation_id: z.any().describe("ID de la formation").nullish(),
   // DEBUT champs collectés qui servent à retrouver le champ formation_id
   // une fois le champs formation_id rempli, ces champs ne sont plus utile
   cfd: formationsProps.cfd.nullish(),

--- a/shared/models/data/effectifsQueue.model.ts
+++ b/shared/models/data/effectifsQueue.model.ts
@@ -1,9 +1,9 @@
 import type { CreateIndexesOptions, IndexSpecification } from "mongodb";
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
-import { CODES_STATUT_APPRENANT_ENUM, zAdresse } from "shared";
+import { CODES_STATUT_APPRENANT_ENUM } from "shared/constants";
 import effectifsModel from "shared/models/data/effectifs.model";
+import { zAdresse } from "shared/models/parts/adresseSchema";
 
 import { zContrat } from "./effectifs/contrat.part";
 import { zFormationEffectif } from "./effectifs/formation.part";
@@ -34,8 +34,8 @@ const apprenantProps = effectifsProps.apprenant.shape;
 export const internalFields = {
   source: z.string({ description: effectifsProps.source.description }),
   source_organisme_id: z.string({ description: effectifsProps.source_organisme_id.description }).nullish(),
-  effectif_id: zObjectId.describe("Id de l'effectif associé").nullish(),
-  organisme_id: zObjectId.describe("Id de l'organisme associé").nullish(),
+  effectif_id: z.any().describe("Id de l'effectif associé").nullish(),
+  organisme_id: z.any().describe("Id de l'organisme associé").nullish(),
   updated_at: z.date({ description: "Date de mise à jour en base de données" }).nullish(),
   created_at: z.date({ description: "Date d'ajout en base de données" }),
   processed_at: z.date({ description: "Date de process des données" }).nullish(),
@@ -63,7 +63,7 @@ export const internalFields = {
  * Une 2eme validation plus poussée (SIRET, formation, ...) est effectuée au moment de la creation de l'effectif et l'erreur est stockée dans le champ `error`.
  */
 export const zEffectifQueue = z.object({
-  _id: zObjectId,
+  _id: z.any(),
   // required fields to create an effectif
   nom_apprenant: z.any({ description: apprenantProps.nom.description }),
   prenom_apprenant: z.any({ description: apprenantProps.prenom.description }),

--- a/shared/models/data/fiabilisationUaiSiret.model.ts
+++ b/shared/models/data/fiabilisationUaiSiret.model.ts
@@ -1,14 +1,13 @@
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
-import { STATUT_FIABILISATION_COUPLES_UAI_SIRET } from "shared";
+import { STATUT_FIABILISATION_COUPLES_UAI_SIRET } from "shared/constants";
 
 import { zodEnumFromObjValues } from "../../utils/zodHelper";
 
 const collectionName = "fiabilisationUaiSiret";
 
 export const zFiabilisationUaiSiret = z.object({
-  _id: zObjectId,
+  _id: z.any(),
   created_at: z.date().nullish(),
   type: zodEnumFromObjValues(STATUT_FIABILISATION_COUPLES_UAI_SIRET)
     .describe("Statut de fiabilisation du couple UAI SIRET")

--- a/shared/models/data/formations.model.ts
+++ b/shared/models/data/formations.model.ts
@@ -1,6 +1,5 @@
 import type { CreateIndexesOptions, IndexSpecification } from "mongodb";
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 import { CFD_REGEX } from "../../constants";
 
@@ -14,7 +13,7 @@ const indexes: [IndexSpecification, CreateIndexesOptions][] = [
 ];
 
 const zFormation = z.object({
-  _id: zObjectId,
+  _id: z.any(),
   cfd: z.string({ description: "Code CFD de la formation" }).regex(CFD_REGEX),
   cfd_start_date: z.date({ description: "Date d'ouverture du CFD" }).nullish(),
   cfd_end_date: z.date({ description: "Date de fermeture du CFD" }).nullish(),

--- a/shared/models/data/formationsCatalogue.model.ts
+++ b/shared/models/data/formationsCatalogue.model.ts
@@ -1,6 +1,5 @@
 import type { CreateIndexesOptions, IndexSpecification } from "mongodb";
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 const collectionName = "formationsCatalogue";
 
@@ -19,7 +18,7 @@ const indexes: [IndexSpecification, CreateIndexesOptions][] = [
 ];
 
 const zFormationCatalogue = z.object({
-  _id: zObjectId,
+  _id: z.any(),
   cle_ministere_educatif: z.string(),
   cfd: z.string(),
   cfd_specialite: z.string().nullish(),

--- a/shared/models/data/invitations.model.ts
+++ b/shared/models/data/invitations.model.ts
@@ -1,6 +1,5 @@
 import type { CreateIndexesOptions, IndexSpecification } from "mongodb";
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 const collectionName = "invitations";
 
@@ -10,11 +9,11 @@ const indexes: [IndexSpecification, CreateIndexesOptions][] = [
 ];
 
 const zInvitation = z.object({
-  _id: zObjectId,
+  _id: z.any(),
   token: z.string({ description: "Jeton d'invitation" }),
   email: z.string({ description: "Email destinataire" }),
-  organisation_id: zObjectId.describe("Organisation cible de l'invitation"),
-  author_id: zObjectId.describe("Auteur de l'invitation"),
+  organisation_id: z.any().describe("Organisation cible de l'invitation"),
+  author_id: z.any().describe("Auteur de l'invitation"),
   created_at: z.date({ description: "Date de création en base de données" }),
 });
 

--- a/shared/models/data/jobEvents.model.ts
+++ b/shared/models/data/jobEvents.model.ts
@@ -1,10 +1,9 @@
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 const collectionName = "jobEvents";
 
 export const zJobEvent = z.object({
-  _id: zObjectId,
+  _id: z.any(),
   jobname: z.string({ description: "Le nom du job" }),
   date: z.date({ description: "La date de l'evenement" }),
   action: z.string({ description: "L'action en cours" }),

--- a/shared/models/data/jwtSessions.model.ts
+++ b/shared/models/data/jwtSessions.model.ts
@@ -1,13 +1,12 @@
 import type { CreateIndexesOptions, IndexSpecification } from "mongodb";
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 const collectionName = "jwtSessions";
 
 const indexes: [IndexSpecification, CreateIndexesOptions][] = [[{ jwt: 1 }, { unique: true }]];
 
 const zJwtSession = z.object({
-  _id: zObjectId,
+  _id: z.any(),
   jwt: z.string({ description: "Session token" }),
 });
 

--- a/shared/models/data/maintenanceMessages.model.ts
+++ b/shared/models/data/maintenanceMessages.model.ts
@@ -1,10 +1,9 @@
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 const collectionName = "maintenanceMessages";
 
 export const zMaintenanceMessage = z.object({
-  _id: zObjectId,
+  _id: z.any(),
   msg: z.string({ description: "Message de maintenance" }),
   name: z.string({ description: "email du créateur du message" }),
   type: z.enum(["alert", "info"]),

--- a/shared/models/data/organisations.model.ts
+++ b/shared/models/data/organisations.model.ts
@@ -1,7 +1,6 @@
 import type { CreateIndexesOptions, IndexSpecification } from "mongodb";
 import type { Jsonify } from "type-fest";
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 import {
   ACADEMIES_BY_CODE,
@@ -14,7 +13,7 @@ import {
   IAcademieCode,
   SIRET_REGEX,
   UAI_REGEX,
-} from "shared";
+} from "shared/constants";
 
 import { zodEnumFromArray, zodEnumFromObjKeys } from "../../utils/zodHelper";
 
@@ -23,7 +22,7 @@ const collectionName = "organisations";
 const indexes: [IndexSpecification, CreateIndexesOptions][] = [];
 
 const zOrganisationBase = z.object({
-  _id: zObjectId,
+  _id: z.any(),
   created_at: z.date({ description: "Date de création en base de données" }),
 });
 

--- a/shared/models/data/organismes.model.ts
+++ b/shared/models/data/organismes.model.ts
@@ -1,7 +1,6 @@
 import type { CreateIndexesOptions, IndexSpecification } from "mongodb";
 import type { Jsonify } from "type-fest";
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 import {
   STATUT_CREATION_ORGANISME,
@@ -11,7 +10,7 @@ import {
   TETE_DE_RESEAUX_BY_ID,
   NATURE_ORGANISME_DE_FORMATION,
   STATUT_PRESENCE_REFERENTIEL,
-} from "shared";
+} from "shared/constants";
 import effectifsModel from "shared/models/data/effectifs.model";
 import { zAdresse } from "shared/models/parts/adresseSchema";
 
@@ -27,7 +26,7 @@ const relationOrganismeSchema = z
     sources: z.array(z.string()).optional(),
 
     // infos TDB
-    _id: zObjectId.nullable().optional(),
+    _id: z.any().nullable().optional(),
     enseigne: z.string().optional(),
     raison_sociale: z.string().optional(),
     commune: z.string().optional(),
@@ -72,7 +71,7 @@ const indexes: [IndexSpecification, CreateIndexesOptions][] = [
 // Si contributeurs = [] et !first_transmission_date Alors Organisme en stock "Non actif"
 const zOrganisme = z
   .object({
-    _id: zObjectId,
+    _id: z.any(),
     uai: z
       .string({
         description: "Code UAI de l'établissement",
@@ -121,7 +120,7 @@ const zOrganisme = z
       .array(
         z
           .object({
-            formation_id: zObjectId.optional(),
+            formation_id: z.any().optional(),
             cle_ministere_educatif: z
               .string({
                 description: "Clé unique de la formation",
@@ -137,7 +136,7 @@ const zOrganisme = z
               .array(
                 z
                   .object({
-                    organisme_id: zObjectId.optional(),
+                    organisme_id: z.any().optional(),
                     nature: zodEnumFromObjValues(NATURE_ORGANISME_DE_FORMATION).optional(),
                     uai: z
                       .string({

--- a/shared/models/data/organismesReferentiel.model.ts
+++ b/shared/models/data/organismesReferentiel.model.ts
@@ -1,6 +1,5 @@
 import type { CreateIndexesOptions, IndexSpecification } from "mongodb";
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 const collectionName = "organismesReferentiel";
 
@@ -25,7 +24,7 @@ const indexes: [IndexSpecification, CreateIndexesOptions][] = [
 ];
 
 const zOrganismeReferentiel = z.object({
-  _id: zObjectId,
+  _id: z.any(),
   siret: z.string(),
   uai: z.string().optional(),
   raison_sociale: z.string().optional(),

--- a/shared/models/data/organismesSoltea.model.ts
+++ b/shared/models/data/organismesSoltea.model.ts
@@ -1,6 +1,5 @@
 import type { CreateIndexesOptions, IndexSpecification } from "mongodb";
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 const collectionName = "organismesSoltea";
 
@@ -10,7 +9,7 @@ const indexes: [IndexSpecification, CreateIndexesOptions][] = [
 ];
 
 const zOrganismeSoltea = z.object({
-  _id: zObjectId,
+  _id: z.any(),
   uai: z.string().nullish().describe("Code UAI de l'établissement"),
   siret: z.string().nullish().describe("N° SIRET de l'établissement"),
   raison_sociale: z.string().nullish(),

--- a/shared/models/data/rncp.model.ts
+++ b/shared/models/data/rncp.model.ts
@@ -1,6 +1,5 @@
 import type { CreateIndexesOptions, IndexSpecification } from "mongodb";
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 const collectionName = "rncp";
 
@@ -10,7 +9,7 @@ const indexes: [IndexSpecification, CreateIndexesOptions][] = [
 ];
 
 const zRncp = z.object({
-  _id: zObjectId,
+  _id: z.any(),
   rncp: z.string(),
   nouveaux_rncp: z.array(z.string()).optional(),
   intitule: z.string(),

--- a/shared/models/data/rome.model.ts
+++ b/shared/models/data/rome.model.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 import { IModelDescriptor } from "./common";
 
@@ -17,5 +16,5 @@ export type IRome = z.output<typeof romeSchema>;
 export default {
   collectionName: "rome",
   indexes: [[{ code: 1 }, { unique: true }]],
-  zod: romeSchema.merge(z.object({ _id: zObjectId })).strict(),
+  zod: romeSchema.merge(z.object({ _id: z.any() })).strict(),
 } as IModelDescriptor;

--- a/shared/models/data/users.model.ts
+++ b/shared/models/data/users.model.ts
@@ -1,6 +1,5 @@
 import type { CreateIndexesOptions, IndexSpecification } from "mongodb";
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 const collectionName = "users";
 
@@ -11,7 +10,7 @@ const indexes: [IndexSpecification, CreateIndexesOptions][] = [
 ];
 
 const zUser = z.object({
-  _id: zObjectId,
+  _id: z.any(),
   username: z.string().describe("Le nom de l'utilisateur, utilisé pour l'authentification"),
   email: z.string().nullish().describe("Email de l'utilisateur"),
   password: z.string().optional().describe("Le mot de passe hashed"),

--- a/shared/models/data/usersMigration.model.ts
+++ b/shared/models/data/usersMigration.model.ts
@@ -1,6 +1,5 @@
 import type { CreateIndexesOptions, IndexSpecification } from "mongodb";
 import { z } from "zod";
-import { zObjectId } from "zod-mongodb-schema";
 
 export const collectionName = "usersMigration";
 
@@ -12,7 +11,7 @@ const indexes: [IndexSpecification, CreateIndexesOptions][] = [
 ];
 
 export const zUsersMigration = z.object({
-  _id: zObjectId,
+  _id: z.any(),
   email: z.string().describe("Email utilisateur"),
   password: z.string().describe("Le mot de passe hashé"),
   civility: z.enum(["Madame", "Monsieur"]).describe("civilité"),
@@ -20,7 +19,7 @@ export const zUsersMigration = z.object({
   prenom: z.string().describe("Le prénom de l'utilisateur"),
   telephone: z.string().optional().describe("Le téléphone de l'utilisateur"),
   fonction: z.string().optional().describe("La fonction de l'utilisateur"),
-  organisation_id: zObjectId.describe("Organisation à laquelle appartient l'utilisateur"),
+  organisation_id: z.any().describe("Organisation à laquelle appartient l'utilisateur"),
 
   // Internal
   account_status: z


### PR DESCRIPTION
**Description**

- Le type zObjectId a des dépendances mongo, donc impossible de l'utiliser coté front
- Remplacement des zObjectId par `z.any()` ( temporaire )
- Correction de dépendance circulaire ( ex : un fichier modèle qui importe `shared`, donc ré-import modèle )