### PR TITLE
fix: retirer ammon et formasup-paca de la liste des erp

### DIFF
--- a/shared/constants/erps.ts
+++ b/shared/constants/erps.ts
@@ -6,6 +6,7 @@ interface ERP {
   helpFilePath?: string;
   helpFileSize?: string;
   apiV3?: boolean;
+  disabled?: boolean;
 }
 
 export const ERPS = sortAlphabeticallyBy("name", [
@@ -71,11 +72,13 @@ export const ERPS = sortAlphabeticallyBy("name", [
     id: "ammon",
     name: "Ammon",
     apiV3: true,
+    disabled: true,
   },
   {
     id: "formasup-paca",
     name: "Formasup PACA",
     apiV3: true,
+    disabled: true,
   },
 ] satisfies ERP[]);
 

--- a/ui/pages/parametres.tsx
+++ b/ui/pages/parametres.tsx
@@ -242,7 +242,7 @@ const ParametresPage = () => {
                 <option selected hidden disabled value="">
                   ERP...
                 </option>
-                {ERPS.map((erp) => (
+                {ERPS.filter(({ disabled }) => !disabled).map((erp) => (
                   <option value={erp.id} key={erp.id}>
                     {erp.name}
                   </option>


### PR DESCRIPTION
fix: [TM-1383](https://tableaudebord-apprentissage.atlassian.net/browse/TM-1383)

**Description**

- Retirer ammon et formasup paca de la liste des ERPs
- Il ne s'agit pas d'une suppression mais d'un filtre sur la valeur de _disabled_ , afin de pouvoir être rétrocompatible sur les comptes déjà configurés avec cet ERP



[TM-1383]: https://tableaudebord-apprentissage.atlassian.net/browse/TM-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ