### PR TITLE
feat: ajout de l'ID de l'utilisateur au tracking plausible

### DIFF
--- a/ui/hooks/plausible.ts
+++ b/ui/hooks/plausible.ts
@@ -14,6 +14,7 @@ export function usePlausibleTracking() {
       props?: Record<string, string | number | boolean>
     ) {
       const eventProps: Record<string, string | number | boolean | undefined> = {
+        userId: auth?._id,
         organisationType: auth?.organisation?.type,
         organisationNom: auth?.organisation ? getOrganisationLabel(auth.organisation) : undefined,
         ...(currentPath ? { currentPath: currentPath } : {}),

--- a/ui/hooks/plausible.ts
+++ b/ui/hooks/plausible.ts
@@ -14,7 +14,6 @@ export function usePlausibleTracking() {
       props?: Record<string, string | number | boolean>
     ) {
       const eventProps: Record<string, string | number | boolean | undefined> = {
-        userEmail: auth?.email,
         organisationType: auth?.organisation?.type,
         organisationNom: auth?.organisation ? getOrganisationLabel(auth.organisation) : undefined,
         ...(currentPath ? { currentPath: currentPath } : {}),

--- a/ui/hooks/plausible.ts
+++ b/ui/hooks/plausible.ts
@@ -14,6 +14,7 @@ export function usePlausibleTracking() {
       props?: Record<string, string | number | boolean>
     ) {
       const eventProps: Record<string, string | number | boolean | undefined> = {
+        userEmail: auth?.email,
         organisationType: auth?.organisation?.type,
         organisationNom: auth?.organisation ? getOrganisationLabel(auth.organisation) : undefined,
         ...(currentPath ? { currentPath: currentPath } : {}),


### PR DESCRIPTION
### Description :

L'objectif de cette Pull Request est d'enrichir le système de tracking avec Plausible en y intégrant l'ID de l'utilisateur comme un nouvel identifiant. Cela améliorera notre capacité à suivre l'engagement des utilisateurs de manière plus précise à travers les différentes pages de 'application.
