### PR TITLE
fix: ajout d'un lien vers le support desk

### DIFF
--- a/shared/constants/support.ts
+++ b/shared/constants/support.ts
@@ -32,3 +32,4 @@ export const SIFA_AUTRE_ELEMENT_LINK = `${SIFA_GROUP}/create/59`;
 
 export const AUTRE_AMELIORATION_ELEMENT_LINK = `${AUTRE_GROUP}/create/55`;
 export const AUTRE_ANOMALIE_ELEMENT_LINK = `${AUTRE_GROUP}/create/49`;
+export const AUTRE_MODIF_RESEAU_ELEMENT_LINK = `${AUTRE_GROUP}/create/79`;

--- a/ui/modules/organismes/ListeOrganismesPage.tsx
+++ b/ui/modules/organismes/ListeOrganismesPage.tsx
@@ -12,7 +12,7 @@ import {
   UnorderedList,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
-import { IOrganisationType } from "shared";
+import { AUTRE_MODIF_RESEAU_ELEMENT_LINK, IOrganisationType } from "shared";
 
 import { _get } from "@/common/httpClient";
 import { Organisme } from "@/common/internal/Organisme";
@@ -103,9 +103,11 @@ function ListeOrganismesPage(props: ListeOrganismesPageProps) {
 
         {["ORGANISME_FORMATION", "TETE_DE_RESEAU"].includes(organisationType) && (
           <Text mt={4}>
-            Si des relations entre organismes ne devraient pas avoir lieu ou sont manquantes, vous devez vous rapprocher
-            de votre Carif-Oref régional afin de modifier les informations collectées (par ex&nbsp;: suppression du
-            formateur rattaché au responsable).
+            Si des organismes de la liste ci-dessous sont manquants ou ne devraient pas apparaître, veuillez{" "}
+            <Link variant="link" color="inherit" href={AUTRE_MODIF_RESEAU_ELEMENT_LINK} isExternal>
+              nous contacter
+            </Link>
+            .
           </Text>
         )}
 


### PR DESCRIPTION
fix: [TM-1102](https://tableaudebord-apprentissage.atlassian.net/browse/TM-1102)

Description:

- Mise à jour du lien de support pour une tête de reseau

[TM-1102]: https://tableaudebord-apprentissage.atlassian.net/browse/TM-1102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ