### PR TITLE
fix: correction du mécanisme d'imposture sur les ml

### DIFF
--- a/server/src/common/actions/admin/mission-locale/mission-locale.admin.actions.ts
+++ b/server/src/common/actions/admin/mission-locale/mission-locale.admin.actions.ts
@@ -1,4 +1,5 @@
 import { ObjectId } from "bson";
+import { IOrganisationMissionLocale } from "shared/models";
 
 import { organisationsDb } from "@/common/model/collections";
 
@@ -17,4 +18,14 @@ export const activateMissionLocale = async (missionLocaleId: string, date: Date)
       },
     }
   );
+};
+
+export const getAllMlFromOrganisations = async (): Promise<Array<IOrganisationMissionLocale>> => {
+  const mls = await organisationsDb()
+    .find({
+      type: "MISSION_LOCALE",
+    })
+    .toArray();
+
+  return mls as Array<IOrganisationMissionLocale>;
 };

--- a/server/src/http/routes/admin.routes/mission-locale.routes.ts
+++ b/server/src/http/routes/admin.routes/mission-locale.routes.ts
@@ -1,12 +1,19 @@
+import Boom from "boom";
 import express from "express";
 import { z } from "zod";
 
-import { activateMissionLocale } from "@/common/actions/admin/mission-locale/mission-locale.admin.actions";
+import {
+  activateMissionLocale,
+  getAllMlFromOrganisations,
+} from "@/common/actions/admin/mission-locale/mission-locale.admin.actions";
+import { getMissionsLocales } from "@/common/apis/apiAlternance/apiAlternance";
 import { returnResult } from "@/http/middlewares/helpers";
 import validateRequestMiddleware from "@/http/middlewares/validateRequestMiddleware";
 
 export default () => {
   const router = express.Router();
+
+  router.get("/", returnResult(getAllMls));
 
   router.post(
     "/activate",
@@ -22,4 +29,16 @@ export default () => {
 const activateMLAtDate = ({ body }) => {
   const { date, missionLocaleId } = body;
   return activateMissionLocale(missionLocaleId, date);
+};
+
+const getAllMls = async () => {
+  const externalML = await getMissionsLocales();
+  if (!externalML) {
+    throw Boom.notFound("Aucune mission locale trouvée");
+  }
+  const organisationMl = await getAllMlFromOrganisations();
+
+  return organisationMl
+    .map((orga) => ({ organisation: orga, externalML: externalML.find((ml) => ml.id === orga.ml_id) }))
+    .filter((ml) => ml.externalML);
 };

--- a/shared/models/data/organisations.model.ts
+++ b/shared/models/data/organisations.model.ts
@@ -18,7 +18,10 @@ import { zodEnumFromArray, zodEnumFromObjKeys } from "../../utils/zodHelper";
 
 const collectionName = "organisations";
 
-const indexes: [IndexSpecification, CreateIndexesOptions][] = [[{ organisme_id: 1 }, {}]];
+const indexes: [IndexSpecification, CreateIndexesOptions][] = [
+  [{ organisme_id: 1 }, {}],
+  [{ ml_id: 1 }, { unique: true }],
+];
 
 const zOrganisationBase = z.object({
   _id: zObjectId,

--- a/ui/modules/auth/inscription/components/MissionLocaleSelect.tsx
+++ b/ui/modules/auth/inscription/components/MissionLocaleSelect.tsx
@@ -2,6 +2,7 @@ import { Box, Input, List, ListItem, Spinner } from "@chakra-ui/react";
 import { useQuery } from "@tanstack/react-query";
 import type { IMissionLocale } from "api-alternance-sdk";
 import { useState, useRef, useEffect } from "react";
+import { IOrganisationMissionLocale } from "shared";
 
 import { _get } from "@/common/httpClient";
 
@@ -12,9 +13,9 @@ interface MissionLocaleSelectProps {
 }
 
 export const MissionLocaleSelect = ({ setOrganisation }: MissionLocaleSelectProps) => {
-  const { data: missionLocales, isLoading } = useQuery<IMissionLocale[]>(["mission-locale"], async () =>
-    _get("/api/v1/mission-locale")
-  );
+  const { data: missionLocales, isLoading } = useQuery<
+    { organisation: IOrganisationMissionLocale; externalML: IMissionLocale }[]
+  >(["mission-locale"], async () => _get("/api/v1/admin/mission-locale"));
 
   const [searchTerm, setSearchTerm] = useState("");
   const [isOpen, setIsOpen] = useState(false);
@@ -22,26 +23,27 @@ export const MissionLocaleSelect = ({ setOrganisation }: MissionLocaleSelectProp
   const [selectedValue, setSelectedValue] = useState<string | null>(null);
 
   const containerRef = useRef<HTMLDivElement | null>(null);
-
   const filteredLocales = missionLocales
     ? missionLocales
         .filter((ml) =>
-          `${ml.nom} ${ml.localisation.ville} ${ml.localisation.cp}`.toLowerCase().includes(searchTerm.toLowerCase())
+          `${ml.externalML.nom} ${ml.externalML.localisation.ville} ${ml.externalML.localisation.cp}`
+            .toLowerCase()
+            .includes(searchTerm.toLowerCase())
         )
-        .sort((a, b) => a.localisation.ville.localeCompare(b.localisation.ville))
+        .sort((a, b) => a.externalML.localisation.ville.localeCompare(b.externalML.localisation.ville))
     : [];
-
-  const handleSelect = (ml: IMissionLocale) => {
-    setSelectedValue(`${ml.nom} (${ml.localisation.ville} - ${ml.localisation.cp})`);
+  const handleSelect = ({
+    organisation,
+    externalML,
+  }: {
+    organisation: IOrganisationMissionLocale;
+    externalML: IMissionLocale;
+  }) => {
+    setSelectedValue(`${externalML.nom} (${externalML.localisation.ville} - ${externalML.localisation.cp})`);
     setSearchTerm("");
     setIsOpen(false);
 
-    setOrganisation({
-      type: "MISSION_LOCALE",
-      nom: ml.nom,
-      siret: ml.siret,
-      ml_id: ml.id,
-    });
+    setOrganisation(organisation);
   };
 
   // Handle keyboard navigation
@@ -98,14 +100,14 @@ export const MissionLocaleSelect = ({ setOrganisation }: MissionLocaleSelectProp
         >
           {filteredLocales.map((ml, index) => (
             <ListItem
-              key={ml.id}
+              key={ml.organisation._id.toString()}
               p={2}
               cursor="pointer"
               bg={highlightIndex === index ? "gray.100" : "white"}
               _hover={{ bg: "gray.200" }}
               onClick={() => handleSelect(ml)}
             >
-              {ml.nom} ({ml.localisation.ville} - {ml.localisation.cp})
+              {ml.externalML.nom} ({ml.externalML.localisation.ville} - {ml.externalML.localisation.cp})
             </ListItem>
           ))}
         </List>


### PR DESCRIPTION
Si il existe un Δ entre le nom de la ML en tant qu'organisme et la ML depuis l'API apprentissage, il y a une création d'un nouvel organisme en moment de l'imposture.
Afin de corriger ça :

- Récupération de l'organisation depuis la BDD plutot que de le constuire a la volée depuis l'API externe
- Mise en place d'un unique sur ml_id afin de s'assurer de l'unicité de la donnée 
-  ⚠️ Correction manuelle en prod et preprod pour supprimer le doublon d'organisation