### PR TITLE
fix: conformité RGPD, suppression du tracking par email

### DIFF
--- a/ui/hooks/plausible.ts
+++ b/ui/hooks/plausible.ts
@@ -14,7 +14,6 @@ export function usePlausibleTracking() {
       props?: Record<string, string | number | boolean>
     ) {
       const eventProps: Record<string, string | number | boolean | undefined> = {
-        userEmail: auth?.email,
         organisationType: auth?.organisation?.type,
         organisationNom: auth?.organisation ? getOrganisationLabel(auth.organisation) : undefined,
         ...(currentPath ? { currentPath: currentPath } : {}),

--- a/ui/hooks/plausible.ts
+++ b/ui/hooks/plausible.ts
@@ -14,6 +14,7 @@ export function usePlausibleTracking() {
       props?: Record<string, string | number | boolean>
     ) {
       const eventProps: Record<string, string | number | boolean | undefined> = {
+        userEmail: auth?.email,
         organisationType: auth?.organisation?.type,
         organisationNom: auth?.organisation ? getOrganisationLabel(auth.organisation) : undefined,
         ...(currentPath ? { currentPath: currentPath } : {}),


### PR DESCRIPTION
### Description:

Pour aligner notre système de suivi avec le RGPD, nous retirons l'adresse e-mail comme identifiant dans Plausible. Cette mise à jour renforce la protection des données personnelles, en privilégiant des identifiants anonymes et non personnels. Elle maintient notre engagement à offrir une expérience utilisateur sécurisée et respectueuse de la vie privée.