### PR TITLE
fix: retrait des effectifs deca des ml

### DIFF
--- a/server/src/common/actions/mission-locale/mission-locale.actions.ts
+++ b/server/src/common/actions/mission-locale/mission-locale.actions.ts
@@ -162,15 +162,7 @@ const generateMissionLocaleMatchStage = (missionLocaleId: number) => {
 };
 
 const generateUnionWithEffectifDECA = (missionLocaleId: number) => {
-  return [
-    generateMissionLocaleMatchStage(missionLocaleId),
-    {
-      $unionWith: {
-        coll: "effectifsDECA",
-        pipeline: [generateMissionLocaleMatchStage(missionLocaleId), { $match: { is_deca_compatible: true } }],
-      },
-    },
-  ];
+  return [generateMissionLocaleMatchStage(missionLocaleId)];
 };
 
 export const getPaginatedEffectifsByMissionLocaleId = async (


### PR DESCRIPTION
Nous procédons au retrait des effectifs DECA des Missions Locales, en raison de la nécessité de revoir la logique d'intégration liée à la gestion des données de suivi des effectifs DECA par les missions locales.