### PR TITLE
feat: mise a jour des donnees de transfert decaRaw vers effectifsDeca

### DIFF
--- a/server/src/common/mongodb/__snapshots__/validationSchema.test.ts.snap
+++ b/server/src/common/mongodb/__snapshots__/validationSchema.test.ts.snap
@@ -349,6 +349,9 @@ exports[`validation-schema should create validation schema for decaRaw: decaRaw 
             "code_postal",
           ],
         },
+        "courriel": {
+          "bsonType": "string",
+        },
         "date_naissance": {
           "anyOf": [
             {
@@ -382,6 +385,9 @@ exports[`validation-schema should create validation schema for decaRaw: decaRaw 
         "sexe": {
           "bsonType": "number",
         },
+        "telephone": {
+          "bsonType": "string",
+        },
       },
       "required": [
         "handicap",
@@ -392,6 +398,8 @@ exports[`validation-schema should create validation schema for decaRaw: decaRaw 
         "derniere_classe",
         "nationalite",
         "sexe",
+        "telephone",
+        "courriel",
       ],
     },
     "created_at": {

--- a/shared/models/data/decaRaw.model.ts
+++ b/shared/models/data/decaRaw.model.ts
@@ -27,6 +27,8 @@ const zAlternant = z.object({
   derniere_classe: z.number(),
   nationalite: z.number(),
   sexe: z.number(),
+  telephone: z.string(),
+  courriel: z.string(),
 });
 
 const zEmployeur = z.object({

--- a/shared/models/data/effectifsDECA.model.ts
+++ b/shared/models/data/effectifsDECA.model.ts
@@ -104,6 +104,7 @@ const zEffectifComputedStatut = z.object({
 
 export const zEffectifDECA = z.object({
   _id: zObjectId.describe("Identifiant MongoDB de l'effectifDeca"),
+  deca_raw_id: zObjectId.describe("Identifiant decaraw associé à cet effectif"),
   organisme_id: zObjectId.describe("Organisme id (lieu de formation de l'apprenant pour la v3)"),
   organisme_responsable_id: zObjectId.describe("Organisme responsable id").nullish(),
   organisme_formateur_id: zObjectId.describe("Organisme formateur id").nullish(),


### PR DESCRIPTION
cf: [tm-1039](https://github.com/mission-apprentissage/flux-retour-cfas/pull/3662)

### Description
Cette PR met à jour les données envoyées de decaRaw vers effectifsDeca en prenant en compte de nouveaux champs. Voici un résumé des principales modifications :

- Ajout de champs supplémentaires comme handicap, telephone, courriel dans la partie apprenant.
- Conversion du champ nationalite en un type compatible avec le schéma Zod existant.
- Conversion du champ adresse.numero en nombre là où cela est nécessaire.
- Utilisation du type type_employeur du schéma Zod existant pour valider et convertir le champ correspondant.
- Mise à jour des schémas de validation pour refléter les modifications apportées aux données.
