### PR TITLE
fix: remove stemming in user search

### DIFF
--- a/server/src/common/utils/usersFiltersUtils.ts
+++ b/server/src/common/utils/usersFiltersUtils.ts
@@ -13,7 +13,11 @@ export const buildTextSearchQuery = (searchTerm: string) => {
     return [];
   }
 
-  return [{ $text: { $search: searchTerm, $language: "french" } }];
+  return [
+    { nom: { $regex: searchTerm, $options: "i" } },
+    { prenom: { $regex: searchTerm, $options: "i" } },
+    { email: { $regex: searchTerm, $options: "i" } },
+  ];
 };
 
 export const buildFiltersFromQuery = (queryParams: UsersFiltersParams) => {


### PR DESCRIPTION
La recherche textuelle de la gestion des users se faisait par stemming, je la remplace par une regex.