### PR TITLE
fix: process effectif queue types

### DIFF
--- a/server/src/common/actions/effectifs.actions.ts
+++ b/server/src/common/actions/effectifs.actions.ts
@@ -24,7 +24,10 @@ import { generateOrganismeComputed } from "./organismes/organismes.actions";
  * Dans le cas d'un effectif téléversé, on ne veut pas verrouiller les champs, même ceux dits "par défaut" (nom, prénom, etc.)
  * Voir aussi la méthode lockEffectif
  */
-export const mergeEffectifWithDefaults = <T extends Partial<IEffectif>>(effectifData: T, lockData: boolean = true) => {
+export const mergeEffectifWithDefaults = (
+  effectifData: Omit<IEffectif, "_id" | "_computed" | "organisme_id">,
+  lockData: boolean = true
+): Omit<IEffectif, "_id" | "_computed" | "organisme_id"> => {
   const defaultValues = defaultValuesEffectif();
   // note: I've tried to use ts-deepmerge, but typing doesn't work well
   return {
@@ -128,7 +131,7 @@ export const lockEffectif = async (effectif: IEffectif) => {
   return updated.value;
 };
 
-export const addComputedFields = async <T extends IEffectif | WithoutId<IEffectifDECA>>({
+export const addComputedFields = async <T extends WithoutId<IEffectif | IEffectifDECA>>({
   organisme,
   effectif,
   certification,
@@ -162,7 +165,7 @@ export const addComputedFields = async <T extends IEffectif | WithoutId<IEffecti
   return computedFields;
 };
 
-export const withComputedFields = async <T extends IEffectif | WithoutId<IEffectifDECA>>(
+export const withComputedFields = async <T extends WithoutId<IEffectif | IEffectifDECA>>(
   effectif: T,
   {
     organisme,

--- a/server/src/common/actions/effectifs.statut.actions.ts
+++ b/server/src/common/actions/effectifs.statut.actions.ts
@@ -45,7 +45,7 @@ function shouldUpdateStatut(effectif: IEffectif): boolean {
  * @returns {IEffectifComputedStatut} L'objet de statut calculé pour l'effectif.
  */
 export function createComputedStatutObject(
-  effectif: IEffectif | WithoutId<IEffectifDECA>,
+  effectif: WithoutId<IEffectif | IEffectifDECA>,
   evaluationDate: Date
 ): IEffectifComputedStatut | null {
   try {
@@ -102,7 +102,7 @@ function handleUpdateError(err: unknown, effectif: IEffectif) {
 }
 
 const generateUnifiedParcours = (
-  effectif: IEffectif | WithoutId<IEffectifDECA>,
+  effectif: WithoutId<IEffectif | IEffectifDECA>,
   evaluationDate: Date
 ): { valeur: StatutApprenant; date: Date }[] => {
   let parcours: { valeur: StatutApprenant; date: Date }[] = [];
@@ -144,7 +144,7 @@ function deduplicateAndSortParcours(parcours: { valeur: StatutApprenant; date: D
 }
 
 function determineStatutsByContrats(
-  effectif: IEffectif | WithoutId<IEffectifDECA>,
+  effectif: WithoutId<IEffectif | IEffectifDECA>,
   evaluationDate?: Date
 ): { valeur: StatutApprenant; date: Date }[] {
   if (!effectif.formation?.date_entree && !effectif.formation?.date_fin) {

--- a/server/src/common/actions/engine/engine.actions.ts
+++ b/server/src/common/actions/engine/engine.actions.ts
@@ -3,11 +3,10 @@ import { cloneDeep } from "lodash-es";
 import { Collection } from "mongodb";
 import { IEffectif } from "shared/models/data/effectifs.model";
 import { IEffectifDECA } from "shared/models/data/effectifsDECA.model";
-import { IEffectifQueue } from "shared/models/data/effectifsQueue.model";
-import { PartialDeep } from "type-fest";
+import type { IDossierApprenantSchemaV3 } from "shared/models/parts/dossierApprenantSchemaV3";
 
 import { getCommune } from "@/common/apis/apiAlternance/apiAlternance";
-import { stripEmptyFields } from "@/common/utils/miscUtils";
+import type { DossierApprenantSchemaV1V2ZodType } from "@/common/validation/dossierApprenantSchemaV1V2";
 
 /**
  * Méthode de construction d'un nouveau tableau d'historique de statut
@@ -123,57 +122,56 @@ export const checkIfEffectifExists = async <E extends IEffectif | IEffectifDECA>
  * Fonctionne pour l'API v2 et v3.
  */
 export const mapEffectifQueueToEffectif = (
-  // devrait être le schéma validé
-  // dossierApprenant: DossierApprenantSchemaV1V2ZodType | DossierApprenantSchemaV3ZodType
-  dossierApprenant: IEffectifQueue
-): PartialDeep<IEffectif> => {
+  dossierApprenant: DossierApprenantSchemaV1V2ZodType | IDossierApprenantSchemaV3
+): Omit<IEffectif, "_id" | "_computed" | "organisme_id"> => {
   // Ne pas remplir l'historique statut en cas de v3
   const { statut_apprenant, date_metier_mise_a_jour_statut } = dossierApprenant;
-  const historiqueStatut =
+  const historiqueStatut: IEffectif["apprenant"]["historique_statut"] =
     statut_apprenant && date_metier_mise_a_jour_statut
       ? [
           {
-            valeur_statut: dossierApprenant.statut_apprenant,
-            date_statut: new Date(dossierApprenant.date_metier_mise_a_jour_statut),
+            valeur_statut: statut_apprenant,
+            date_statut: new Date(date_metier_mise_a_jour_statut),
             date_reception: new Date(),
           },
         ]
       : [];
-  const contrats: PartialDeep<IEffectif["contrats"]> = [
-    stripEmptyFields({
+
+  const contrats: IEffectif["contrats"] = [
+    {
       date_debut: dossierApprenant.contrat_date_debut,
       date_fin: dossierApprenant.contrat_date_fin,
       date_rupture: dossierApprenant.contrat_date_rupture,
-      cause_rupture: dossierApprenant.cause_rupture_contrat,
-      siret: dossierApprenant.siret_employeur,
-    }),
-    stripEmptyFields({
-      date_debut: dossierApprenant.contrat_date_debut_2,
-      date_fin: dossierApprenant.contrat_date_fin_2,
-      date_rupture: dossierApprenant.contrat_date_rupture_2,
-      cause_rupture: dossierApprenant.cause_rupture_contrat_2,
-      siret: dossierApprenant.siret_employeur_2,
-    }),
-    stripEmptyFields({
-      date_debut: dossierApprenant.contrat_date_debut_3,
-      date_fin: dossierApprenant.contrat_date_fin_3,
-      date_rupture: dossierApprenant.contrat_date_rupture_3,
-      cause_rupture: dossierApprenant.cause_rupture_contrat_3,
-      siret: dossierApprenant.siret_employeur_3,
-    }),
-    stripEmptyFields({
-      date_debut: dossierApprenant.contrat_date_debut_4,
-      date_fin: dossierApprenant.contrat_date_fin_4,
-      date_rupture: dossierApprenant.contrat_date_rupture_4,
-      cause_rupture: dossierApprenant.cause_rupture_contrat_4,
-      siret: dossierApprenant.siret_employeur_4,
-    }),
+      cause_rupture: "cause_rupture_contrat" in dossierApprenant ? dossierApprenant.cause_rupture_contrat : null,
+      siret: "siret_employeur" in dossierApprenant ? dossierApprenant.siret_employeur : null,
+    },
+    {
+      date_debut: "contrat_date_debut_2" in dossierApprenant ? dossierApprenant.contrat_date_debut_2 : null,
+      date_fin: "contrat_date_fin_2" in dossierApprenant ? dossierApprenant.contrat_date_fin_2 : null,
+      date_rupture: "contrat_date_rupture_2" in dossierApprenant ? dossierApprenant.contrat_date_rupture_2 : null,
+      cause_rupture: "cause_rupture_contrat_2" in dossierApprenant ? dossierApprenant.cause_rupture_contrat_2 : null,
+      siret: "siret_employeur_2" in dossierApprenant ? dossierApprenant.siret_employeur_2 : null,
+    },
+    {
+      date_debut: "contrat_date_debut_3" in dossierApprenant ? dossierApprenant.contrat_date_debut_3 : null,
+      date_fin: "contrat_date_fin_3" in dossierApprenant ? dossierApprenant.contrat_date_fin_3 : null,
+      date_rupture: "contrat_date_rupture_3" in dossierApprenant ? dossierApprenant.contrat_date_rupture_3 : null,
+      cause_rupture: "cause_rupture_contrat_3" in dossierApprenant ? dossierApprenant.cause_rupture_contrat_3 : null,
+      siret: "siret_employeur_3" in dossierApprenant ? dossierApprenant.siret_employeur_3 : null,
+    },
+    {
+      date_debut: "contrat_date_debut_4" in dossierApprenant ? dossierApprenant.contrat_date_debut_4 : null,
+      date_fin: "contrat_date_fin_4" in dossierApprenant ? dossierApprenant.contrat_date_fin_4 : null,
+      date_rupture: "contrat_date_rupture_4" in dossierApprenant ? dossierApprenant.contrat_date_rupture_4 : null,
+      cause_rupture: "cause_rupture_contrat_4" in dossierApprenant ? dossierApprenant.cause_rupture_contrat_4 : null,
+      siret: "siret_employeur_4" in dossierApprenant ? dossierApprenant.siret_employeur_4 : null,
+    },
   ].filter((contrat) => contrat.date_debut || contrat.date_fin || contrat.date_rupture);
 
-  return stripEmptyFields<PartialDeep<IEffectif>>({
+  return {
     annee_scolaire: dossierApprenant.annee_scolaire,
     source: dossierApprenant.source,
-    source_organisme_id: dossierApprenant.source_organisme_id,
+    source_organisme_id: "source_organisme_id" in dossierApprenant ? dossierApprenant.source_organisme_id : null,
     id_erp_apprenant: dossierApprenant.id_erp_apprenant,
     apprenant: {
       historique_statut: historiqueStatut,
@@ -183,64 +181,83 @@ export const mapEffectifQueueToEffectif = (
       date_de_naissance: dossierApprenant.date_de_naissance_apprenant,
       courriel: dossierApprenant.email_contact,
       telephone: dossierApprenant.tel_apprenant,
-      adresse: stripEmptyFields({
+      adresse: {
         code_insee: dossierApprenant.code_commune_insee_apprenant,
-        code_postal: dossierApprenant.code_postal_apprenant,
-        complete: dossierApprenant.adresse_apprenant,
-      }),
-      adresse_naissance: stripEmptyFields({
-        code_insee: dossierApprenant.code_commune_insee_de_naissance_apprenant,
-        code_postal: dossierApprenant.code_postal_de_naissance_apprenant,
-      }),
-      // Optional v3 fields
-      ...stripEmptyFields<PartialDeep<IEffectif["apprenant"]>>({
-        sexe: dossierApprenant.sexe_apprenant,
-        rqth: dossierApprenant.rqth_apprenant,
-        date_rqth: dossierApprenant.date_rqth_apprenant,
-        has_nir: dossierApprenant.has_nir,
-        responsable_mail1: dossierApprenant.responsable_apprenant_mail1,
-        responsable_mail2: dossierApprenant.responsable_apprenant_mail2,
-        derniere_situation: dossierApprenant.derniere_situation,
-        dernier_organisme_uai: dossierApprenant.dernier_organisme_uai?.toString(),
-        type_cfa: dossierApprenant.type_cfa,
-      }),
+        code_postal: "code_postal_apprenant" in dossierApprenant ? dossierApprenant.code_postal_apprenant : null,
+        complete: "adresse_apprenant" in dossierApprenant ? dossierApprenant.adresse_apprenant : null,
+      },
+      adresse_naissance: {
+        code_insee:
+          "code_commune_insee_de_naissance_apprenant" in dossierApprenant
+            ? dossierApprenant.code_commune_insee_de_naissance_apprenant
+            : null,
+        code_postal:
+          "code_postal_de_naissance_apprenant" in dossierApprenant
+            ? dossierApprenant.code_postal_de_naissance_apprenant
+            : null,
+      },
+      sexe: "sexe_apprenant" in dossierApprenant ? dossierApprenant.sexe_apprenant : null,
+      rqth: "rqth_apprenant" in dossierApprenant ? dossierApprenant.rqth_apprenant : null,
+      date_rqth: "date_rqth_apprenant" in dossierApprenant ? dossierApprenant.date_rqth_apprenant : null,
+      has_nir: "has_nir" in dossierApprenant ? dossierApprenant.has_nir : null,
+      responsable_mail1:
+        "responsable_apprenant_mail1" in dossierApprenant ? dossierApprenant.responsable_apprenant_mail1 : null,
+      responsable_mail2:
+        "responsable_apprenant_mail2" in dossierApprenant ? dossierApprenant.responsable_apprenant_mail2 : null,
+      derniere_situation: "derniere_situation" in dossierApprenant ? dossierApprenant.derniere_situation : null,
+      dernier_organisme_uai:
+        "dernier_organisme_uai" in dossierApprenant ? dossierApprenant.dernier_organisme_uai?.toString() : null,
+      type_cfa: "type_cfa" in dossierApprenant ? dossierApprenant.type_cfa : null,
     },
     contrats,
     formation: {
-      cfd: dossierApprenant.formation_cfd || dossierApprenant.id_formation,
+      cfd:
+        "formation_cfd" in dossierApprenant
+          ? dossierApprenant.formation_cfd
+          : "id_formation" in dossierApprenant
+            ? dossierApprenant.id_formation
+            : null,
       rncp: dossierApprenant.formation_rncp,
-      libelle_long: dossierApprenant.libelle_long_formation,
-      periode: dossierApprenant.periode_formation,
+      libelle_long: "libelle_long_formation" in dossierApprenant ? dossierApprenant.libelle_long_formation : null,
+      periode: "periode_formation" in dossierApprenant ? dossierApprenant.periode_formation : [],
       annee: dossierApprenant.annee_formation,
-      ...stripEmptyFields<PartialDeep<NonNullable<IEffectif["formation"]>>>({
-        obtention_diplome: dossierApprenant.obtention_diplome_formation,
-        date_obtention_diplome: dossierApprenant.date_obtention_diplome_formation,
-        date_exclusion: dossierApprenant.date_exclusion_formation,
-        cause_exclusion: dossierApprenant.cause_exclusion_formation,
-        referent_handicap:
-          dossierApprenant.email_referent_handicap_formation ||
-          dossierApprenant.prenom_referent_handicap_formation ||
-          dossierApprenant.email_referent_handicap_formation
-            ? stripEmptyFields({
-                nom: dossierApprenant.nom_referent_handicap_formation,
-                prenom: dossierApprenant.prenom_referent_handicap_formation,
-                email: dossierApprenant.email_referent_handicap_formation,
-              })
-            : undefined,
-        date_inscription: dossierApprenant.date_inscription_formation,
-        // Les ERPs (ou les anciens fichiers de téléversement) peuvent continuer à utiliser duree_theorique_formation
-        // qui est l'ancien champ en années (contrairement à duree_theorique_formation_mois qui est en mois).
-        // On assure donc une rétrocompatibilité discrète en convertissant le champ en mois si besoin et
-        // en mettant dans le bon champ.
-        duree_theorique_mois: dossierApprenant.duree_theorique_formation_mois
+
+      obtention_diplome:
+        "obtention_diplome_formation" in dossierApprenant ? dossierApprenant.obtention_diplome_formation : null,
+      date_obtention_diplome:
+        "date_obtention_diplome_formation" in dossierApprenant
+          ? dossierApprenant.date_obtention_diplome_formation
+          : null,
+      date_exclusion: "date_exclusion_formation" in dossierApprenant ? dossierApprenant.date_exclusion_formation : null,
+      cause_exclusion:
+        "cause_exclusion_formation" in dossierApprenant ? dossierApprenant.cause_exclusion_formation : null,
+      referent_handicap:
+        ("email_referent_handicap_formation" in dossierApprenant &&
+          dossierApprenant.email_referent_handicap_formation) ||
+        ("prenom_referent_handicap_formation" in dossierApprenant &&
+          dossierApprenant.prenom_referent_handicap_formation) ||
+        ("email_referent_handicap_formation" in dossierApprenant && dossierApprenant.email_referent_handicap_formation)
+          ? {
+              nom: dossierApprenant.nom_referent_handicap_formation,
+              prenom: dossierApprenant.prenom_referent_handicap_formation,
+              email: dossierApprenant.email_referent_handicap_formation,
+            }
+          : undefined,
+      date_inscription: dossierApprenant.date_inscription_formation,
+      // Les ERPs (ou les anciens fichiers de téléversement) peuvent continuer à utiliser duree_theorique_formation
+      // qui est l'ancien champ en années (contrairement à duree_theorique_formation_mois qui est en mois).
+      // On assure donc une rétrocompatibilité discrète en convertissant le champ en mois si besoin et
+      // en mettant dans le bon champ.
+      duree_theorique_mois:
+        "duree_theorique_formation_mois" in dossierApprenant
           ? dossierApprenant.duree_theorique_formation_mois
-          : dossierApprenant.duree_theorique_formation
+          : "duree_theorique_formation" in dossierApprenant && dossierApprenant.duree_theorique_formation
             ? dossierApprenant.duree_theorique_formation * 12
             : undefined,
-        formation_presentielle: dossierApprenant.formation_presentielle,
-        date_fin: dossierApprenant.date_fin_formation,
-        date_entree: dossierApprenant.date_entree_formation,
-      }),
+      formation_presentielle:
+        "formation_presentielle" in dossierApprenant ? dossierApprenant.formation_presentielle : null,
+      date_fin: dossierApprenant.date_fin_formation,
+      date_entree: dossierApprenant.date_entree_formation,
     },
-  });
+  };
 };

--- a/server/src/common/actions/organismes/organismes.actions.ts
+++ b/server/src/common/actions/organismes/organismes.actions.ts
@@ -1009,8 +1009,8 @@ function getOrganismeListProjection(
 export async function getInvalidUaisFromDossierApprenant(data: Partial<IEffectifQueue>[]): Promise<string[]> {
   const uais = new Set<string>();
   for (const dossier of data) {
-    if (dossier.etablissement_formateur_uai) uais.add(dossier.etablissement_formateur_uai);
-    if (dossier.etablissement_responsable_uai) uais.add(dossier.etablissement_responsable_uai);
+    if (typeof dossier.etablissement_formateur_uai === "string") uais.add(dossier.etablissement_formateur_uai);
+    if (typeof dossier.etablissement_responsable_uai === "string") uais.add(dossier.etablissement_responsable_uai);
   }
   const invalidsUais: string[] = [];
   for (const uai of uais) {
@@ -1025,8 +1025,9 @@ export async function getInvalidUaisFromDossierApprenant(data: Partial<IEffectif
 export async function getInvalidSiretsFromDossierApprenant(data: Partial<IEffectifQueue>[]): Promise<string[]> {
   const sirets = new Set<string>();
   for (const dossier of data) {
-    if (dossier.etablissement_formateur_siret) sirets.add(dossier.etablissement_formateur_siret);
-    if (dossier.etablissement_responsable_siret) sirets.add(dossier.etablissement_responsable_siret);
+    if (typeof dossier.etablissement_formateur_siret === "string") sirets.add(dossier.etablissement_formateur_siret);
+    if (typeof dossier.etablissement_responsable_siret === "string")
+      sirets.add(dossier.etablissement_responsable_siret);
   }
   const invalidsSirets: string[] = [];
   for (const siret of sirets) {

--- a/server/src/common/actions/v2/formation.v2.actions.ts
+++ b/server/src/common/actions/v2/formation.v2.actions.ts
@@ -3,8 +3,8 @@ import { ObjectId } from "mongodb";
 import { formationV2Db } from "@/common/model/collections";
 
 export const getOrCreateFormationV2 = async (
-  cfd: string,
-  rncp: string,
+  cfd: string | null,
+  rncp: string | null,
   organisme_responsable_id: ObjectId,
   organisme_formateur_id: ObjectId
 ) => {
@@ -19,23 +19,23 @@ export const getOrCreateFormationV2 = async (
 };
 
 const getFormationV2 = async (
-  cfd: string,
-  rncp: string,
+  cfd: string | null,
+  rncp: string | null,
   organisme_responsable_id: ObjectId,
   organisme_formateur_id: ObjectId
 ) => {
   // CFD & RNCP --> tjr en uppercase
   return formationV2Db().findOne({
-    cfd: cfd.replace(/\s/g, "").toLowerCase(),
-    rncp: rncp.replace(/\s/g, "").toLowerCase(),
+    cfd: cfd?.replace(/\s/g, "").toLowerCase() ?? null,
+    rncp: rncp?.replace(/\s/g, "").toLowerCase() ?? null,
     organisme_responsable_id,
     organisme_formateur_id,
   });
 };
 
 const insertFormationV2 = async (
-  cfd: string,
-  rncp: string,
+  cfd: string | null,
+  rncp: string | null,
   organisme_responsable_id: ObjectId,
   organisme_formateur_id: ObjectId
 ) => {
@@ -44,8 +44,8 @@ const insertFormationV2 = async (
     draft: true,
     created_at: new Date(),
     updated_at: new Date(),
-    cfd: cfd.replace(/\s/g, "").toLowerCase(),
-    rncp: rncp.replace(/\s/g, "").toLowerCase(),
+    cfd: cfd?.replace(/\s/g, "").toLowerCase() ?? null,
+    rncp: rncp?.replace(/\s/g, "").toLowerCase() ?? null,
     organisme_responsable_id,
     organisme_formateur_id,
   });

--- a/server/src/common/mongodb/__snapshots__/validationSchema.test.ts.snap
+++ b/server/src/common/mongodb/__snapshots__/validationSchema.test.ts.snap
@@ -681,14 +681,30 @@ exports[`validation-schema > should create validation schema for effectifs > eff
                   "description": "Code Bassin d'emploi",
                 },
                 "code_insee": {
-                  "bsonType": "string",
+                  "anyOf": [
+                    {
+                      "bsonType": "string",
+                      "description": "Le code insee doit contenir 5 caractères",
+                      "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
+                    },
+                    {
+                      "bsonType": "null",
+                    },
+                  ],
                   "description": "Le code insee doit contenir 5 caractères",
-                  "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
                 },
                 "code_postal": {
-                  "bsonType": "string",
+                  "anyOf": [
+                    {
+                      "bsonType": "string",
+                      "description": "Le code postal doit contenir 5 caractères",
+                      "pattern": "^[0-9]{5}$",
+                    },
+                    {
+                      "bsonType": "null",
+                    },
+                  ],
                   "description": "Le code postal doit contenir 5 caractères",
-                  "pattern": "^[0-9]{5}$",
                 },
                 "commune": {
                   "bsonType": "string",
@@ -700,7 +716,10 @@ exports[`validation-schema > should create validation schema for effectifs > eff
                   "description": "Complément d'adresse",
                 },
                 "complete": {
-                  "bsonType": "string",
+                  "bsonType": [
+                    "string",
+                    "null",
+                  ],
                   "description": "Adresse complète",
                 },
                 "departement": {
@@ -963,14 +982,30 @@ exports[`validation-schema > should create validation schema for effectifs > eff
                   "description": "Code Bassin d'emploi",
                 },
                 "code_insee": {
-                  "bsonType": "string",
+                  "anyOf": [
+                    {
+                      "bsonType": "string",
+                      "description": "Le code insee doit contenir 5 caractères",
+                      "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
+                    },
+                    {
+                      "bsonType": "null",
+                    },
+                  ],
                   "description": "Le code insee doit contenir 5 caractères",
-                  "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
                 },
                 "code_postal": {
-                  "bsonType": "string",
+                  "anyOf": [
+                    {
+                      "bsonType": "string",
+                      "description": "Le code postal doit contenir 5 caractères",
+                      "pattern": "^[0-9]{5}$",
+                    },
+                    {
+                      "bsonType": "null",
+                    },
+                  ],
                   "description": "Le code postal doit contenir 5 caractères",
-                  "pattern": "^[0-9]{5}$",
                 },
                 "commune": {
                   "bsonType": "string",
@@ -982,7 +1017,10 @@ exports[`validation-schema > should create validation schema for effectifs > eff
                   "description": "Complément d'adresse",
                 },
                 "complete": {
-                  "bsonType": "string",
+                  "bsonType": [
+                    "string",
+                    "null",
+                  ],
                   "description": "Adresse complète",
                 },
                 "departement": {
@@ -1587,14 +1625,30 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                           "description": "Code Bassin d'emploi",
                         },
                         "code_insee": {
-                          "bsonType": "string",
+                          "anyOf": [
+                            {
+                              "bsonType": "string",
+                              "description": "Le code insee doit contenir 5 caractères",
+                              "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
+                            },
+                            {
+                              "bsonType": "null",
+                            },
+                          ],
                           "description": "Le code insee doit contenir 5 caractères",
-                          "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
                         },
                         "code_postal": {
-                          "bsonType": "string",
+                          "anyOf": [
+                            {
+                              "bsonType": "string",
+                              "description": "Le code postal doit contenir 5 caractères",
+                              "pattern": "^[0-9]{5}$",
+                            },
+                            {
+                              "bsonType": "null",
+                            },
+                          ],
                           "description": "Le code postal doit contenir 5 caractères",
-                          "pattern": "^[0-9]{5}$",
                         },
                         "commune": {
                           "bsonType": "string",
@@ -1606,7 +1660,10 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                           "description": "Complément d'adresse",
                         },
                         "complete": {
-                          "bsonType": "string",
+                          "bsonType": [
+                            "string",
+                            "null",
+                          ],
                           "description": "Adresse complète",
                         },
                         "departement": {
@@ -2083,14 +2140,30 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                         "description": "Code Bassin d'emploi",
                       },
                       "code_insee": {
-                        "bsonType": "string",
+                        "anyOf": [
+                          {
+                            "bsonType": "string",
+                            "description": "Le code insee doit contenir 5 caractères",
+                            "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
+                          },
+                          {
+                            "bsonType": "null",
+                          },
+                        ],
                         "description": "Le code insee doit contenir 5 caractères",
-                        "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
                       },
                       "code_postal": {
-                        "bsonType": "string",
+                        "anyOf": [
+                          {
+                            "bsonType": "string",
+                            "description": "Le code postal doit contenir 5 caractères",
+                            "pattern": "^[0-9]{5}$",
+                          },
+                          {
+                            "bsonType": "null",
+                          },
+                        ],
                         "description": "Le code postal doit contenir 5 caractères",
-                        "pattern": "^[0-9]{5}$",
                       },
                       "commune": {
                         "bsonType": "string",
@@ -2102,7 +2175,10 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                         "description": "Complément d'adresse",
                       },
                       "complete": {
-                        "bsonType": "string",
+                        "bsonType": [
+                          "string",
+                          "null",
+                        ],
                         "description": "Adresse complète",
                       },
                       "departement": {
@@ -2351,7 +2427,15 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                 "description": "Cause de rupture du contrat",
               },
               "date_debut": {
-                "bsonType": "date",
+                "anyOf": [
+                  {
+                    "bsonType": "date",
+                    "description": "Date de début du contrat",
+                  },
+                  {
+                    "bsonType": "null",
+                  },
+                ],
                 "description": "Date de début du contrat",
               },
               "date_fin": {
@@ -2454,9 +2538,6 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                 "description": "Le type d'employeur doit être en adéquation avec son statut juridique.",
               },
             },
-            "required": [
-              "date_debut",
-            ],
           },
         },
         {
@@ -3519,14 +3600,30 @@ exports[`validation-schema > should create validation schema for effectifsArchiv
                   "description": "Code Bassin d'emploi",
                 },
                 "code_insee": {
-                  "bsonType": "string",
+                  "anyOf": [
+                    {
+                      "bsonType": "string",
+                      "description": "Le code insee doit contenir 5 caractères",
+                      "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
+                    },
+                    {
+                      "bsonType": "null",
+                    },
+                  ],
                   "description": "Le code insee doit contenir 5 caractères",
-                  "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
                 },
                 "code_postal": {
-                  "bsonType": "string",
+                  "anyOf": [
+                    {
+                      "bsonType": "string",
+                      "description": "Le code postal doit contenir 5 caractères",
+                      "pattern": "^[0-9]{5}$",
+                    },
+                    {
+                      "bsonType": "null",
+                    },
+                  ],
                   "description": "Le code postal doit contenir 5 caractères",
-                  "pattern": "^[0-9]{5}$",
                 },
                 "commune": {
                   "bsonType": "string",
@@ -3538,7 +3635,10 @@ exports[`validation-schema > should create validation schema for effectifsArchiv
                   "description": "Complément d'adresse",
                 },
                 "complete": {
-                  "bsonType": "string",
+                  "bsonType": [
+                    "string",
+                    "null",
+                  ],
                   "description": "Adresse complète",
                 },
                 "departement": {
@@ -3801,14 +3901,30 @@ exports[`validation-schema > should create validation schema for effectifsArchiv
                   "description": "Code Bassin d'emploi",
                 },
                 "code_insee": {
-                  "bsonType": "string",
+                  "anyOf": [
+                    {
+                      "bsonType": "string",
+                      "description": "Le code insee doit contenir 5 caractères",
+                      "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
+                    },
+                    {
+                      "bsonType": "null",
+                    },
+                  ],
                   "description": "Le code insee doit contenir 5 caractères",
-                  "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
                 },
                 "code_postal": {
-                  "bsonType": "string",
+                  "anyOf": [
+                    {
+                      "bsonType": "string",
+                      "description": "Le code postal doit contenir 5 caractères",
+                      "pattern": "^[0-9]{5}$",
+                    },
+                    {
+                      "bsonType": "null",
+                    },
+                  ],
                   "description": "Le code postal doit contenir 5 caractères",
-                  "pattern": "^[0-9]{5}$",
                 },
                 "commune": {
                   "bsonType": "string",
@@ -3820,7 +3936,10 @@ exports[`validation-schema > should create validation schema for effectifsArchiv
                   "description": "Complément d'adresse",
                 },
                 "complete": {
-                  "bsonType": "string",
+                  "bsonType": [
+                    "string",
+                    "null",
+                  ],
                   "description": "Adresse complète",
                 },
                 "departement": {
@@ -4425,14 +4544,30 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                           "description": "Code Bassin d'emploi",
                         },
                         "code_insee": {
-                          "bsonType": "string",
+                          "anyOf": [
+                            {
+                              "bsonType": "string",
+                              "description": "Le code insee doit contenir 5 caractères",
+                              "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
+                            },
+                            {
+                              "bsonType": "null",
+                            },
+                          ],
                           "description": "Le code insee doit contenir 5 caractères",
-                          "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
                         },
                         "code_postal": {
-                          "bsonType": "string",
+                          "anyOf": [
+                            {
+                              "bsonType": "string",
+                              "description": "Le code postal doit contenir 5 caractères",
+                              "pattern": "^[0-9]{5}$",
+                            },
+                            {
+                              "bsonType": "null",
+                            },
+                          ],
                           "description": "Le code postal doit contenir 5 caractères",
-                          "pattern": "^[0-9]{5}$",
                         },
                         "commune": {
                           "bsonType": "string",
@@ -4444,7 +4579,10 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                           "description": "Complément d'adresse",
                         },
                         "complete": {
-                          "bsonType": "string",
+                          "bsonType": [
+                            "string",
+                            "null",
+                          ],
                           "description": "Adresse complète",
                         },
                         "departement": {
@@ -4921,14 +5059,30 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                         "description": "Code Bassin d'emploi",
                       },
                       "code_insee": {
-                        "bsonType": "string",
+                        "anyOf": [
+                          {
+                            "bsonType": "string",
+                            "description": "Le code insee doit contenir 5 caractères",
+                            "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
+                          },
+                          {
+                            "bsonType": "null",
+                          },
+                        ],
                         "description": "Le code insee doit contenir 5 caractères",
-                        "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
                       },
                       "code_postal": {
-                        "bsonType": "string",
+                        "anyOf": [
+                          {
+                            "bsonType": "string",
+                            "description": "Le code postal doit contenir 5 caractères",
+                            "pattern": "^[0-9]{5}$",
+                          },
+                          {
+                            "bsonType": "null",
+                          },
+                        ],
                         "description": "Le code postal doit contenir 5 caractères",
-                        "pattern": "^[0-9]{5}$",
                       },
                       "commune": {
                         "bsonType": "string",
@@ -4940,7 +5094,10 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                         "description": "Complément d'adresse",
                       },
                       "complete": {
-                        "bsonType": "string",
+                        "bsonType": [
+                          "string",
+                          "null",
+                        ],
                         "description": "Adresse complète",
                       },
                       "departement": {
@@ -5189,7 +5346,15 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                 "description": "Cause de rupture du contrat",
               },
               "date_debut": {
-                "bsonType": "date",
+                "anyOf": [
+                  {
+                    "bsonType": "date",
+                    "description": "Date de début du contrat",
+                  },
+                  {
+                    "bsonType": "null",
+                  },
+                ],
                 "description": "Date de début du contrat",
               },
               "date_fin": {
@@ -5292,9 +5457,6 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                 "description": "Le type d'employeur doit être en adéquation avec son statut juridique.",
               },
             },
-            "required": [
-              "date_debut",
-            ],
           },
         },
         {
@@ -6105,14 +6267,30 @@ exports[`validation-schema > should create validation schema for effectifsDECA >
                   "description": "Code Bassin d'emploi",
                 },
                 "code_insee": {
-                  "bsonType": "string",
+                  "anyOf": [
+                    {
+                      "bsonType": "string",
+                      "description": "Le code insee doit contenir 5 caractères",
+                      "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
+                    },
+                    {
+                      "bsonType": "null",
+                    },
+                  ],
                   "description": "Le code insee doit contenir 5 caractères",
-                  "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
                 },
                 "code_postal": {
-                  "bsonType": "string",
+                  "anyOf": [
+                    {
+                      "bsonType": "string",
+                      "description": "Le code postal doit contenir 5 caractères",
+                      "pattern": "^[0-9]{5}$",
+                    },
+                    {
+                      "bsonType": "null",
+                    },
+                  ],
                   "description": "Le code postal doit contenir 5 caractères",
-                  "pattern": "^[0-9]{5}$",
                 },
                 "commune": {
                   "bsonType": "string",
@@ -6124,7 +6302,10 @@ exports[`validation-schema > should create validation schema for effectifsDECA >
                   "description": "Complément d'adresse",
                 },
                 "complete": {
-                  "bsonType": "string",
+                  "bsonType": [
+                    "string",
+                    "null",
+                  ],
                   "description": "Adresse complète",
                 },
                 "departement": {
@@ -6718,14 +6899,30 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                           "description": "Code Bassin d'emploi",
                         },
                         "code_insee": {
-                          "bsonType": "string",
+                          "anyOf": [
+                            {
+                              "bsonType": "string",
+                              "description": "Le code insee doit contenir 5 caractères",
+                              "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
+                            },
+                            {
+                              "bsonType": "null",
+                            },
+                          ],
                           "description": "Le code insee doit contenir 5 caractères",
-                          "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
                         },
                         "code_postal": {
-                          "bsonType": "string",
+                          "anyOf": [
+                            {
+                              "bsonType": "string",
+                              "description": "Le code postal doit contenir 5 caractères",
+                              "pattern": "^[0-9]{5}$",
+                            },
+                            {
+                              "bsonType": "null",
+                            },
+                          ],
                           "description": "Le code postal doit contenir 5 caractères",
-                          "pattern": "^[0-9]{5}$",
                         },
                         "commune": {
                           "bsonType": "string",
@@ -6737,7 +6934,10 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                           "description": "Complément d'adresse",
                         },
                         "complete": {
-                          "bsonType": "string",
+                          "bsonType": [
+                            "string",
+                            "null",
+                          ],
                           "description": "Adresse complète",
                         },
                         "departement": {
@@ -7188,14 +7388,30 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                         "description": "Code Bassin d'emploi",
                       },
                       "code_insee": {
-                        "bsonType": "string",
+                        "anyOf": [
+                          {
+                            "bsonType": "string",
+                            "description": "Le code insee doit contenir 5 caractères",
+                            "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
+                          },
+                          {
+                            "bsonType": "null",
+                          },
+                        ],
                         "description": "Le code insee doit contenir 5 caractères",
-                        "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
                       },
                       "code_postal": {
-                        "bsonType": "string",
+                        "anyOf": [
+                          {
+                            "bsonType": "string",
+                            "description": "Le code postal doit contenir 5 caractères",
+                            "pattern": "^[0-9]{5}$",
+                          },
+                          {
+                            "bsonType": "null",
+                          },
+                        ],
                         "description": "Le code postal doit contenir 5 caractères",
-                        "pattern": "^[0-9]{5}$",
                       },
                       "commune": {
                         "bsonType": "string",
@@ -7207,7 +7423,10 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                         "description": "Complément d'adresse",
                       },
                       "complete": {
-                        "bsonType": "string",
+                        "bsonType": [
+                          "string",
+                          "null",
+                        ],
                         "description": "Adresse complète",
                       },
                       "departement": {
@@ -7456,7 +7675,15 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                 "description": "Cause de rupture du contrat",
               },
               "date_debut": {
-                "bsonType": "date",
+                "anyOf": [
+                  {
+                    "bsonType": "date",
+                    "description": "Date de début du contrat",
+                  },
+                  {
+                    "bsonType": "null",
+                  },
+                ],
                 "description": "Date de début du contrat",
               },
               "date_fin": {
@@ -7535,9 +7762,6 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
                 ],
               },
             },
-            "required": [
-              "date_debut",
-            ],
           },
         },
         {
@@ -8302,12 +8526,24 @@ Pour les jeunes résidents à l’étranger, il conviendra de mettre « 99 » su
             "bsonType": "object",
             "properties": {
               "message": {
+                "bsonType": "string",
                 "description": "message d'erreur",
               },
               "path": {
+                "bsonType": "array",
                 "description": "champ en erreur",
+                "items": {
+                  "bsonType": [
+                    "string",
+                    "number",
+                  ],
+                },
               },
             },
+            "required": [
+              "message",
+              "path",
+            ],
           },
         },
         {
@@ -9860,14 +10096,30 @@ exports[`validation-schema > should create validation schema for organismes > or
           "description": "Code Bassin d'emploi",
         },
         "code_insee": {
-          "bsonType": "string",
+          "anyOf": [
+            {
+              "bsonType": "string",
+              "description": "Le code insee doit contenir 5 caractères",
+              "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
+            },
+            {
+              "bsonType": "null",
+            },
+          ],
           "description": "Le code insee doit contenir 5 caractères",
-          "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
         },
         "code_postal": {
-          "bsonType": "string",
+          "anyOf": [
+            {
+              "bsonType": "string",
+              "description": "Le code postal doit contenir 5 caractères",
+              "pattern": "^[0-9]{5}$",
+            },
+            {
+              "bsonType": "null",
+            },
+          ],
           "description": "Le code postal doit contenir 5 caractères",
-          "pattern": "^[0-9]{5}$",
         },
         "commune": {
           "bsonType": "string",
@@ -9879,7 +10131,10 @@ exports[`validation-schema > should create validation schema for organismes > or
           "description": "Complément d'adresse",
         },
         "complete": {
-          "bsonType": "string",
+          "bsonType": [
+            "string",
+            "null",
+          ],
           "description": "Adresse complète",
         },
         "departement": {
@@ -10886,14 +11141,30 @@ exports[`validation-schema > should create validation schema for organismes > or
                       "description": "Code Bassin d'emploi",
                     },
                     "code_insee": {
-                      "bsonType": "string",
+                      "anyOf": [
+                        {
+                          "bsonType": "string",
+                          "description": "Le code insee doit contenir 5 caractères",
+                          "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
+                        },
+                        {
+                          "bsonType": "null",
+                        },
+                      ],
                       "description": "Le code insee doit contenir 5 caractères",
-                      "pattern": "^[0-9]{1}[0-9A-Z]{1}[0-9]{3}$",
                     },
                     "code_postal": {
-                      "bsonType": "string",
+                      "anyOf": [
+                        {
+                          "bsonType": "string",
+                          "description": "Le code postal doit contenir 5 caractères",
+                          "pattern": "^[0-9]{5}$",
+                        },
+                        {
+                          "bsonType": "null",
+                        },
+                      ],
                       "description": "Le code postal doit contenir 5 caractères",
-                      "pattern": "^[0-9]{5}$",
                     },
                     "commune": {
                       "bsonType": "string",
@@ -10905,7 +11176,10 @@ exports[`validation-schema > should create validation schema for organismes > or
                       "description": "Complément d'adresse",
                     },
                     "complete": {
-                      "bsonType": "string",
+                      "bsonType": [
+                        "string",
+                        "null",
+                      ],
                       "description": "Adresse complète",
                     },
                     "departement": {

--- a/server/src/common/validation/contratsDossierApprenantSchemaV3.ts
+++ b/server/src/common/validation/contratsDossierApprenantSchemaV3.ts
@@ -1,11 +1,7 @@
-import { DossierApprenantSchemaV3BaseWithApiDataType } from "shared/models/parts/dossierApprenantSchemaV3";
+import { IDossierApprenantSchemaV3 } from "shared/models/parts/dossierApprenantSchemaV3";
 import { z, ZodIssueCode } from "zod";
 
-export const validateContrat = (
-  contrat: DossierApprenantSchemaV3BaseWithApiDataType,
-  suffix: string,
-  ctx: z.RefinementCtx
-) => {
+export const validateContrat = (contrat: IDossierApprenantSchemaV3, suffix: string, ctx: z.RefinementCtx) => {
   const withSuffix = (str: string) => `${str}${suffix}`;
   const contrat_date_fin = withSuffix("contrat_date_fin");
   const cause_rupture_contrat = withSuffix("cause_rupture_contrat");

--- a/server/src/common/validation/dossierApprenantSchemaV1V2.ts
+++ b/server/src/common/validation/dossierApprenantSchemaV1V2.ts
@@ -6,45 +6,45 @@ import { z } from "zod";
  * Les données entrantes de l'API V1 sont validées par dossierApprenantSchema (Joi).
  * @returns
  */
-const dossierApprenantSchemaV1V2 = () =>
-  z.object({
-    // REQUIRED FIELDS
-    nom_apprenant: primitivesV1.apprenant.nom,
-    prenom_apprenant: primitivesV1.apprenant.prenom,
-    date_de_naissance_apprenant: primitivesV1.apprenant.date_de_naissance,
-    uai_etablissement: primitivesV1.etablissement_responsable.uai,
-    nom_etablissement: primitivesV1.etablissement_responsable.nom,
-    id_formation: primitivesV1.formation.code_cfd,
-    annee_scolaire: primitivesV1.formation.annee_scolaire,
-    statut_apprenant: primitivesV1.apprenant.statut,
-    date_metier_mise_a_jour_statut: primitivesV1.apprenant.date_metier_mise_a_jour_statut,
-    id_erp_apprenant: primitivesV1.apprenant.id_erp,
-    source: primitivesV1.source,
+const dossierApprenantSchemaV1V2 = z.object({
+  // REQUIRED FIELDS
+  nom_apprenant: primitivesV1.apprenant.nom,
+  prenom_apprenant: primitivesV1.apprenant.prenom,
+  date_de_naissance_apprenant: primitivesV1.apprenant.date_de_naissance,
+  uai_etablissement: primitivesV1.etablissement_responsable.uai,
+  nom_etablissement: primitivesV1.etablissement_responsable.nom,
+  id_formation: primitivesV1.formation.code_cfd,
+  annee_scolaire: primitivesV1.formation.annee_scolaire,
+  statut_apprenant: primitivesV1.apprenant.statut,
+  date_metier_mise_a_jour_statut: primitivesV1.apprenant.date_metier_mise_a_jour_statut,
+  id_erp_apprenant: primitivesV1.apprenant.id_erp,
+  source: primitivesV1.source,
 
-    // OPTIONAL FIELDS
-    api_version: primitivesV1.api_version.optional(),
-    ine_apprenant: primitivesV1.apprenant.ine.optional(),
-    email_contact: primitivesV1.apprenant.email.optional(),
-    tel_apprenant: primitivesV1.apprenant.telephone.nullish(),
-    code_commune_insee_apprenant: primitivesV1.apprenant.code_commune_insee.optional(),
-    siret_etablissement: primitivesV1.etablissement_responsable.siret.optional(),
-    libelle_court_formation: primitivesV1.formation.libelle_court.optional(),
-    libelle_long_formation: primitivesV1.formation.libelle_long.optional(),
-    periode_formation: primitivesV1.formation.periode.nullish(),
-    annee_formation: primitivesV1.formation.annee.optional(),
-    formation_rncp: primitivesV1.formation.code_rncp.optional(),
-    contrat_date_debut: primitivesV1.contrat.date_debut.optional(),
-    contrat_date_fin: primitivesV1.contrat.date_fin.optional(),
-    contrat_date_rupture: primitivesV1.contrat.date_rupture.optional(),
-    user_erp_id: primitivesV1.user_erp_id.optional(),
+  // OPTIONAL FIELDS
+  api_version: primitivesV1.api_version.optional(),
+  ine_apprenant: primitivesV1.apprenant.ine.optional(),
+  email_contact: primitivesV1.apprenant.email.optional(),
+  tel_apprenant: primitivesV1.apprenant.telephone.nullish(),
+  code_commune_insee_apprenant: primitivesV1.apprenant.code_commune_insee.optional(),
+  siret_etablissement: primitivesV1.etablissement_responsable.siret.optional(),
+  libelle_court_formation: primitivesV1.formation.libelle_court.optional(),
+  libelle_long_formation: primitivesV1.formation.libelle_long.optional(),
+  periode_formation: primitivesV1.formation.periode.nullish(),
+  annee_formation: primitivesV1.formation.annee.optional(),
+  formation_rncp: primitivesV1.formation.code_rncp.optional(),
+  contrat_date_debut: primitivesV1.contrat.date_debut.optional(),
+  contrat_date_fin: primitivesV1.contrat.date_fin.optional(),
+  contrat_date_rupture: primitivesV1.contrat.date_rupture.optional(),
+  user_erp_id: primitivesV1.user_erp_id.optional(),
 
-    // OPTIONAL V2 BUT REQUIRED V3
+  // OPTIONAL V2 BUT REQUIRED V3
 
-    date_inscription_formation: primitivesV3.formation.date_inscription.optional(),
-    date_entree_formation: primitivesV3.formation.date_entree.optional(),
-    date_fin_formation: primitivesV3.formation.date_fin.optional(),
-  });
+  date_inscription_formation: primitivesV3.formation.date_inscription.optional(),
+  date_entree_formation: primitivesV3.formation.date_entree.optional(),
+  date_fin_formation: primitivesV3.formation.date_fin.optional(),
+});
 
-export type DossierApprenantSchemaV1V2ZodType = z.input<ReturnType<typeof dossierApprenantSchemaV1V2>>;
+export type DossierApprenantSchemaV1V2ZodType = z.output<typeof dossierApprenantSchemaV1V2>;
+export type DossierApprenantSchemaV1V2ZodTypeInput = z.input<typeof dossierApprenantSchemaV1V2>;
 
 export default dossierApprenantSchemaV1V2;

--- a/server/src/http/routes/specific.routes/dossiers-apprenants.routes.ts
+++ b/server/src/http/routes/specific.routes/dossiers-apprenants.routes.ts
@@ -27,8 +27,8 @@ export default () => {
       await Joi.array().max(POST_DOSSIERS_APPRENANTS_MAX_INPUT_LENGTH).validateAsync(body, { abortEarly: false })
     ).map((e) => stripNullProperties(e));
     const isV3 = originalUrl.includes("/v3");
-    const v2Schema = dossierApprenantSchemaV1V2();
-    const v3Schema = dossierApprenantSchemaV3Input();
+    const v2Schema = dossierApprenantSchemaV1V2;
+    const v3Schema = dossierApprenantSchemaV3Input;
     const validationSchema = isV3 ? v3Schema : v2Schema;
 
     const source = user.source;

--- a/server/src/jobs/hydrate/open-api/schema.ts
+++ b/server/src/jobs/hydrate/open-api/schema.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import dossierApprenantSchema from "@/common/validation/dossierApprenantSchemaV1V2";
 import loginSchemaLegacy from "@/common/validation/loginSchemaLegacy";
 
-const dossierApprenantSchemaWithErrors = dossierApprenantSchema().extend({
+const dossierApprenantSchemaWithErrors = dossierApprenantSchema.extend({
   validation_errors: z
     .array(
       z.object({
@@ -25,7 +25,7 @@ const dossierApprenantSchemaWithErrors = dossierApprenantSchema().extend({
     .openapi({ description: "Erreurs de validation de cet effectif" }),
 });
 
-const dossierApprenantSchemaV3WithErrors = dossierApprenantSchemaV3Base().extend({
+const dossierApprenantSchemaV3WithErrors = dossierApprenantSchemaV3Base.extend({
   validation_errors: z
     .array(
       z.object({
@@ -142,7 +142,7 @@ const dossierApprenantPostRoute: Omit<RouteConfig, "path"> = {
       required: true,
       content: {
         "application/json": {
-          schema: z.array(dossierApprenantSchema()),
+          schema: z.array(dossierApprenantSchema),
         },
       },
     },
@@ -188,7 +188,7 @@ registry.registerPath({
       required: true,
       content: {
         "application/json": {
-          schema: z.array(dossierApprenantSchemaV3Base().omit({ has_nir: true })),
+          schema: z.array(dossierApprenantSchemaV3Base.omit({ has_nir: true })),
         },
       },
     },

--- a/server/tests/data/randomizedSample.ts
+++ b/server/tests/data/randomizedSample.ts
@@ -5,11 +5,11 @@ import RandExp from "randexp";
 import { CODES_STATUT_APPRENANT, CFD_REGEX, INE_REGEX, RNCP_REGEX, SOURCE_APPRENANT } from "shared";
 import { IEffectif } from "shared/models/data/effectifs.model";
 import { IOrganisme } from "shared/models/data/organismes.model";
-import { DossierApprenantSchemaV3ZodType } from "shared/models/parts/dossierApprenantSchemaV3";
+import { IDossierApprenantSchemaV3 } from "shared/models/parts/dossierApprenantSchemaV3";
 import type { PartialDeep } from "type-fest";
 
 import { addComputedFields } from "@/common/actions/effectifs.actions";
-import { DossierApprenantSchemaV1V2ZodType } from "@/common/validation/dossierApprenantSchemaV1V2";
+import { type DossierApprenantSchemaV1V2ZodTypeInput } from "@/common/validation/dossierApprenantSchemaV1V2";
 
 import sampleEtablissements, { SampleEtablissement } from "./sampleEtablissements";
 import { sampleLibelles } from "./sampleLibelles";
@@ -129,8 +129,8 @@ export const createSampleEffectif = async ({
 };
 
 export const createRandomDossierApprenantApiInput = (
-  params: Partial<DossierApprenantSchemaV1V2ZodType> = {}
-): DossierApprenantSchemaV1V2ZodType => {
+  params: Partial<DossierApprenantSchemaV1V2ZodTypeInput> = {}
+): DossierApprenantSchemaV1V2ZodTypeInput => {
   const annee_scolaire = getRandomAnneeScolaire();
   const { uai, siret } = getRandomEtablissement();
   const formation = createRandomFormation(annee_scolaire);
@@ -163,7 +163,7 @@ export const createRandomDossierApprenantApiInput = (
   };
 };
 
-export const createRandomDossierApprenantApiInputV3 = (params?: Partial<DossierApprenantSchemaV3ZodType>) => {
+export const createRandomDossierApprenantApiInputV3 = (params?: Partial<IDossierApprenantSchemaV3>) => {
   const anneeScolaire = getRandomAnneeScolaire();
   const date_inscription_formation = new Date(new Date().setFullYear(parseInt(anneeScolaire.split("-")[0]), 8, 1));
   const date_entree_formation = new Date(date_inscription_formation);

--- a/server/tests/integration/jobs/ingestion/process-ingestion.test.ts
+++ b/server/tests/integration/jobs/ingestion/process-ingestion.test.ts
@@ -21,12 +21,12 @@ const SIRET = "77937827200016";
 
 const UAI_REFERENTIEL_FERME = "4422672E";
 const SIRET_REFERENTIEL_FERME = "44370584100099";
-
+188;
 const UAI_RESPONSABLE = "0755805C";
 const SIRET_RESPONSABLE = "77568013501139";
 
 const ORGANISME_SOURCE_ID = getRandomSourceOrganismeId();
-const sortByPath = (array: { path?: string[] }[] | undefined | null) =>
+const sortByPath = (array: { path?: Array<string | number> }[] | undefined | null) =>
   array?.sort((a, b) => ((a?.path?.[0] || "") < (b?.path?.[0] || "") ? -1 : 1));
 
 describe("Processus d'ingestion", () => {
@@ -209,8 +209,21 @@ describe("Processus d'ingestion", () => {
               academie: "02",
               region: "93",
               mission_locale_id: 211,
+              complete: null,
             },
-            adresse_naissance: {},
+            adresse_naissance: {
+              code_insee: null,
+              code_postal: null,
+            },
+            responsable_mail1: null,
+            responsable_mail2: null,
+            rqth: null,
+            sexe: null,
+            type_cfa: null,
+            date_rqth: null,
+            dernier_organisme_uai: null,
+            derniere_situation: null,
+            has_nir: null,
           },
           contrats: [],
           formation: {
@@ -222,6 +235,16 @@ describe("Processus d'ingestion", () => {
             niveau: "3",
             niveau_libelle: "3 (CAP...)",
             rncp: "RNCP34670", // RNCP associé au CFD
+            cause_exclusion: null,
+            date_entree: null,
+            date_exclusion: null,
+            date_fin: null,
+            date_inscription: null,
+            date_obtention_diplome: null,
+            duree_theorique_mois: null,
+            formation_presentielle: null,
+            obtention_diplome: null,
+            referent_handicap: null,
           },
           id_erp_apprenant: "9a890d67-e233-46d5-8611-06d6648e7611",
           is_lock: {
@@ -264,12 +287,24 @@ describe("Processus d'ingestion", () => {
           updated_at: expect.any(Date),
           transmitted_at: expect.any(Date),
           organisme_id: expect.any(ObjectId),
+          source_organisme_id: null,
           _raw: {
             formation: {
               annee: 0,
               cfd: "50033610",
               libelle_long: "TECHNICIEN D'ETUDES DU BATIMENT OPTION A : ETUDES ET ECONOMIE (BAC PRO)",
               periode: [2021, 2023],
+              cause_exclusion: null,
+              date_entree: null,
+              date_exclusion: null,
+              date_fin: null,
+              date_inscription: null,
+              date_obtention_diplome: null,
+              duree_theorique_mois: null,
+              formation_presentielle: null,
+              obtention_diplome: null,
+              referent_handicap: null,
+              rncp: null,
             },
           },
           _computed: {
@@ -682,6 +717,7 @@ describe("Processus d'ingestion", () => {
                 prenom: "John",
               },
               rncp: "RNCP5364",
+              libelle_long: null,
             },
           },
           _computed: {
@@ -758,8 +794,16 @@ describe("Processus d'ingestion", () => {
         expect(insertedDossier).toStrictEqual({
           _id: effectifForInput?._id,
           apprenant: {
-            adresse: {},
-            adresse_naissance: {},
+            adresse: {
+              code_insee: null,
+              code_postal: null,
+              complete: null,
+            },
+            adresse_naissance: {
+              code_insee: null,
+              code_postal: null,
+            },
+            courriel: null,
             historique_statut: [
               {
                 valeur_statut: 2,
@@ -770,6 +814,17 @@ describe("Processus d'ingestion", () => {
             nom: "DOE",
             prenom: "John",
             date_de_naissance: new Date("2000-10-28T00:00:00.000Z"),
+            responsable_mail1: null,
+            responsable_mail2: null,
+            rqth: null,
+            sexe: null,
+            telephone: null,
+            type_cfa: null,
+            ine: null,
+            date_rqth: null,
+            dernier_organisme_uai: null,
+            derniere_situation: null,
+            has_nir: null,
           },
           contrats: [],
           formation: {
@@ -786,6 +841,12 @@ describe("Processus d'ingestion", () => {
             duree_formation_relle: 10,
             date_fin: new Date("2022-06-30T00:00:00.000Z"),
             date_entree: new Date("2021-09-01T00:00:00.000Z"),
+            cause_exclusion: null,
+            date_exclusion: null,
+            date_obtention_diplome: null,
+            formation_presentielle: null,
+            obtention_diplome: null,
+            referent_handicap: null,
           },
           is_lock: expect.any(Object),
           lieu_de_formation: {
@@ -805,6 +866,14 @@ describe("Processus d'ingestion", () => {
               duree_theorique_mois: 24,
               periode: [],
               rncp: "RNCP5364",
+              cfd: null,
+              cause_exclusion: null,
+              date_exclusion: null,
+              date_obtention_diplome: null,
+              formation_presentielle: null,
+              libelle_long: null,
+              obtention_diplome: null,
+              referent_handicap: null,
             },
           },
           _computed: {
@@ -957,8 +1026,15 @@ describe("Processus d'ingestion", () => {
         expect(insertedDossier).toStrictEqual({
           _id: effectifForInput?._id,
           apprenant: {
-            adresse: {},
-            adresse_naissance: {},
+            adresse: {
+              code_insee: null,
+              code_postal: null,
+              complete: null,
+            },
+            adresse_naissance: {
+              code_insee: null,
+              code_postal: null,
+            },
             historique_statut: [
               {
                 valeur_statut: 2,
@@ -971,6 +1047,16 @@ describe("Processus d'ingestion", () => {
             date_de_naissance: new Date("2000-10-28T00:00:00.000Z"),
             has_nir: true,
             sexe: "F",
+            courriel: null,
+            date_rqth: null,
+            dernier_organisme_uai: null,
+            derniere_situation: null,
+            ine: null,
+            responsable_mail1: null,
+            responsable_mail2: null,
+            rqth: null,
+            telephone: null,
+            type_cfa: null,
           },
           contrats: [],
           formation: {
@@ -987,6 +1073,12 @@ describe("Processus d'ingestion", () => {
             duree_theorique_mois: 24,
             date_fin: new Date("2022-06-30T00:00:00.000Z"),
             date_entree: new Date("2021-09-01T00:00:00.000Z"),
+            cause_exclusion: null,
+            date_exclusion: null,
+            date_obtention_diplome: null,
+            formation_presentielle: null,
+            obtention_diplome: null,
+            referent_handicap: null,
           },
           is_lock: expect.any(Object),
           lieu_de_formation: {
@@ -1006,6 +1098,14 @@ describe("Processus d'ingestion", () => {
               duree_theorique_mois: 24,
               periode: [],
               rncp: "RNCP34670",
+              cause_exclusion: null,
+              cfd: null,
+              date_exclusion: null,
+              date_obtention_diplome: null,
+              formation_presentielle: null,
+              libelle_long: null,
+              obtention_diplome: null,
+              referent_handicap: null,
             },
           },
           _computed: {
@@ -1334,7 +1434,7 @@ describe("Processus d'ingestion", () => {
     });
 
     describe("Ingestion de mises à jour de données invalides", () => {
-      const commonSampleData: WithoutId<IEffectifQueue> = {
+      const commonSampleData = {
         ine_apprenant: "772957826QH",
         nom_apprenant: "MBAPPE",
         prenom_apprenant: "Kylian",

--- a/shared/constants/dossierApprenant.ts
+++ b/shared/constants/dossierApprenant.ts
@@ -1,3 +1,7 @@
+import { z } from "zod";
+
+import { zodOpenApi } from "../models/zodOpenApi";
+
 /**
  * Codes des statuts des apprenants
  */
@@ -7,11 +11,26 @@ export const CODES_STATUT_APPRENANT = {
   abandon: 0,
 } as const;
 
+export const zCodeStatutApprenant = zodOpenApi.union(
+  [
+    z.literal(CODES_STATUT_APPRENANT.abandon),
+    z.literal(CODES_STATUT_APPRENANT.inscrit),
+    z.literal(CODES_STATUT_APPRENANT.apprenti),
+  ],
+  {
+    errorMap: () => ({
+      message: "Valeurs possibles: 0,2,3",
+    }),
+  }
+);
+
+export type ICodeStatutApprenant = z.output<typeof zCodeStatutApprenant>;
+
 export const CODES_STATUT_APPRENANT_ENUM = [
   CODES_STATUT_APPRENANT.abandon,
   CODES_STATUT_APPRENANT.inscrit,
   CODES_STATUT_APPRENANT.apprenti,
-];
+] satisfies ICodeStatutApprenant[];
 
 export const STATUT_APPRENANT_LABEL_MAP = {
   [CODES_STATUT_APPRENANT.abandon]: { label: "Abandon", color: "#FCEEAC" },
@@ -41,9 +60,72 @@ export const getStatutApprenantNameFromCode = (
 ) => LABELS_STATUT_APPRENANT.find((item) => item.code === statutCode)?.name ?? "NC";
 
 // Liste des codes de dernière situation tels que définis par SIFA
-export const EFFECTIF_DERNIER_SITUATION = [
-  1003, 1005, 1009, 1017, 1019, 1021, 1023, 2001, 2003, 2005, 2007, 3001, 3101, 3003, 3103, 3009, 3109, 3011, 3111,
-  3031, 3131, 3032, 3132, 3033, 3133, 3117, 3119, 3021, 3121, 3023, 3123, 4001, 4101, 4003, 4103, 4005, 4105, 4007,
-  4107, 4009, 4011, 4111, 4013, 4113, 4015, 4115, 4017, 4117, 4019, 4119, 4021, 4121, 4023, 4123, 4025, 4125, 4027,
-  4127, 5901, 5903, 5905, 5907, 5909, 9900, 9999,
-] as const;
+export const zEffectifDernierSituation = zodOpenApi.union([
+  z.literal(1003),
+  z.literal(1005),
+  z.literal(1009),
+  z.literal(1017),
+  z.literal(1019),
+  z.literal(1021),
+  z.literal(1023),
+  z.literal(2001),
+  z.literal(2003),
+  z.literal(2005),
+  z.literal(2007),
+  z.literal(3001),
+  z.literal(3101),
+  z.literal(3003),
+  z.literal(3103),
+  z.literal(3009),
+  z.literal(3109),
+  z.literal(3011),
+  z.literal(3111),
+  z.literal(3031),
+  z.literal(3131),
+  z.literal(3032),
+  z.literal(3132),
+  z.literal(3033),
+  z.literal(3133),
+  z.literal(3117),
+  z.literal(3119),
+  z.literal(3021),
+  z.literal(3121),
+  z.literal(3023),
+  z.literal(3123),
+  z.literal(4001),
+  z.literal(4101),
+  z.literal(4003),
+  z.literal(4103),
+  z.literal(4005),
+  z.literal(4105),
+  z.literal(4007),
+  z.literal(4107),
+  z.literal(4009),
+  z.literal(4011),
+  z.literal(4111),
+  z.literal(4013),
+  z.literal(4113),
+  z.literal(4015),
+  z.literal(4115),
+  z.literal(4017),
+  z.literal(4117),
+  z.literal(4019),
+  z.literal(4119),
+  z.literal(4021),
+  z.literal(4121),
+  z.literal(4023),
+  z.literal(4123),
+  z.literal(4025),
+  z.literal(4125),
+  z.literal(4027),
+  z.literal(4127),
+  z.literal(5901),
+  z.literal(5903),
+  z.literal(5905),
+  z.literal(5907),
+  z.literal(5909),
+  z.literal(9900),
+  z.literal(9999),
+]);
+
+export type IEffectifDernierSituation = z.output<typeof zEffectifDernierSituation>;

--- a/shared/models/data/effectifs/apprenant.part.ts
+++ b/shared/models/data/effectifs/apprenant.part.ts
@@ -1,9 +1,9 @@
 import {
   CODES_STATUT_APPRENANT,
-  EFFECTIF_DERNIER_SITUATION,
   SEXE_APPRENANT_ENUM,
   CODE_POSTAL_REGEX,
   DERNIER_ORGANISME_UAI_REGEX,
+  zEffectifDernierSituation,
 } from "../../../constants";
 import { zodLiteralUnion } from "../../../utils/zodHelper";
 import { zAdresse, zAdresseWithMissionLocale } from "../../parts/adresseSchema";
@@ -103,9 +103,7 @@ export const zApprenant = zodOpenApi.object({
   situation_avant_contrat: zodLiteralUnion([11, 12, 21, 31, 41, 51, 52, 53, 54, 90, 99], {
     description: "Situation de l'apprenant avant le contrat",
   }).nullish(),
-  derniere_situation: zodLiteralUnion(EFFECTIF_DERNIER_SITUATION, {
-    description: "Situation de l'apprenant N-1",
-  }).nullish(),
+  derniere_situation: zEffectifDernierSituation.describe("Situation de l'apprenant N-1").nullish(),
   dernier_organisme_uai: zodOpenApi
     .string({
       description: `Numéro UAI de l’établissement fréquenté l’année dernière (N-1), si déjà en apprentissage, mettre l’UAI du site de formation

--- a/shared/models/data/effectifs/contrat.part.ts
+++ b/shared/models/data/effectifs/contrat.part.ts
@@ -51,7 +51,7 @@ export const zContrat = zodOpenApi.object({
     .openapi({ example: 10 })
     .nullish(),
   adresse: zAdresse.nullish(),
-  date_debut: zodOpenApi.date({ description: "Date de début du contrat" }),
+  date_debut: zodOpenApi.date({ description: "Date de début du contrat" }).nullish(),
   date_fin: zodOpenApi.date({ description: "Date de fin du contrat" }).nullish(),
   date_rupture: zodOpenApi.date({ description: "Date de rupture du contrat" }).nullish(),
   cause_rupture: zodOpenApi.string({ description: "Cause de rupture du contrat" }).nullish(),

--- a/shared/models/data/effectifsQueue.model.ts
+++ b/shared/models/data/effectifsQueue.model.ts
@@ -43,14 +43,14 @@ const internalFields = {
   updated_at: z.date({ description: "Date de mise à jour en base de données" }).nullish(),
   created_at: z.date({ description: "Date d'ajout en base de données" }),
   processed_at: z.date({ description: "Date de process des données" }).nullish(),
-  error: z.any({ description: "Erreur rencontrée lors de la création de l'effectif" }).nullish(),
+  error: z.unknown({ description: "Erreur rencontrée lors de la création de l'effectif" }).nullish(),
   api_version: z.string({ description: "Version de l'api utilisée (v2 ou v3)" }).nullish(),
   validation_errors: z
     .array(
       z
         .object({
-          message: z.any({ description: "message d'erreur" }),
-          path: z.any({ description: "champ en erreur" }),
+          message: z.string({ description: "message d'erreur" }),
+          path: z.union([z.string(), z.number()]).array().describe("champ en erreur"),
         })
         .passthrough(),
       {
@@ -69,98 +69,98 @@ const internalFields = {
 const zEffectifQueue = z.object({
   _id: zObjectId,
   // required fields to create an effectif
-  nom_apprenant: z.any({ description: apprenantProps.nom.description }),
-  prenom_apprenant: z.any({ description: apprenantProps.prenom.description }),
-  date_de_naissance_apprenant: z.any({ description: apprenantProps.date_de_naissance.description }),
-  uai_etablissement: z.any({ description: organismeProps.uai.description }), // This field is missing in V3
-  nom_etablissement: z.any({ description: organismeProps.nom.description }), // This field is missing in V3
-  id_formation: z.any({ description: formationProps.cfd.description }), // This field is missing in V3
-  annee_scolaire: z.any({ description: effectifsProps.annee_scolaire.description }),
-  statut_apprenant: z.any({ description: CODES_STATUT_APPRENANT_ENUM.join(",") }),
-  date_metier_mise_a_jour_statut: z.any(),
-  id_erp_apprenant: z.any({ description: effectifsProps.id_erp_apprenant.description }),
+  nom_apprenant: z.unknown({ description: apprenantProps.nom.description }),
+  prenom_apprenant: z.unknown({ description: apprenantProps.prenom.description }),
+  date_de_naissance_apprenant: z.unknown({ description: apprenantProps.date_de_naissance.description }),
+  uai_etablissement: z.unknown({ description: organismeProps.uai.description }), // This field is missing in V3
+  nom_etablissement: z.unknown({ description: organismeProps.nom.description }), // This field is missing in V3
+  id_formation: z.unknown({ description: formationProps.cfd.description }), // This field is missing in V3
+  annee_scolaire: z.unknown({ description: effectifsProps.annee_scolaire.description }),
+  statut_apprenant: z.unknown({ description: CODES_STATUT_APPRENANT_ENUM.join(",") }),
+  date_metier_mise_a_jour_statut: z.unknown(),
+  id_erp_apprenant: z.unknown({ description: effectifsProps.id_erp_apprenant.description }),
   // Optional fields in effectif
-  ine_apprenant: z.any({ description: apprenantProps.ine.description }),
-  email_contact: z.any({ description: apprenantProps.courriel.description }),
-  tel_apprenant: z.any({ description: apprenantProps.telephone.description }),
-  siret_etablissement: z.any({ description: organismeProps.siret.description }), // This field is missing in V3
-  libelle_court_formation: z.any(), // This field is missing in V3
-  libelle_long_formation: z.any({ description: formationProps.libelle_long.description }), // This field is missing in V3
-  periode_formation: z.any({ description: formationProps.periode.description }), // This field is missing in V3
-  annee_formation: z.any({ description: formationProps.annee.description }),
-  formation_rncp: z.any({ description: formationProps.rncp.description }),
+  ine_apprenant: z.unknown({ description: apprenantProps.ine.description }),
+  email_contact: z.unknown({ description: apprenantProps.courriel.description }),
+  tel_apprenant: z.unknown({ description: apprenantProps.telephone.description }),
+  siret_etablissement: z.unknown({ description: organismeProps.siret.description }), // This field is missing in V3
+  libelle_court_formation: z.unknown(), // This field is missing in V3
+  libelle_long_formation: z.unknown({ description: formationProps.libelle_long.description }), // This field is missing in V3
+  periode_formation: z.unknown({ description: formationProps.periode.description }), // This field is missing in V3
+  annee_formation: z.unknown({ description: formationProps.annee.description }),
+  formation_rncp: z.unknown({ description: formationProps.rncp.description }),
 
-  contrat_date_debut: z.any({ description: contratProps.date_debut.description }),
-  contrat_date_fin: z.any({ description: contratProps.date_fin.description }),
-  contrat_date_rupture: z.any({ description: contratProps.date_rupture.description }),
+  contrat_date_debut: z.unknown({ description: contratProps.date_debut.description }),
+  contrat_date_fin: z.unknown({ description: contratProps.date_fin.description }),
+  contrat_date_rupture: z.unknown({ description: contratProps.date_rupture.description }),
 
   // V3 FIELDS
   // OPTIONAL FIELDS
   has_nir: z.boolean({ description: "Identification nationale securité social" }).nullish(),
-  adresse_apprenant: z.any({ description: "Adresse de l'apprenant" }),
+  adresse_apprenant: z.unknown({ description: "Adresse de l'apprenant" }),
 
-  code_postal_apprenant: z.any({ description: "Code postal de l'apprenant" }),
-  code_postal_de_naissance_apprenant: z.any({ description: apprenantProps.code_postal_de_naissance.description }),
-  code_commune_insee_apprenant: z.any({ description: zAdresse.shape.code_insee.description }),
-  code_commune_insee_de_naissance_apprenant: z.any({
+  code_postal_apprenant: z.unknown({ description: "Code postal de l'apprenant" }),
+  code_postal_de_naissance_apprenant: z.unknown({ description: apprenantProps.code_postal_de_naissance.description }),
+  code_commune_insee_apprenant: z.unknown({ description: zAdresse.shape.code_insee.description }),
+  code_commune_insee_de_naissance_apprenant: z.unknown({
     description: zAdresse.shape.code_insee.description,
   }),
-  sexe_apprenant: z.any({ description: apprenantProps.sexe.description }),
-  rqth_apprenant: z.any({ description: "Reconnaissance de la Qualité de Travailleur Handicapé de l'apprenant" }),
-  date_rqth_apprenant: z.any({ description: "Date de reconnaissance du RQTH de l'apprenant" }),
-  responsable_apprenant_mail1: z.any({ description: "Mail du responsable de l'apprenant" }),
-  responsable_apprenant_mail2: z.any({ description: "Mail du responsable de l'apprenant" }),
-  derniere_situation: z.any({ description: "Situation de l'apprenant N-1" }),
-  dernier_organisme_uai: z.any({
+  sexe_apprenant: z.unknown({ description: apprenantProps.sexe.description }),
+  rqth_apprenant: z.unknown({ description: "Reconnaissance de la Qualité de Travailleur Handicapé de l'apprenant" }),
+  date_rqth_apprenant: z.unknown({ description: "Date de reconnaissance du RQTH de l'apprenant" }),
+  responsable_apprenant_mail1: z.unknown({ description: "Mail du responsable de l'apprenant" }),
+  responsable_apprenant_mail2: z.unknown({ description: "Mail du responsable de l'apprenant" }),
+  derniere_situation: z.unknown({ description: "Situation de l'apprenant N-1" }),
+  dernier_organisme_uai: z.unknown({
     description:
       "Numéro UAI de l’établissement fréquenté l’année dernière (N-1), si déjà en apprentissage, mettre l’UAI du site de formation ou département",
   }),
-  type_cfa: z.any({ description: "Type de CFA (nomenclature SIFA)" }),
-  obtention_diplome_formation: z.any(),
-  date_obtention_diplome_formation: z.any({ description: formationProps.date_obtention_diplome.description }),
-  date_exclusion_formation: z.any(),
-  cause_exclusion_formation: z.any(),
-  nom_referent_handicap_formation: z.any(),
-  prenom_referent_handicap_formation: z.any(),
-  email_referent_handicap_formation: z.any(),
-  cause_rupture_contrat: z.any({ description: contratProps.cause_rupture.description }),
-  contrat_date_debut_2: z.any({ description: "Date de début du contrat 2" }),
-  contrat_date_fin_2: z.any({ description: "Date de fin du contrat 2" }),
-  contrat_date_rupture_2: z.any({ description: "Date de rupture du contrat 2" }),
-  cause_rupture_contrat_2: z.any({ description: "Cause de rupture du contrat 2" }),
-  contrat_date_debut_3: z.any({ description: "Date de début du contrat 3" }),
-  contrat_date_fin_3: z.any({ description: "Date de fin du contrat 3" }),
-  contrat_date_rupture_3: z.any({ description: "Date de rupture du contrat 3" }),
-  cause_rupture_contrat_3: z.any({ description: "Cause de rupture du contrat 3" }),
-  contrat_date_debut_4: z.any({ description: "Date de début du contrat 4" }),
-  contrat_date_fin_4: z.any({ description: "Date de fin du contrat 4" }),
-  contrat_date_rupture_4: z.any({ description: "Date de rupture du contrat 4" }),
-  cause_rupture_contrat_4: z.any({ description: "Cause de rupture du contrat 4" }),
-  siret_employeur: z.any({ description: organismeProps.siret.description }),
-  siret_employeur_2: z.any({ description: organismeProps.siret.description }),
-  siret_employeur_3: z.any({ description: organismeProps.siret.description }),
-  siret_employeur_4: z.any({ description: organismeProps.siret.description }),
-  formation_presentielle: z.any({ description: "Formation 100% à distance ou non" }),
-  etablissement_lieu_de_formation_adresse: z.any({ description: "Adresse du lieu de formation" }),
-  etablissement_lieu_de_formation_code_postal: z.any({ description: "Code postal du lieu de formation" }),
+  type_cfa: z.unknown({ description: "Type de CFA (nomenclature SIFA)" }),
+  obtention_diplome_formation: z.unknown(),
+  date_obtention_diplome_formation: z.unknown({ description: formationProps.date_obtention_diplome.description }),
+  date_exclusion_formation: z.unknown(),
+  cause_exclusion_formation: z.unknown(),
+  nom_referent_handicap_formation: z.unknown(),
+  prenom_referent_handicap_formation: z.unknown(),
+  email_referent_handicap_formation: z.unknown(),
+  cause_rupture_contrat: z.unknown({ description: contratProps.cause_rupture.description }),
+  contrat_date_debut_2: z.unknown({ description: "Date de début du contrat 2" }),
+  contrat_date_fin_2: z.unknown({ description: "Date de fin du contrat 2" }),
+  contrat_date_rupture_2: z.unknown({ description: "Date de rupture du contrat 2" }),
+  cause_rupture_contrat_2: z.unknown({ description: "Cause de rupture du contrat 2" }),
+  contrat_date_debut_3: z.unknown({ description: "Date de début du contrat 3" }),
+  contrat_date_fin_3: z.unknown({ description: "Date de fin du contrat 3" }),
+  contrat_date_rupture_3: z.unknown({ description: "Date de rupture du contrat 3" }),
+  cause_rupture_contrat_3: z.unknown({ description: "Cause de rupture du contrat 3" }),
+  contrat_date_debut_4: z.unknown({ description: "Date de début du contrat 4" }),
+  contrat_date_fin_4: z.unknown({ description: "Date de fin du contrat 4" }),
+  contrat_date_rupture_4: z.unknown({ description: "Date de rupture du contrat 4" }),
+  cause_rupture_contrat_4: z.unknown({ description: "Cause de rupture du contrat 4" }),
+  siret_employeur: z.unknown({ description: organismeProps.siret.description }),
+  siret_employeur_2: z.unknown({ description: organismeProps.siret.description }),
+  siret_employeur_3: z.unknown({ description: organismeProps.siret.description }),
+  siret_employeur_4: z.unknown({ description: organismeProps.siret.description }),
+  formation_presentielle: z.unknown({ description: "Formation 100% à distance ou non" }),
+  etablissement_lieu_de_formation_adresse: z.unknown({ description: "Adresse du lieu de formation" }),
+  etablissement_lieu_de_formation_code_postal: z.unknown({ description: "Code postal du lieu de formation" }),
 
   // REQUIRED FIELDS
-  date_inscription_formation: z.any({ description: formationProps.date_inscription.description }),
-  date_entree_formation: z.any({ description: formationProps.date_entree.description }),
-  date_fin_formation: z.any({ description: formationProps.date_fin.description }),
+  date_inscription_formation: z.unknown({ description: formationProps.date_inscription.description }),
+  date_entree_formation: z.unknown({ description: formationProps.date_entree.description }),
+  date_fin_formation: z.unknown({ description: formationProps.date_fin.description }),
   // Legacy field, do not drop because it is still used by ERPs and old Excel import
-  duree_theorique_formation: z.any({ description: "Durée théorique de la formation en années" }),
+  duree_theorique_formation: z.unknown({ description: "Durée théorique de la formation en années" }),
   // New field, prefer this.
-  duree_theorique_formation_mois: z.any({ description: "Durée théorique de la formation en mois" }),
+  duree_theorique_formation_mois: z.unknown({ description: "Durée théorique de la formation en mois" }),
 
-  etablissement_responsable_uai: z.any({ description: "UAI de l'établissement responsable" }),
-  etablissement_responsable_siret: z.any({ description: "SIRET de l'établissement responsable" }),
-  etablissement_formateur_uai: z.any({ description: "UAI de l'établissement formateur" }),
-  etablissement_formateur_siret: z.any({ description: "SIRET de l'établissement formateur" }),
-  etablissement_lieu_de_formation_uai: z.any({ description: "UAI de l'établissement (lieu de formation)" }),
-  etablissement_lieu_de_formation_siret: z.any({ description: "SIRET de l'établissement (lieu de formation)" }),
+  etablissement_responsable_uai: z.unknown({ description: "UAI de l'établissement responsable" }),
+  etablissement_responsable_siret: z.unknown({ description: "SIRET de l'établissement responsable" }),
+  etablissement_formateur_uai: z.unknown({ description: "UAI de l'établissement formateur" }),
+  etablissement_formateur_siret: z.unknown({ description: "SIRET de l'établissement formateur" }),
+  etablissement_lieu_de_formation_uai: z.unknown({ description: "UAI de l'établissement (lieu de formation)" }),
+  etablissement_lieu_de_formation_siret: z.unknown({ description: "SIRET de l'établissement (lieu de formation)" }),
 
-  formation_cfd: z.any({ description: formationProps.cfd.description }),
+  formation_cfd: z.unknown({ description: formationProps.cfd.description }),
 
   // internal fields
   ...internalFields,

--- a/shared/models/parts/adresseSchema.ts
+++ b/shared/models/parts/adresseSchema.ts
@@ -33,14 +33,14 @@ export const zAdresse = zodOpenApi.object({
     })
     .regex(CODE_POSTAL_REGEX)
     .openapi({ example: "75001" })
-    .optional(),
+    .nullish(),
   code_insee: zodOpenApi
     .string({
       description: "Le code insee doit contenir 5 caractères",
     })
     .regex(CODE_INSEE_REGEX)
     .openapi({ example: "54318" })
-    .optional(),
+    .nullish(),
   commune: zodOpenApi
     .string({
       description: "Commune",
@@ -66,7 +66,7 @@ export const zAdresse = zodOpenApi.object({
       description: "Adresse complète",
     })
     .openapi({ example: "13 Boulevard de la liberté 75001 PARIS" })
-    .optional(),
+    .nullish(),
   pays: zodEnumFromObjKeys(PAYS_BY_CODE).describe("Pays").optional(),
   bassinEmploi: zodOpenApi
     .string({

--- a/shared/models/parts/dossierApprenantSchemaV3.ts
+++ b/shared/models/parts/dossierApprenantSchemaV3.ts
@@ -17,159 +17,149 @@ export const stripModelAdditionalKeys = (validationSchema: any, data: any) => {
   return strippedData;
 };
 
-export const dossierApprenantSchemaV3Base = () =>
+export const dossierApprenantSchemaV3Base = z.object({
+  // REQUIRED FIELDS
+  nom_apprenant: primitivesV1.apprenant.nom,
+  prenom_apprenant: primitivesV1.apprenant.prenom,
+  date_de_naissance_apprenant: primitivesV1.apprenant.date_de_naissance,
+  // The following fields are missing in V3
+  // uai_etablissement: primitivesV1.etablissement_responsable.uai,
+  // nom_etablissement: primitivesV1.etablissement_responsable.nom,
+  // id_formation: primitivesV1.formation.code_cfd,
+  annee_scolaire: primitivesV1.formation.annee_scolaire,
+  statut_apprenant: primitivesV1.apprenant.statut.nullish(),
+  date_metier_mise_a_jour_statut: primitivesV1.apprenant.date_metier_mise_a_jour_statut.nullish(),
+  id_erp_apprenant: primitivesV1.apprenant.id_erp,
+
+  // OPTIONAL FIELDS
+  ine_apprenant: primitivesV1.apprenant.ine.optional(),
+  email_contact: primitivesV1.apprenant.email.optional(),
+  tel_apprenant: primitivesV1.apprenant.telephone.nullish(),
+  // The following field is missing in V3
+  // siret_etablissement: primitivesV1.etablissement_responsable.siret.optional(),
+  libelle_court_formation: primitivesV1.formation.libelle_court.optional(),
+  // The following field are missing in V3
+  // libelle_long_formation: primitivesV1.formation.libelle_long.optional(),
+  // periode_formation: primitivesV1.formation.periode.nullish(),
+  annee_formation: primitivesV1.formation.annee.optional(),
+  formation_rncp: primitivesV1.formation.code_rncp.optional(),
+  contrat_date_debut: primitivesV1.contrat.date_debut.optional(),
+  contrat_date_fin: primitivesV1.contrat.date_fin.optional(),
+  contrat_date_rupture: primitivesV1.contrat.date_rupture.optional(),
+
+  // V3 FIELDS
+  // OPTIONAL FIELDS
+  has_nir: primitivesV3.apprenant.has_nir.optional(),
+  adresse_apprenant: primitivesV3.apprenant.adresse.optional(),
+
+  code_postal_apprenant: primitivesV3.apprenant.code_postal.optional(),
+  code_postal_de_naissance_apprenant: primitivesV3.apprenant.code_postal.optional(),
+  code_commune_insee_apprenant: primitivesV1.apprenant.code_commune_insee.optional(),
+  code_commune_insee_de_naissance_apprenant: primitivesV1.apprenant.code_commune_insee.optional(),
+
+  sexe_apprenant: primitivesV3.apprenant.sexe.optional(),
+  rqth_apprenant: primitivesV3.apprenant.rqth.optional(),
+  date_rqth_apprenant: primitivesV3.apprenant.date_rqth.optional(),
+  responsable_apprenant_mail1: primitivesV3.responsable.email.optional(),
+  responsable_apprenant_mail2: primitivesV3.responsable.email.optional(),
+  obtention_diplome_formation: primitivesV3.formation.obtention_diplome.optional(),
+  date_obtention_diplome_formation: primitivesV3.formation.date_obtention_diplome.optional(),
+  date_exclusion_formation: primitivesV3.formation.date_exclusion.optional(),
+  cause_exclusion_formation: primitivesV3.formation.cause_exclusion.optional(),
+  nom_referent_handicap_formation: primitivesV3.formation.referent_handicap.nom.optional(),
+  prenom_referent_handicap_formation: primitivesV3.formation.referent_handicap.prenom.optional(),
+  email_referent_handicap_formation: primitivesV3.formation.referent_handicap.email.optional(),
+  cause_rupture_contrat: primitivesV3.contrat.cause_rupture.optional(),
+  contrat_date_debut_2: primitivesV1.contrat.date_debut.optional(),
+  contrat_date_fin_2: primitivesV1.contrat.date_fin.optional(),
+  contrat_date_rupture_2: primitivesV1.contrat.date_rupture.optional(),
+  cause_rupture_contrat_2: primitivesV3.contrat.cause_rupture.optional(),
+  contrat_date_debut_3: primitivesV1.contrat.date_debut.optional(),
+  contrat_date_fin_3: primitivesV1.contrat.date_fin.optional(),
+  contrat_date_rupture_3: primitivesV1.contrat.date_rupture.optional(),
+  cause_rupture_contrat_3: primitivesV3.contrat.cause_rupture.optional(),
+  contrat_date_debut_4: primitivesV1.contrat.date_debut.optional(),
+  contrat_date_fin_4: primitivesV1.contrat.date_fin.optional(),
+  contrat_date_rupture_4: primitivesV1.contrat.date_rupture.optional(),
+  cause_rupture_contrat_4: primitivesV3.contrat.cause_rupture.optional(),
+  siret_employeur: primitivesV3.employeur.siret.optional(),
+  siret_employeur_2: primitivesV3.employeur.siret.optional(),
+  siret_employeur_3: primitivesV3.employeur.siret.optional(),
+  siret_employeur_4: primitivesV3.employeur.siret.optional(),
+  formation_presentielle: primitivesV3.formation.presentielle.optional(),
+  // These two fields should have been required but sometimes, it is missing in YMAG
+  duree_theorique_formation: primitivesV3.formation.duree_theorique.optional(), // Legacy, but still in use by ERPs and Excel import.
+  duree_theorique_formation_mois: primitivesV3.formation.duree_theorique_mois.optional(), // The new field.
+
+  // REQUIRED FIELDS
+  date_inscription_formation: primitivesV3.formation.date_inscription,
+  date_entree_formation: primitivesV3.formation.date_entree,
+  date_fin_formation: primitivesV3.formation.date_fin,
+
+  etablissement_responsable_uai: primitivesV1.etablissement_responsable.uai,
+  etablissement_responsable_siret: primitivesV1.etablissement_responsable.siret,
+  etablissement_formateur_uai: primitivesV1.etablissement_formateur.uai,
+  etablissement_formateur_siret: primitivesV1.etablissement_formateur.siret,
+  etablissement_lieu_de_formation_uai: primitivesV1.etablissement_lieu_de_formation.uai.optional(),
+  etablissement_lieu_de_formation_siret: primitivesV1.etablissement_lieu_de_formation.siret.optional(),
+  etablissement_lieu_de_formation_adresse: primitivesV1.etablissement_lieu_de_formation.adresse.optional(),
+  etablissement_lieu_de_formation_code_postal: primitivesV1.etablissement_lieu_de_formation.code_postal.optional(),
+
+  formation_cfd: primitivesV1.formation.code_cfd.nullish(),
+  // Champs SIFA
+  derniere_situation: primitivesV3.derniere_situation.optional(),
+  dernier_organisme_uai: primitivesV3.dernier_organisme_uai.optional(),
+  type_cfa: primitivesV3.type_cfa.optional(),
+});
+
+const dossierApprenantSchemaV3 = dossierApprenantSchemaV3Base.merge(
   z.object({
-    // REQUIRED FIELDS
-    nom_apprenant: primitivesV1.apprenant.nom,
-    prenom_apprenant: primitivesV1.apprenant.prenom,
-    date_de_naissance_apprenant: primitivesV1.apprenant.date_de_naissance,
-    // The following fields are missing in V3
-    // uai_etablissement: primitivesV1.etablissement_responsable.uai,
-    // nom_etablissement: primitivesV1.etablissement_responsable.nom,
-    // id_formation: primitivesV1.formation.code_cfd,
-    annee_scolaire: primitivesV1.formation.annee_scolaire,
-    statut_apprenant: primitivesV1.apprenant.statut.nullish(),
-    date_metier_mise_a_jour_statut: primitivesV1.apprenant.date_metier_mise_a_jour_statut.nullish(),
-    id_erp_apprenant: primitivesV1.apprenant.id_erp,
+    // These fields are hidden in documentation because they are generated by the API itself.
+    api_version: primitivesV1.api_version.optional(),
+    source: primitivesV1.source,
+    source_organisme_id: primitivesV1.source_organisme_id.optional(),
+  })
+);
 
-    // OPTIONAL FIELDS
-    ine_apprenant: primitivesV1.apprenant.ine.optional(),
-    email_contact: primitivesV1.apprenant.email.optional(),
-    tel_apprenant: primitivesV1.apprenant.telephone.nullish(),
-    // The following field is missing in V3
-    // siret_etablissement: primitivesV1.etablissement_responsable.siret.optional(),
-    libelle_court_formation: primitivesV1.formation.libelle_court.optional(),
-    // The following field are missing in V3
-    // libelle_long_formation: primitivesV1.formation.libelle_long.optional(),
-    // periode_formation: primitivesV1.formation.periode.nullish(),
-    annee_formation: primitivesV1.formation.annee.optional(),
-    formation_rncp: primitivesV1.formation.code_rncp.optional(),
-    contrat_date_debut: primitivesV1.contrat.date_debut.optional(),
-    contrat_date_fin: primitivesV1.contrat.date_fin.optional(),
-    contrat_date_rupture: primitivesV1.contrat.date_rupture.optional(),
-
-    // V3 FIELDS
-    // OPTIONAL FIELDS
-    has_nir: primitivesV3.apprenant.has_nir.optional(),
-    adresse_apprenant: primitivesV3.apprenant.adresse.optional(),
-
-    code_postal_apprenant: primitivesV3.apprenant.code_postal.optional(),
-    code_postal_de_naissance_apprenant: primitivesV3.apprenant.code_postal.optional(),
-    code_commune_insee_apprenant: primitivesV1.apprenant.code_commune_insee.optional(),
-    code_commune_insee_de_naissance_apprenant: primitivesV1.apprenant.code_commune_insee.optional(),
-
-    sexe_apprenant: primitivesV3.apprenant.sexe.optional(),
-    rqth_apprenant: primitivesV3.apprenant.rqth.optional(),
-    date_rqth_apprenant: primitivesV3.apprenant.date_rqth.optional(),
-    responsable_apprenant_mail1: primitivesV3.responsable.email.optional(),
-    responsable_apprenant_mail2: primitivesV3.responsable.email.optional(),
-    obtention_diplome_formation: primitivesV3.formation.obtention_diplome.optional(),
-    date_obtention_diplome_formation: primitivesV3.formation.date_obtention_diplome.optional(),
-    date_exclusion_formation: primitivesV3.formation.date_exclusion.optional(),
-    cause_exclusion_formation: primitivesV3.formation.cause_exclusion.optional(),
-    nom_referent_handicap_formation: primitivesV3.formation.referent_handicap.nom.optional(),
-    prenom_referent_handicap_formation: primitivesV3.formation.referent_handicap.prenom.optional(),
-    email_referent_handicap_formation: primitivesV3.formation.referent_handicap.email.optional(),
-    cause_rupture_contrat: primitivesV3.contrat.cause_rupture.optional(),
-    contrat_date_debut_2: primitivesV1.contrat.date_debut.optional(),
-    contrat_date_fin_2: primitivesV1.contrat.date_fin.optional(),
-    contrat_date_rupture_2: primitivesV1.contrat.date_rupture.optional(),
-    cause_rupture_contrat_2: primitivesV3.contrat.cause_rupture.optional(),
-    contrat_date_debut_3: primitivesV1.contrat.date_debut.optional(),
-    contrat_date_fin_3: primitivesV1.contrat.date_fin.optional(),
-    contrat_date_rupture_3: primitivesV1.contrat.date_rupture.optional(),
-    cause_rupture_contrat_3: primitivesV3.contrat.cause_rupture.optional(),
-    contrat_date_debut_4: primitivesV1.contrat.date_debut.optional(),
-    contrat_date_fin_4: primitivesV1.contrat.date_fin.optional(),
-    contrat_date_rupture_4: primitivesV1.contrat.date_rupture.optional(),
-    cause_rupture_contrat_4: primitivesV3.contrat.cause_rupture.optional(),
-    siret_employeur: primitivesV3.employeur.siret.optional(),
-    siret_employeur_2: primitivesV3.employeur.siret.optional(),
-    siret_employeur_3: primitivesV3.employeur.siret.optional(),
-    siret_employeur_4: primitivesV3.employeur.siret.optional(),
-    formation_presentielle: primitivesV3.formation.presentielle.optional(),
-    // These two fields should have been required but sometimes, it is missing in YMAG
-    duree_theorique_formation: primitivesV3.formation.duree_theorique.optional(), // Legacy, but still in use by ERPs and Excel import.
-    duree_theorique_formation_mois: primitivesV3.formation.duree_theorique_mois.optional(), // The new field.
-
-    // REQUIRED FIELDS
-    date_inscription_formation: primitivesV3.formation.date_inscription,
-    date_entree_formation: primitivesV3.formation.date_entree,
-    date_fin_formation: primitivesV3.formation.date_fin,
-
-    etablissement_responsable_uai: primitivesV1.etablissement_responsable.uai,
-    etablissement_responsable_siret: primitivesV1.etablissement_responsable.siret,
-    etablissement_formateur_uai: primitivesV1.etablissement_formateur.uai,
-    etablissement_formateur_siret: primitivesV1.etablissement_formateur.siret,
-    etablissement_lieu_de_formation_uai: primitivesV1.etablissement_lieu_de_formation.uai.optional(),
-    etablissement_lieu_de_formation_siret: primitivesV1.etablissement_lieu_de_formation.siret.optional(),
-    etablissement_lieu_de_formation_adresse: primitivesV1.etablissement_lieu_de_formation.adresse.optional(),
-    etablissement_lieu_de_formation_code_postal: primitivesV1.etablissement_lieu_de_formation.code_postal.optional(),
-
-    formation_cfd: primitivesV1.formation.code_cfd.nullish(),
-    // Champs SIFA
-    derniere_situation: primitivesV3.derniere_situation.optional(),
-    dernier_organisme_uai: primitivesV3.dernier_organisme_uai.optional(),
-    type_cfa: primitivesV3.type_cfa.optional(),
-  });
-
-const dossierApprenantSchemaV3BaseWithApiData = () => {
-  return dossierApprenantSchemaV3Base().merge(
+export const dossierApprenantSchemaV3Input = dossierApprenantSchemaV3Base
+  .merge(
     z.object({
+      nir_apprenant: z
+        .preprocess(
+          (v: any) => (v ? String(v).replace(/[\s.-]+/g, "") : v),
+          z
+            .any()
+            // On indique juste "13 chiffres attendus", car ça ne devrait pas être 15 (on répare silencieusement quand même à la ligne suivante)
+            .describe("NIR de l'apprenant")
+            .openapi({
+              example: "1234567890123",
+              type: "string",
+            })
+            .transform<boolean>(Boolean)
+        )
+        .optional(),
       // These fields are hidden in documentation because they are generated by the API itself.
       api_version: primitivesV1.api_version.optional(),
       source: primitivesV1.source,
       source_organisme_id: primitivesV1.source_organisme_id.optional(),
     })
-  );
-};
-const dossierApprenantSchemaV3 = () => {
-  return dossierApprenantSchemaV3BaseWithApiData();
-};
-
-export const dossierApprenantSchemaV3Input = () => {
-  return dossierApprenantSchemaV3Base()
-    .merge(
-      z.object({
-        nir_apprenant: z
-          .preprocess(
-            (v: any) => (v ? String(v).replace(/[\s.-]+/g, "") : v),
-            z
-              .any()
-              // On indique juste "13 chiffres attendus", car ça ne devrait pas être 15 (on répare silencieusement quand même à la ligne suivante)
-              .describe("NIR de l'apprenant")
-              .openapi({
-                example: "1234567890123",
-                type: "string",
-              })
-              .transform<boolean>(Boolean)
-          )
-          .optional(),
-        // These fields are hidden in documentation because they are generated by the API itself.
-        api_version: primitivesV1.api_version.optional(),
-        source: primitivesV1.source,
-        source_organisme_id: primitivesV1.source_organisme_id.optional(),
-      })
-    )
-    .omit({
-      has_nir: true,
-    });
-};
+  )
+  .omit({
+    has_nir: true,
+  });
 
 // Utilisé par le téléversement manuel. Le but côté métier est d'obliger les utilisateurs à remplir des champs dont
 // ils pourraient avoir besoin dans SIFA alors que ce n'est pas toujours présent côté ERPs.
 // Source de la décision: https://mission-apprentissage.slack.com/archives/C02FR2L1VB8/p1693232432865229
-const dossierApprenantSchemaV3WithMoreRequiredFields = () => {
-  return dossierApprenantSchemaV3Base().merge(
-    z.object({
-      email_contact: primitivesV1.apprenant.email,
-      adresse_apprenant: primitivesV3.apprenant.adresse,
-      code_postal_apprenant: primitivesV3.apprenant.code_postal,
-      sexe_apprenant: primitivesV3.apprenant.sexe,
-      annee_formation: primitivesV1.formation.annee,
-    })
-  );
-};
+const dossierApprenantSchemaV3WithMoreRequiredFields = dossierApprenantSchemaV3Base.merge(
+  z.object({
+    email_contact: primitivesV1.apprenant.email,
+    adresse_apprenant: primitivesV3.apprenant.adresse,
+    code_postal_apprenant: primitivesV3.apprenant.code_postal,
+    sexe_apprenant: primitivesV3.apprenant.sexe,
+    annee_formation: primitivesV1.formation.annee,
+  })
+);
 
 export function dossierApprenantSchemaV3WithMoreRequiredFieldsValidatingUAISiret(
   invalidsUais: string[],
@@ -180,7 +170,7 @@ export function dossierApprenantSchemaV3WithMoreRequiredFieldsValidatingUAISiret
   const messageUai = "UAI non valide";
   const messageSiret = "Siret non valide";
 
-  return dossierApprenantSchemaV3WithMoreRequiredFields().merge(
+  return dossierApprenantSchemaV3WithMoreRequiredFields.merge(
     z.object({
       etablissement_responsable_uai: primitivesV1.etablissement_responsable.uai.refine(validateUAI, {
         message: messageUai,
@@ -198,13 +188,13 @@ export function dossierApprenantSchemaV3WithMoreRequiredFieldsValidatingUAISiret
   );
 }
 
-export function computeWarningsForDossierApprenantSchemaV3(data: Array<DossierApprenantSchemaV3ZodType>) {
+export function computeWarningsForDossierApprenantSchemaV3(data: Array<IDossierApprenantSchemaV3>) {
   return {
     contratCount: countContratWarning(data),
   };
 }
 
-const countContratWarning = (data: Array<DossierApprenantSchemaV3ZodType>) => {
+const countContratWarning = (data: Array<IDossierApprenantSchemaV3>) => {
   return data.reduce(
     (acc: number, { contrat_date_debut, contrat_date_debut_2, contrat_date_debut_3, contrat_date_debut_4 }) => {
       return !contrat_date_debut && !contrat_date_debut_2 && !contrat_date_debut_3 && !contrat_date_debut_4
@@ -215,9 +205,7 @@ const countContratWarning = (data: Array<DossierApprenantSchemaV3ZodType>) => {
   );
 };
 
-export type DossierApprenantSchemaV3BaseWithApiDataType = z.input<
-  ReturnType<typeof dossierApprenantSchemaV3BaseWithApiData>
->;
-export type DossierApprenantSchemaV3ZodType = z.input<ReturnType<typeof dossierApprenantSchemaV3>>;
+export type IDossierApprenantSchemaV3 = z.output<typeof dossierApprenantSchemaV3>;
+export type IDossierApprenantSchemaV3Input = z.input<typeof dossierApprenantSchemaV3>;
 
 export default dossierApprenantSchemaV3;

--- a/shared/models/parts/zodPrimitives.ts
+++ b/shared/models/parts/zodPrimitives.ts
@@ -4,7 +4,6 @@ import { capitalize } from "lodash-es";
 import { z } from "zod";
 
 import {
-  EFFECTIF_DERNIER_SITUATION,
   CFD_REGEX,
   CODE_NAF_REGEX,
   RNCP_REGEX,
@@ -13,7 +12,9 @@ import {
   CODE_POSTAL_REGEX,
   DERNIER_ORGANISME_UAI_REGEX,
   PHONE_REGEX_PATTERN,
+  zCodeStatutApprenant,
   CODES_STATUT_APPRENANT_ENUM,
+  zEffectifDernierSituation,
 } from "shared";
 
 import { telephoneConverter } from "../../utils/frenchTelephoneNumber";
@@ -114,17 +115,7 @@ export const primitivesV1 = {
       example: "2000-10-28T00:00:00.000Z",
     }),
     statut: z
-      .preprocess(
-        (v: any) => (CODES_STATUT_APPRENANT_ENUM.includes(parseInt(v, 10) as any) ? parseInt(v, 10) : v),
-        z
-          .number({
-            invalid_type_error: `Valeurs possibles: ${CODES_STATUT_APPRENANT_ENUM.join(",")}`,
-          })
-          .int()
-          .refine((value) => (CODES_STATUT_APPRENANT_ENUM as number[]).includes(value), {
-            message: `Valeurs valides: ${CODES_STATUT_APPRENANT_ENUM.join(",")}`,
-          })
-      )
+      .preprocess((v: unknown) => (typeof v === "string" ? parseInt(v, 10) : v), zCodeStatutApprenant)
       .openapi({
         description: `Valeurs possibles: ${CODES_STATUT_APPRENANT_ENUM.join(",")}`,
         enum: CODES_STATUT_APPRENANT_ENUM,
@@ -237,7 +228,7 @@ export const primitivesV1 = {
     periode: z
       .preprocess(
         // periode is sent as string "year1-year2" i.e. "2020-2022", we transform it to [2020,2022]
-        (v: any) => (typeof v === "string" ? v.trim().split("-").map(Number) : v),
+        (v: unknown) => (typeof v === "string" ? v.trim().split("-").map(Number) : v),
         z.array(z.number().int().min(2000).max(2100)).length(2)
       )
       .describe("Période de la formation, en année (peut être sur plusieurs années)")
@@ -320,15 +311,13 @@ export const primitivesV3 = {
         .describe("Code postal de l'apprenant")
     ),
     sexe: z.preprocess(
-      (v: any) => (v ? String(v).trim().replace("H", "M").replace("1", "M").replace("2", "F") : v),
-      z
-        .string()
-        .trim()
-        .regex(/^[MF]$/, "M, H ou F attendu")
-        .describe("Sexe de l'apprenant")
-        .openapi({
-          example: "M",
-        })
+      (v: unknown) =>
+        typeof v === "string" || typeof v === "number"
+          ? String(v).trim().replace("H", "M").replace("1", "M").replace("2", "F")
+          : v,
+      z.enum(["M", "F"], { message: "M, H ou F attendu" }).describe("Sexe de l'apprenant").openapi({
+        example: "M",
+      })
     ),
     rqth: z.boolean().describe("Reconnaissance de la Qualité de Travailleur Handicapé").openapi({ example: true }),
     date_rqth: extensions
@@ -439,20 +428,8 @@ export const primitivesV3 = {
     code_naf: extensions.code_naf().describe("Code NAF de l'employeur").openapi({ example: "1071D" }),
   },
   derniere_situation: z
-    .preprocess(
-      (v: any) => (v ? Number(v) : v),
-      z.coerce
-        .number()
-        .int()
-        .refine((e) => EFFECTIF_DERNIER_SITUATION.includes(e as any), {
-          message: "Format invalide (ex : 1003, 3111, 4017)",
-        })
-    )
-    .describe("Situation de l'apprenant N-1")
-    .openapi({
-      type: "integer",
-      enum: EFFECTIF_DERNIER_SITUATION as any,
-    }),
+    .preprocess((v: unknown) => (typeof v === "string" ? parseInt(v, 10) : v), zEffectifDernierSituation)
+    .describe("Situation de l'apprenant N-1"),
   dernier_organisme_uai: z.coerce
     .string()
     .regex(DERNIER_ORGANISME_UAI_REGEX, "UAI ou département")
@@ -464,20 +441,20 @@ export const primitivesV3 = {
     }),
   type_cfa: z.preprocess(
     (input) => {
-      if (input) {
-        // Vérifie si l'entrée est un nombre entre 1 et 10 sans le zéro initial
-        const match = String(input).match(/^(1|2|3|4|5|6|7|8|9|10)$/);
-        if (match) {
-          // Rajoute un zéro devant si nécessaire
-          return match[0].length === 1 ? "0" + match[0] : match[0];
-        }
+      if (typeof input === "string") {
+        return input.padStart(2, "0");
       }
+
+      if (typeof input === "number") {
+        return input.toString().padStart(2, "0");
+      }
+
       return input;
     },
     z
-      .string()
-      .regex(/^(01|02|03|04|05|06|07|08|09|10)$/, "01 à 10")
-      .describe("Type de CFA")
+      .enum(["01", "02", "03", "04", "05", "06", "07", "08", "09", "10"], {
+        description: "Type de CFA",
+      })
       .openapi({
         enum: ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10"],
         description: "Type de CFA",

--- a/ui/components/Effectif/EffectifQueueItemView.tsx
+++ b/ui/components/Effectif/EffectifQueueItemView.tsx
@@ -109,7 +109,7 @@ const DescriptionErrorListComponent = ({ errorList }) => (
 const EffectifQueueItemView = ({ effectifQueueItem }: EffectifQueueItemViewProps) => {
   const validationErrorFormated = buildValidationError(effectifQueueItem.validation_errors);
   const computeRequired = (value) => {
-    return !(dossierApprenantSchemaV3Base().shape[value] instanceof z.ZodOptional) ? (
+    return !(dossierApprenantSchemaV3Base.shape[value] instanceof z.ZodOptional) ? (
       <Box as="span" role="presentation" aria-hidden="true" color="red.500" ml={1}>
         *
       </Box>


### PR DESCRIPTION
Les effectifs venant de EffectifQueue étaient typé en any au lieu de unknown. Bien que l'on valide le schema lors de la sauvegarde de dossierApprenant, on sauvegarde la donnée `raw` qui du coup n'est pas `preprocess` (par exemple conversion du siret number --> string) https://sentry.apprentissage.beta.gouv.fr/organizations/sentry/issues/10708/?environment=production&project=11&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=0

