### PR TITLE
feat: redirection depuis la page d'accueil en cas d'erreur de transmission

### DIFF
--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -821,6 +821,8 @@ export function getOrganismeProjection(
     organismesResponsables: 1,
     organismesFormateurs: 1,
     fiabilisation_statut: 1,
+    has_transmission_errors: 1,
+    transmission_errors_date: 1,
     erps: permissionsOrganisme.infoTransmissionEffectifs,
     erp_unsupported: permissionsOrganisme.infoTransmissionEffectifs,
     first_transmission_date: permissionsOrganisme.infoTransmissionEffectifs,

--- a/server/src/common/mongodb/__snapshots__/validationSchema.test.ts.snap
+++ b/server/src/common/mongodb/__snapshots__/validationSchema.test.ts.snap
@@ -11969,6 +11969,10 @@ exports[`validation-schema should create validation schema for organismes: organ
       "bsonType": "array",
       "maxItems": 0,
     },
+    "has_transmission_errors": {
+      "bsonType": "bool",
+      "description": "Indique si cet organisme a une transmissions d'effectif en erreur",
+    },
     "is_transmission_target": {
       "bsonType": [
         "bool",
@@ -12710,6 +12714,10 @@ exports[`validation-schema should create validation schema for organismes: organ
       "bsonType": "string",
       "description": "N° SIRET de l'établissement",
       "pattern": "^[0-9]{14}$",
+    },
+    "transmission_errors_date": {
+      "bsonType": "date",
+      "description": "Date d'erreur de transmission",
     },
     "uai": {
       "bsonType": "string",

--- a/server/src/http/routes/specific.routes/dossiers-apprenants.routes.ts
+++ b/server/src/http/routes/specific.routes/dossiers-apprenants.routes.ts
@@ -59,16 +59,18 @@ export default () => {
       };
     });
 
-    // Si une erreur est détectée, on met à jour l'organisme pour indiquer qu'il y a des erreurs de transmission
-    const hasError = effectifsToQueue.find((effectif) => effectif.validation_errors?.length);
-    if (hasError) {
-      await updateOrganisme(new ObjectId(user.source_organisme_id), {
-        has_transmission_errors: true,
-        transmission_errors_date: new Date(),
-      });
-    }
-
     try {
+      if (isV3 && !user.source_organisme_id) {
+        // Si une erreur est détectée, on met à jour l'organisme pour indiquer qu'il y a des erreurs de transmission
+        const hasError = effectifsToQueue.find((effectif) => effectif.validation_errors?.length);
+        if (hasError) {
+          await updateOrganisme(new ObjectId(user.source_organisme_id), {
+            has_transmission_errors: true,
+            transmission_errors_date: new Date(),
+          });
+        }
+      }
+
       if (effectifsToQueue.length === 1) {
         await effectifsQueueDb().insertOne(effectifsToQueue[0]);
       } else if (effectifsToQueue.length) {

--- a/server/src/http/routes/specific.routes/transmission.routes.ts
+++ b/server/src/http/routes/specific.routes/transmission.routes.ts
@@ -7,6 +7,7 @@ import {
   getErrorsTransmissionStatusDetailsForAGivenDay,
   getSuccessfulTransmissionStatusDetailsForAGivenDay,
 } from "@/common/actions/indicateurs/transmissions/transmission.action";
+import { updateOrganisme } from "@/common/actions/organismes/organismes.actions";
 import paginationSchema from "@/common/validation/paginationSchema";
 import { extensions } from "@/common/validation/utils/zodPrimitives";
 import { returnResult, requireOrganismePermission } from "@/http/middlewares/helpers";
@@ -35,6 +36,15 @@ export default () => {
     requireOrganismePermission("configurerModeTransmission"),
     validateRequestMiddleware({ params: z.object({ date: extensions.iso8601Date() }), query: pagination }),
     returnResult(getTransmissionByDateSuccess)
+  );
+  router.put(
+    "/reset-notification",
+    requireOrganismePermission("configurerModeTransmission"),
+    returnResult(async (req, res) => {
+      await updateOrganisme(res.locals.organismeId, {
+        has_transmission_errors: false,
+      });
+    })
   );
 
   return router;

--- a/shared/models/data/organismes.model.ts
+++ b/shared/models/data/organismes.model.ts
@@ -215,6 +215,12 @@ const zOrganisme = z
     created_at: z.date({ description: "Date d'ajout en base de données" }),
     natureValidityWarning: z.boolean().optional(),
     formations: z.array(z.any()).max(0).optional(),
+    has_transmission_errors: z
+      .boolean({
+        description: "Indique si cet organisme a une transmissions d'effectif en erreur",
+      })
+      .optional(),
+    transmission_errors_date: z.date({ description: "Date d'erreur de transmission" }).optional(),
     is_transmission_target: z
       .boolean({
         description:

--- a/ui/common/internal/Organisme.ts
+++ b/ui/common/internal/Organisme.ts
@@ -967,6 +967,11 @@ export interface Organisme {
    */
   mode_de_transmission_configuration_author_fullname?: string;
   /**
+   * Gestion erreurs transmission
+   */
+  has_transmission_errors?: boolean;
+  transmission_errors_date?: string;
+  /**
    * Date de mise à jour en base de données
    */
   updated_at?: string;

--- a/ui/components/Notifications/TransmissionErrors.tsx
+++ b/ui/components/Notifications/TransmissionErrors.tsx
@@ -1,0 +1,59 @@
+import { CloseIcon } from "@chakra-ui/icons";
+import { Flex, IconButton, Link, Text } from "@chakra-ui/react";
+import React, { useEffect, useState } from "react";
+
+import { _put } from "@/common/httpClient";
+import { Organisme } from "@/common/internal/Organisme";
+
+import Ribbons from "../Ribbons/Ribbons";
+
+const NotificationTransmissionError = ({ organisme }: { organisme: Organisme }) => {
+  const [hasTransmissionError, setHasTransmissionError] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (organisme?.has_transmission_errors) {
+      setHasTransmissionError(true);
+    }
+  }, [organisme]);
+
+  const onCloseNotification = async () => {
+    await _put(`/api/v1/organismes/${organisme._id}/transmission/reset-notification`, {});
+    setHasTransmissionError(false);
+  };
+
+  return (
+    <>
+      {hasTransmissionError && (
+        <Ribbons variant="alert" mb={6}>
+          <Flex justify="space-between" align="center">
+            <Text color="grey.800">
+              <strong>
+                {`Des erreurs dans l’envoi des données ont été détectées${
+                  organisme.transmission_errors_date
+                    ? ` le ${new Date(organisme.transmission_errors_date).toLocaleDateString()}`
+                    : ""
+                }`}
+              </strong>
+              . Consultez le{" "}
+              <Link href="/transmissions" display="inline" textDecoration="underline">
+                rapport de transmission
+              </Link>{" "}
+              pour les identifier et les corriger. Une fois la correction effectuée, vous pouvez fermer ce bandeau et
+              revenir dans 24h pour vérifier que les erreurs ont disparu.
+            </Text>
+            <IconButton
+              aria-label="Close"
+              icon={<CloseIcon />}
+              onClick={() => onCloseNotification()}
+              size="sm"
+              variant="ghost"
+              ml={4}
+            />
+          </Flex>
+        </Ribbons>
+      )}
+    </>
+  );
+};
+
+export default NotificationTransmissionError;

--- a/ui/modules/dashboard/DashboardOrganisme.tsx
+++ b/ui/modules/dashboard/DashboardOrganisme.tsx
@@ -46,6 +46,7 @@ import { exportDataAsXlsx } from "@/common/utils/exportUtils";
 import { formatCivility, formatSiretSplitted } from "@/common/utils/stringUtils";
 import DownloadButton from "@/components/buttons/DownloadButton";
 import CerfaLink from "@/components/Cerfa/CerfaLink";
+import NotificationTransmissionError from "@/components/Notifications/TransmissionErrors";
 import Ribbons from "@/components/Ribbons/Ribbons";
 import SuggestFeature from "@/components/SuggestFeature/SuggestFeature";
 import { InfoTooltip } from "@/components/Tooltip/InfoTooltip";
@@ -696,6 +697,9 @@ const DashboardOrganisme = ({ organisme, modePublique }: Props) => {
                 (année scolaire 2023-2024)
               </Text>
             </Heading>
+
+            <NotificationTransmissionError organisme={organisme} />
+
             {indicateursEffectifsPartielsMessage && (
               <Ribbons variant="warning" mt="0.5rem">
                 <Text color="grey.800">

--- a/ui/modules/transmissions/ListeTransmissionsPage.tsx
+++ b/ui/modules/transmissions/ListeTransmissionsPage.tsx
@@ -1,5 +1,7 @@
 import { Container, Heading, Text } from "@chakra-ui/react";
+import { useEffect } from "react";
 
+import { _put } from "@/common/httpClient";
 import { Organisme } from "@/common/internal/Organisme";
 import SimplePage from "@/components/Page/SimplePage";
 import TransmissionByDayTable from "@/modules/transmissions/TransmissionByDayTable";
@@ -7,7 +9,18 @@ import TransmissionByDayTable from "@/modules/transmissions/TransmissionByDayTab
 interface ListeTransmissionsPage {
   organisme: Organisme;
 }
+
 const ListeTransmissionsPage = (props: ListeTransmissionsPage) => {
+  useEffect(() => {
+    const resetNotification = async () => {
+      if (props.organisme.has_transmission_errors) {
+        await _put(`/api/v1/organismes/${props.organisme._id}/transmission/reset-notification`, {});
+      }
+    };
+
+    resetNotification();
+  }, [props.organisme]);
+
   return (
     <SimplePage>
       <Container maxW="xl" p="8">


### PR DESCRIPTION
Cf: [TM-1086](https://tableaudebord-apprentissage.atlassian.net/browse/TM-1086)

### Description
Cette PR ajoute la gestion des erreurs de transmission des organismes de formation en introduisant les champs has_transmission_errors et transmission_errors_date. Elle met à jour l'action updateOrganisme et le schéma de validation MongoDB pour inclure ces nouveaux champs. Une nouvelle route PUT /reset-notification est ajoutée pour réinitialiser les notifications d'erreur de transmission. Enfin, un composant NotificationTransmissionError est intégré à l'interface utilisateur pour afficher et gérer ces erreurs, et la page des transmissions est modifiée pour réinitialiser automatiquement les notifications d'erreur lorsqu'elle est chargée.

[TM-1086]: https://tableaudebord-apprentissage.atlassian.net/browse/TM-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ