### PR TITLE
feat: ajout du nombre de doublons supprimé au tracking

### DIFF
--- a/ui/modules/mon-espace/effectifs/doublons/EffectifDoublonDeleteAllAlertDialog.tsx
+++ b/ui/modules/mon-espace/effectifs/doublons/EffectifDoublonDeleteAllAlertDialog.tsx
@@ -60,7 +60,9 @@ const EffectifDoublonDeleteAllAlertDialog = ({
             <Button
               colorScheme="red"
               onClick={async () => {
-                trackPlausibleEvent("suppression_doublons_effectifs_en_lot");
+                trackPlausibleEvent("suppression_doublons_effectifs_en_lot", undefined, {
+                  nb_doublons_supprimes_lot: dusplicateCount,
+                });
                 await _delete(`/api/v1/organismes/${organismeId}/duplicates`);
                 queryClient.invalidateQueries(["duplicates-effectifs"]);
                 onClose();


### PR DESCRIPTION
### Description
Cette modification du code vise à améliorer le suivi des suppressions de doublons dans l'application. Auparavant, bien que l'application enregistrait les événements de suppression de doublons, elle ne permettait pas de connaître le nombre exact de doublons supprimés lors de chaque opération en lot. Pour pallier ce manque, il est proposé d'ajouter une propriété nommée **nb_doublons_supprimes_lot** à l'événement envoyé à Plausible. Cette propriété contiendra le nombre de doublons supprimés lors de l'opération en question, permettant ainsi une meilleure analyse et compréhension de l'efficacité des actions de nettoyage de données.
