### PR TITLE
fix: Ajout d'erp dans la liste 

### DIFF
--- a/shared/constants/erps.ts
+++ b/shared/constants/erps.ts
@@ -67,6 +67,16 @@ export const ERPS = sortAlphabeticallyBy("name", [
     name: "Formasup HDF",
     apiV3: true,
   },
+  {
+    id: "ammon",
+    name: "Ammon",
+    apiV3: true,
+  },
+  {
+    id: "formasup-paca",
+    name: "Formasup PACA",
+    apiV3: true,
+  },
 ] satisfies ERP[]);
 
 export const ERPS_BY_ID = ERPS.reduce(


### PR DESCRIPTION
fix [TM-898](https://tableaudebord-apprentissage.atlassian.net/browse/TM-898)

**Description**

- Ajout de Ammon et Formasup PACA

[TM-898]: https://tableaudebord-apprentissage.atlassian.net/browse/TM-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ