### PR TITLE
chore: update du script de setup pour utiliser l'image docker d'ansible

### DIFF
--- a/.bin/scripts/setup-local-env.sh
+++ b/.bin/scripts/setup-local-env.sh
@@ -2,18 +2,33 @@
 set -euo pipefail
 
 echo "Updating local server/.env & ui/.env"
-ANSIBLE_CONFIG="${ROOT_DIR}/.infra/ansible/ansible.cfg" ansible all \
-  --limit "local" \
-  -m template \
-  -a "src=\"${ROOT_DIR}/.infra/.env_server\" dest=\"${ROOT_DIR}/server/.env\"" \
-  --extra-vars "@${ROOT_DIR}/.infra/vault/vault.yml" \
-  --vault-password-file="${SCRIPT_DIR}/get-vault-password-client.sh"
-ANSIBLE_CONFIG="${ROOT_DIR}/.infra/ansible/ansible.cfg" ansible all \
-  --limit "local" \
-  -m template \
-  -a "src=\"${ROOT_DIR}/.infra/.env_ui\" dest=\"${ROOT_DIR}/ui/.env\"" \
-  --extra-vars "@${ROOT_DIR}/.infra/vault/vault.yml" \
-  --vault-password-file="${SCRIPT_DIR}/get-vault-password-client.sh"
+
+delete_cleartext() {
+  rm -f "${ROOT_DIR}/.vault_pwd.txt"
+}
+
+trap delete_cleartext EXIT
+"${SCRIPT_DIR}/get-vault-password-client.sh" > "${ROOT_DIR}/.vault_pwd.txt"
+
+MSYS_NO_PATHCONV=1 docker run -it --rm \
+  -v "${ROOT_DIR}:/root" \
+  -e ANSIBLE_CONFIG="/root/.infra/ansible/ansible.cfg" \
+  alpine/ansible sh -c 'chmod 0600 /root/.vault_pwd.txt && ansible all \
+    --limit "local" \
+    -m flux-retour-cfas \
+    -a "src=\"/root/.infra/.env_server\" dest=\"/root/server/.env\"" \
+    --extra-vars "@root/.infra/vault/vault.yml" \
+    --vault-password-file="/root/.vault_pwd.txt"'
+
+MSYS_NO_PATHCONV=1 docker run -it --rm \
+  -v "${ROOT_DIR}:/root" \
+  -e ANSIBLE_CONFIG="/root/.infra/ansible/ansible.cfg" \
+  alpine/ansible sh -c 'chmod 0600 /root/.vault_pwd.txt && ansible all \
+    --limit "local" \
+    -m flux-retour-cfas \
+    -a "src=\"/root/.infra/.env_ui\" dest=\"/root/ui/.env\"" \
+    --extra-vars "@root/.infra/vault/vault.yml" \
+    --vault-password-file="/root/.vault_pwd.txt"'
 
 echo "PUBLIC_VERSION=0.0.0-local" >> "${ROOT_DIR}/server/.env"
 


### PR DESCRIPTION
Update du script de setup de l'env en utilisant l'image docker d'ansible.
- Permet à un environnement Windows de lancer Ansible sans souci.
- Ajout de MSYS_NO_PATHCONV pour compatibilité GitBash
- Renommage du template

Inspiré de la base qu'on avait faite avec @moroine sur https://github.com/mission-apprentissage/api-apprentissage/pull/262