### PR TITLE
fix: accepter 0 ou null sur apprenant.derniere_situation

### DIFF
--- a/server/src/common/actions/engine/engine.actions.ts
+++ b/server/src/common/actions/engine/engine.actions.ts
@@ -221,7 +221,10 @@ export const mapEffectifQueueToEffectif = (
         "responsable_apprenant_mail1" in dossierApprenant ? dossierApprenant.responsable_apprenant_mail1 : null,
       responsable_mail2:
         "responsable_apprenant_mail2" in dossierApprenant ? dossierApprenant.responsable_apprenant_mail2 : null,
-      derniere_situation: "derniere_situation" in dossierApprenant ? dossierApprenant.derniere_situation : null,
+      derniere_situation:
+        "derniere_situation" in dossierApprenant && dossierApprenant.derniere_situation !== 0
+          ? dossierApprenant.derniere_situation
+          : null,
       dernier_organisme_uai:
         "dernier_organisme_uai" in dossierApprenant ? dossierApprenant.dernier_organisme_uai?.toString() : null,
       type_cfa: "type_cfa" in dossierApprenant ? dossierApprenant.type_cfa : null,

--- a/shared/models/parts/zodPrimitives.ts
+++ b/shared/models/parts/zodPrimitives.ts
@@ -453,7 +453,10 @@ export const primitivesV3 = {
     code_naf: extensions.code_naf().describe("Code NAF de l'employeur").openapi({ example: "1071D" }),
   },
   derniere_situation: z
-    .preprocess((v: unknown) => (typeof v === "string" ? parseInt(v, 10) : v), zEffectifDernierSituation)
+    .preprocess(
+      (v: unknown) => (typeof v === "string" ? parseInt(v, 10) : v),
+      z.union([zEffectifDernierSituation, z.literal(0), z.null()])
+    )
     .describe("Situation de l'apprenant N-1"),
   dernier_organisme_uai: z.coerce
     .string()

--- a/ui/modules/mon-espace/effectifs/engine/effectifForm/blocks/apprenant/apprenantSchema.ts
+++ b/ui/modules/mon-espace/effectifs/engine/effectifForm/blocks/apprenant/apprenantSchema.ts
@@ -459,6 +459,13 @@ export const apprenantSchema = {
     label: "Situation de l'apprenant l’année dernière (N-1) :",
     options: [
       {
+        name: "Sans situation",
+        options: [
+          { label: "Non renseigné", value: null },
+          { label: "0 – Aucune situation", value: 0 },
+        ],
+      },
+      {
         name: "1er cycle second degré",
         options: [
           {


### PR DESCRIPTION
Cf: [TM-2105](url)

Il faut tester l'ingestion avec la valeur 0 ou null en preprod pour voir l'impact sur les transmissions

[TM-2105]: https://tableaudebord-apprentissage.atlassian.net/browse/TM-2105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ