### PR TITLE
fix: correction recette nouvelle page effectifs

### DIFF
--- a/ui/modules/mon-espace/effectifs/doublons/EffectifsDoublonsDetailTable.tsx
+++ b/ui/modules/mon-espace/effectifs/doublons/EffectifsDoublonsDetailTable.tsx
@@ -327,6 +327,7 @@ const EffectifsDoublonsDetailTable = ({ data }: { data: any }) => {
                     borderColor="grey.800"
                     color="grey.800"
                     textTransform="none"
+                    letterSpacing="0px"
                     width={FIXED_COLUMN_WIDTH}
                     minWidth={FIXED_COLUMN_WIDTH}
                     maxWidth={FIXED_COLUMN_WIDTH}
@@ -341,6 +342,7 @@ const EffectifsDoublonsDetailTable = ({ data }: { data: any }) => {
                       borderColor="grey.800"
                       color="grey.800"
                       textTransform="none"
+                      letterSpacing="0px"
                       width={COLUMN_WIDTH}
                       minWidth={COLUMN_WIDTH}
                       p="2"

--- a/ui/modules/mon-espace/effectifs/engine/effectifForm/EffectifForm.tsx
+++ b/ui/modules/mon-espace/effectifs/engine/effectifForm/EffectifForm.tsx
@@ -26,7 +26,7 @@ import { BasicModal } from "@/components/Modals/BasicModal";
 import Ribbons from "@/components/Ribbons/Ribbons";
 import { effectifIdAtom, effectifFromDecaAtom } from "@/modules/mon-espace/effectifs/engine/atoms";
 import { effectifStateSelector, valuesSelector } from "@/modules/mon-espace/effectifs/engine/formEngine/atoms";
-import { Trash } from "@/theme/components/icons";
+import { Alert, Trash } from "@/theme/components/icons";
 import { ErrorPill } from "@/theme/components/icons/ErrorPill";
 import { PlainArrowRight } from "@/theme/components/icons/PlainArrowRight";
 
@@ -291,6 +291,7 @@ export const EffectifForm = memo(
                   validationErrors={validationErrorsByBlock.apprenant}
                   requiredSifa={requiredSifaByBlock.apprenant}
                 >
+                  <WarningMessage modeSifa />
                   <EffectifApprenant apprenant={values?.apprenant} modeSifa={modeSifa} />
                 </AccordionItemChild>
               )}
@@ -303,6 +304,7 @@ export const EffectifForm = memo(
                   validationErrors={validationErrorsByBlock.formation}
                   requiredSifa={requiredSifaByBlock.formation}
                 >
+                  <WarningMessage modeSifa />
                   <EffectifFormation />
                 </AccordionItemChild>
               )}
@@ -315,6 +317,7 @@ export const EffectifForm = memo(
                   validationErrors={validationErrorsByBlock.contrats}
                   requiredSifa={requiredSifaByBlock.contrats}
                 >
+                  <WarningMessage modeSifa />
                   <ApprenantContrats contrats={values?.contrats} />
                 </AccordionItemChild>
               )}
@@ -325,6 +328,20 @@ export const EffectifForm = memo(
     );
   }
 );
+
+export const WarningMessage = ({ modeSifa }: { modeSifa: boolean }) => {
+  if (!modeSifa) return null;
+
+  return (
+    <HStack alignItems={"center"} mt={4}>
+      <Alert color="warning" bg="white" boxSize="5" />
+      <Text fontSize="zeta" color="warning">
+        Les champs verrouillés ci-dessous le sont en raison de l&#39;envoi automatique, chaque nuit, par votre ERP, des
+        données de votre établissement.
+      </Text>
+    </HStack>
+  );
+};
 
 // eslint-disable-next-line react/display-name
 const AccordionItemChild = React.memo(

--- a/ui/modules/mon-espace/effectifs/engine/effectifsTable/EffectifsFilterPanel.tsx
+++ b/ui/modules/mon-espace/effectifs/engine/effectifsTable/EffectifsFilterPanel.tsx
@@ -43,16 +43,16 @@ const EffectifsFilterPanel: React.FC<EffectifsFilterPanelProps> = ({
           />
         )}
 
-        {/* Source */}
-        {availableFilters?.source && (
+        {/* Formation */}
+        {availableFilters?.formation_libelle_long && (
           <EffectifsFilterComponent
-            filterKey="source"
-            displayName="Source de la donnée"
-            options={availableFilters.source}
-            selectedValues={filters.source || []}
-            onChange={(values) => handleCheckboxChange("source", values)}
-            isOpen={openFilter === "source"}
-            setIsOpen={(isOpen) => setOpenFilter(isOpen ? "source" : null)}
+            filterKey="formation_libelle_long"
+            displayName="Formation"
+            options={availableFilters.formation_libelle_long}
+            selectedValues={filters.formation_libelle_long || []}
+            onChange={(values) => handleCheckboxChange("formation_libelle_long", values)}
+            isOpen={openFilter === "formation_libelle_long"}
+            setIsOpen={(isOpen) => setOpenFilter(isOpen ? "formation_libelle_long" : null)}
           />
         )}
 
@@ -69,16 +69,16 @@ const EffectifsFilterPanel: React.FC<EffectifsFilterPanelProps> = ({
           />
         )}
 
-        {/* Formation */}
-        {availableFilters?.formation_libelle_long && (
+        {/* Source */}
+        {availableFilters?.source && (
           <EffectifsFilterComponent
-            filterKey="formation_libelle_long"
-            displayName="Formation"
-            options={availableFilters.formation_libelle_long}
-            selectedValues={filters.formation_libelle_long || []}
-            onChange={(values) => handleCheckboxChange("formation_libelle_long", values)}
-            isOpen={openFilter === "formation_libelle_long"}
-            setIsOpen={(isOpen) => setOpenFilter(isOpen ? "formation_libelle_long" : null)}
+            filterKey="source"
+            displayName="Source de la donnée"
+            options={availableFilters.source}
+            selectedValues={filters.source || []}
+            onChange={(values) => handleCheckboxChange("source", values)}
+            isOpen={openFilter === "source"}
+            setIsOpen={(isOpen) => setOpenFilter(isOpen ? "source" : null)}
           />
         )}
 


### PR DESCRIPTION
Cf: [TM-1780](https://tableaudebord-apprentissage.atlassian.net/browse/TM-1780)


**Quelques retours sur la page "Mes effectifs" :**
- ordre des filtres : année scolaire > formation > statut > source de la donnée
- je me rends compte qu'il manque cette petite phrase "UX" en orange qui explique pourquoi les champs sont verrouillés (ça date d'il y a plusieurs semaines/mois)
- Quelques retours sur la page "Mon enquête SIFA" :
- je n'ai pas de filtres disponibles (normalement, il y a "Formation" et "Source de la donnée")
- je ne peux pas recetter un effectif qui aurait de la donnée manquante car je n'ai que des données complètes

Sur les duplicats, il faudrait réduire l'interlettrage des en-têtes de colonne (edited)

[TM-1780]: https://tableaudebord-apprentissage.atlassian.net/browse/TM-1780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ