### PR TITLE
fix: correctif sur l'affichage de la date de rutpure

### DIFF
--- a/server/src/common/actions/mission-locale/mission-locale.actions.ts
+++ b/server/src/common/actions/mission-locale/mission-locale.actions.ts
@@ -184,7 +184,7 @@ const matchDernierStatutPipelineMl = (): any => {
   const match = {
     $match: {
       "effectif_snapshot._computed.statut.en_cours": STATUT_APPRENANT.RUPTURANT,
-      date_rupture: { $lte: Date.now() },
+      date_rupture: { $lte: new Date() },
     },
   };
   return match;

--- a/server/src/common/actions/mission-locale/mission-locale.actions.ts
+++ b/server/src/common/actions/mission-locale/mission-locale.actions.ts
@@ -184,7 +184,7 @@ const matchDernierStatutPipelineMl = (): any => {
   const match = {
     $match: {
       "effectif_snapshot._computed.statut.en_cours": STATUT_APPRENANT.RUPTURANT,
-      $date_rupture: { $lte: Date.now() },
+      date_rupture: { $lte: Date.now() },
     },
   };
   return match;
@@ -869,7 +869,6 @@ export const getEffectifARisqueByMissionLocaleId = async (missionLocaleMongoId: 
 
 const getEffectifMissionLocaleEligibleToBrevoAggregation = (
   missionLocaleMongoId: ObjectId,
-  statut,
   missionLocaleActivationDate?: Date
 ) => [
   generateMissionLocaleMatchStage(missionLocaleMongoId),
@@ -884,7 +883,7 @@ export const getEffectifMissionLocaleEligibleToBrevoCount = async (
   missionLocaleActivationDate?: Date
 ) => {
   const effectifsMissionLocaleAggregation = [
-    ...getEffectifMissionLocaleEligibleToBrevoAggregation(missionLocaleMongoId, statut, missionLocaleActivationDate),
+    ...getEffectifMissionLocaleEligibleToBrevoAggregation(missionLocaleMongoId, missionLocaleActivationDate),
 
     {
       $facet: {
@@ -940,7 +939,7 @@ export const getEffectifMissionLocaleEligibleToBrevo = async (
   missionLocaleActivationDate?: Date
 ) => {
   const effectifsMissionLocaleAggregation = [
-    ...getEffectifMissionLocaleEligibleToBrevoAggregation(missionLocaleMongoId, statut, missionLocaleActivationDate),
+    ...getEffectifMissionLocaleEligibleToBrevoAggregation(missionLocaleMongoId, missionLocaleActivationDate),
     {
       $match: {
         soft_deleted: { $ne: true },

--- a/server/src/common/mongodb/__snapshots__/validationSchema.test.ts.snap
+++ b/server/src/common/mongodb/__snapshots__/validationSchema.test.ts.snap
@@ -9341,6 +9341,16 @@ exports[`validation-schema > should create validation schema for missionLocaleEf
         },
       },
     },
+    "date_rupture": {
+      "anyOf": [
+        {
+          "bsonType": "date",
+        },
+        {
+          "bsonType": "null",
+        },
+      ],
+    },
     "deja_connu": {
       "bsonType": [
         "bool",

--- a/server/src/db/migrations/20250722090948-ajout-date-rupture.ts
+++ b/server/src/db/migrations/20250722090948-ajout-date-rupture.ts
@@ -1,0 +1,8 @@
+import { addJob } from "job-processor";
+
+export const up = async () => {
+  await addJob({
+    name: "tmp:migration:ml-date-rupture",
+    queued: true,
+  });
+};

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -36,6 +36,7 @@ import { hydrateOrganismesOPCOs } from "./hydrate/hydrate-organismes-opcos";
 import { hydrateRNCP } from "./hydrate/hydrate-rncp";
 import {
   hydrateMissionLocaleAdresse,
+  hydrateMissionLocaleEffectifDateRupture,
   hydrateMissionLocaleOrganisation,
   hydrateMissionLocaleSnapshot,
   hydrateMissionLocaleStats,
@@ -434,6 +435,11 @@ export async function setupJobProcessor() {
       "tmp:force-hydrate-transmissions": {
         handler: async () => {
           return forceHydrateAllTransmissions();
+        },
+      },
+      "tmp:migration:ml-date-rupture": {
+        handler: async () => {
+          return hydrateMissionLocaleEffectifDateRupture();
         },
       },
     },

--- a/shared/models/data/missionLocaleEffectif.model.ts
+++ b/shared/models/data/missionLocaleEffectif.model.ts
@@ -51,6 +51,7 @@ const zMissionLocaleEffectif = z.object({
   _id: zObjectId,
   mission_locale_id: zObjectId,
   effectif_id: zObjectId,
+  date_rupture: z.date().nullish(),
   situation: zSituationEnum.nullish(),
   situation_autre: z.string().nullish(),
   created_at: z.date(),

--- a/shared/models/routes/mission-locale/MissionLocaleEffectif.ts
+++ b/shared/models/routes/mission-locale/MissionLocaleEffectif.ts
@@ -39,7 +39,7 @@ const zEffectifMissionLocale = z
     prioritaire: z.boolean().nullish(),
     injoignable: z.boolean().nullish(),
     autorisation_contact: z.boolean().nullish(),
-    dernier_statut: z
+    date_rupture: z
       .object({
         date: z.date(),
         valeur: zStatutApprenantEnum,

--- a/ui/app/_components/mission-locale/PriorityTable.tsx
+++ b/ui/app/_components/mission-locale/PriorityTable.tsx
@@ -51,7 +51,7 @@ export function PriorityTable({ priorityData = [], searchTerm, hadEffectifsPrior
 
   const tableData = useMemo(() => {
     return priorityData.map((effectif) => {
-      const labelMonth = formatMonthAndYear(effectif.dernier_statut.date || "");
+      const labelMonth = formatMonthAndYear(effectif.date_rupture || "");
       return {
         rawData: effectif,
         element: {

--- a/ui/app/_components/mission-locale/effectifs/EffectifInfo.tsx
+++ b/ui/app/_components/mission-locale/effectifs/EffectifInfo.tsx
@@ -74,7 +74,7 @@ export function EffectifInfo({
             ) : (
               <Badge severity="success">traité</Badge>
             )}
-            <p className="fr-badge fr-badge--beige-gris-galet">{getMonthYearFromDate(effectif.dernier_statut?.date)}</p>
+            <p className="fr-badge fr-badge--beige-gris-galet">{getMonthYearFromDate(effectif.date_rupture)}</p>
           </Stack>
 
           {isAdmin && !effectif.a_traiter && (

--- a/ui/app/_components/mission-locale/effectifs/EffectifInfo.tsx
+++ b/ui/app/_components/mission-locale/effectifs/EffectifInfo.tsx
@@ -106,9 +106,7 @@ export function EffectifInfo({
               <Typography component="p">
                 <span className="fr-notice__title">Date de la rupture du contrat d&apos;apprentissage :</span>
                 <span className="fr-notice__desc">
-                  {formatDate(effectif.contrats?.[0]?.date_rupture)
-                    ? `le ${formatDate(effectif.contrats?.[0]?.date_rupture)}`
-                    : "non renseignée"}
+                  {formatDate(effectif.date_rupture) ? `le ${formatDate(effectif.date_rupture)}` : "non renseignée"}
                 </span>
               </Typography>
             </Box>

--- a/ui/app/_components/mission-locale/effectifs/PageHeader.tsx
+++ b/ui/app/_components/mission-locale/effectifs/PageHeader.tsx
@@ -29,7 +29,7 @@ export function PageHeader({
   const nomListe = rawList || API_EFFECTIF_LISTE.A_TRAITER;
   const listQuery = `?nom_liste=${nomListe}`;
 
-  const basePath = effectifId ? `/admin/mission-locale/${mlId}` : `/mission-locale`;
+  const basePath = effectifId ? `/admin/mission-locale/${mlId}/edit` : `/mission-locale`;
 
   const getHref = (id: string) => `${basePath}/${id}${listQuery}`;
 

--- a/ui/app/_components/mission-locale/types.ts
+++ b/ui/app/_components/mission-locale/types.ts
@@ -11,10 +11,7 @@ export type EffectifData = {
 };
 
 export type EffectifPriorityData = EffectifData & {
-  dernier_statut: {
-    date: string;
-    statut: string;
-  };
+  date_rupture: string;
 };
 
 export type MonthItem = {


### PR DESCRIPTION
La logique principale se basait sur le dernier statut a date, or il faut traiter avec les dates de fin de formation.
On se base désormais sur la date de rupture au moment de la création du snapshot ( afin de ne pas prendre le risque de faire disparaitre des jeunes )