### PR TITLE
feat: indication plus générale des CFA qui ne transmetent pas

### DIFF
--- a/ui/modules/dashboard/DashboardOrganisme.tsx
+++ b/ui/modules/dashboard/DashboardOrganisme.tsx
@@ -690,7 +690,7 @@ const DashboardOrganisme = ({ organisme, modePublique }: Props) => {
         {organisme.permissions?.indicateursEffectifs ? (
           <>
             <Heading as="h1" color="#465F9D" fontSize="beta" fontWeight="700" mb={8}>
-              Aperçu de {modePublique ? "ses" : "vos"} effectifs
+              Aperçu de {modePublique ? "ses" : "vos"} indicateurs
               {hasOrganismesFormateurs && " et établissements"}
               <Text fontSize="gamma" as="span" ml="2">
                 (année scolaire 2023-2024)
@@ -707,9 +707,11 @@ const DashboardOrganisme = ({ organisme, modePublique }: Props) => {
               </Ribbons>
             )}
 
-            {aucunEffectifTransmis && (
-              <BandeauTransmission organisme={organisme} modePublique={modePublique} modeIndicateurs />
-            )}
+            {aucunEffectifTransmis &&
+              indicateursEffectifs &&
+              Object.values(indicateursEffectifs).every((value) => value === 0) && (
+                <BandeauTransmission organisme={organisme} modePublique={modePublique} modeIndicateurs />
+              )}
 
             {indicateursEffectifs && (
               <IndicateursGrid indicateursEffectifs={indicateursEffectifs} loading={indicateursEffectifsLoading} />

--- a/ui/modules/organismes/BandeauTransmission.tsx
+++ b/ui/modules/organismes/BandeauTransmission.tsx
@@ -24,7 +24,7 @@ function BandeauTransmission({
   ...props
 }: BandeauTransmissionProps & SystemProps) {
   return (
-    <Ribbons variant="warning" {...props}>
+    <Ribbons variant="alert" {...props}>
       <Text color="grey.800">{getContenuBandeauTransmission({ organisme, modePublique, modeIndicateurs })}</Text>
     </Ribbons>
   );
@@ -46,12 +46,14 @@ function getContenuBandeauTransmission({
   if (!organisme.mode_de_transmission) {
     return (
       <>
-        Les {modeIndicateurs ? "indicateurs sont nuls" : "effectifs sont vides"} car votre établissement ne transmet pas
-        encore ses effectifs. Veuillez{" "}
+        {modeIndicateurs ? "Les indicateurs sont nuls, car les " : "Les "}
+        effectifs ne sont pas encore transmis. Votre CFA ou les organismes dont vous avez la gestion peuvent transmettre
+        les effectifs. Si vous souhaitez démarrer le partage, cliquez sur “
         <Link href="/parametres" borderBottom="1px" _hover={{ textDecoration: "none" }}>
           paramétrer
-        </Link>{" "}
-        votre moyen de transmission.
+        </Link>
+        ” et laissez-vous guider. Le couple UAI/SIRET de chaque établissement doit être bien renseigné pour éviter les
+        erreurs de transmission.
       </>
     );
   }


### PR DESCRIPTION
Cf: [TM-1103](https://tableaudebord-apprentissage.atlassian.net/jira/software/projects/TM/boards/1/backlog?selectedIssue=TM-1103)

### Description : 
Actuellement, pour un CFA, le message affiché lorsqu'il n'y a pas d'effectifs transmis n'est pas adapté. Il indique que l'établissement ne transmet pas encore ses effectifs, ce qui peut être confus pour ces utilisateurs car ils n'ont pas d'effectifs à transmettre. Cette PR vise à clarifier ce message et à s'assurer qu'il est plus pertinent pour tous les types de CFA (responsable, formateur, responsable-formateur).

[TM-1103]: https://tableaudebord-apprentissage.atlassian.net/browse/TM-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ