### PR TITLE
fix: ajout d'une catch pour la mise a jour de formation catalogue

### DIFF
--- a/server/src/jobs/hydrate/hydrate-formations-catalogue.ts
+++ b/server/src/jobs/hydrate/hydrate-formations-catalogue.ts
@@ -45,18 +45,22 @@ export const hydrateFormationsCatalogue = async () => {
     if (pendingFormations.length > 0) {
       queriesInProgress.push(
         ...pendingFormations.map(({ _id, ...formation }) =>
-          formationsCatalogueDb().updateOne(
-            {
-              cle_ministere_educatif: formation.cle_ministere_educatif,
-            },
-            {
-              $set: formation,
-              $setOnInsert: { _id },
-            },
-            {
-              upsert: true,
-            }
-          )
+          formationsCatalogueDb()
+            .updateOne(
+              {
+                cle_ministere_educatif: formation.cle_ministere_educatif,
+              },
+              {
+                $set: formation,
+                $setOnInsert: { _id },
+              },
+              {
+                upsert: true,
+              }
+            )
+            .catch((err) => {
+              logger.error({ err: err }, "insertion formation échouée", formation.cle_ministere_educatif);
+            })
         )
       );
     }


### PR DESCRIPTION
**Description**

- Durant les mises à jour , des exceptions ne sont pas catch sur les formations catalogues, créant des erreurs sur les jobs processors
