### PR TITLE
fix: reduce sentry trace sample rate

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "@sentry/cli": "^2.37.0",
     "@sentry/integrations": "^7.114.0",
     "@sentry/node": "^7.119.2",
+    "@sentry/types": "^7.114.0",
     "@supercharge/promise-pool": "^2.4.0",
     "@types/boom": "^7.3.5",
     "@types/multer": "^1.4.12",

--- a/ui/sentry.client.config.ts
+++ b/ui/sentry.client.config.ts
@@ -14,7 +14,7 @@ import { publicConfig } from "./config.public";
 
 init({
   dsn: publicConfig.sentry_dsn,
-  tracesSampleRate: publicConfig.env === "production" ? 0.1 : 1.0,
+  tracesSampleRate: publicConfig.env === "production" ? 0.01 : 1.0,
   tracePropagationTargets: [/^https:\/\/[^/]*\.apprentissage\.beta\.gouv\.fr/, publicConfig.baseUrl, /^\//],
   environment: publicConfig.env,
   enabled: publicConfig.env !== "local",

--- a/ui/sentry.edge.config.ts
+++ b/ui/sentry.edge.config.ts
@@ -10,7 +10,7 @@ import { publicConfig } from "./config.public";
 
 init({
   dsn: publicConfig.sentry_dsn,
-  tracesSampleRate: publicConfig.env === "production" ? 0.1 : 1.0,
+  tracesSampleRate: publicConfig.env === "production" ? 0.01 : 1.0,
   tracePropagationTargets: [/^https:\/\/[^/]*\.apprentissage\.beta\.gouv\.fr/, publicConfig.baseUrl],
   environment: publicConfig.env,
   enabled: publicConfig.env !== "local",

--- a/ui/sentry.server.config.ts
+++ b/ui/sentry.server.config.ts
@@ -9,7 +9,7 @@ import { publicConfig } from "./config.public";
 
 init({
   dsn: publicConfig.sentry_dsn,
-  tracesSampleRate: publicConfig.env === "production" ? 0.1 : 1.0,
+  tracesSampleRate: publicConfig.env === "production" ? 0.01 : 1.0,
   tracePropagationTargets: [/^https:\/\/[^/]*\.apprentissage\.beta\.gouv\.fr/, publicConfig.baseUrl],
   environment: publicConfig.env,
   enabled: publicConfig.env !== "local",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3768,6 +3768,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/types@npm:^7.114.0":
+  version: 7.120.2
+  resolution: "@sentry/types@npm:7.120.2"
+  checksum: 45a46cd13f2b7a0590439c0b98e14b50cd1a0a610d8b5d977934a82336ad88a9fd0efb6a93c86063ae25ae2e587994b6b7ad122e808c82110d71c132cc55b02b
+  languageName: node
+  linkType: hard
+
 "@sentry/utils@npm:7.119.2":
   version: 7.119.2
   resolution: "@sentry/utils@npm:7.119.2"
@@ -16186,6 +16193,7 @@ __metadata:
     "@sentry/cli": ^2.37.0
     "@sentry/integrations": ^7.114.0
     "@sentry/node": ^7.119.2
+    "@sentry/types": ^7.114.0
     "@supercharge/promise-pool": ^2.4.0
     "@types/boom": ^7.3.5
     "@types/bunyan": ^1.8.11


### PR DESCRIPTION
Le serveur de monitoring est en train de die, il n'a plus de place... Le problème c'est le nombre de traces (en partie).

Sachant que si une transaction TBA est trace, et alors les requetes enfants seront trace egalement (call commune/organisme sur API)...