### PR TITLE
fix: deduplication error

### DIFF
--- a/server/src/common/actions/cfa/cfa-effectifs.actions.ts
+++ b/server/src/common/actions/cfa/cfa-effectifs.actions.ts
@@ -8,6 +8,7 @@ import { CfaEffectifSource, ICfaEffectif, ICfaEffectifsResponse } from "shared/m
 import { getAnneesScolaireListFromDate } from "shared/utils";
 import { v4 as uuidv4 } from "uuid";
 
+import { isDecaSnapshot, migrateMlRecordEffectifId } from "@/common/actions/mission-locale/mission-locale.actions";
 import { getOrganisationOrganismeByOrganismeId } from "@/common/actions/organisations.actions";
 import { normalisePersonIdentifiant } from "@/common/actions/personV2/personV2.actions";
 import { buildCollabStatusSwitch } from "@/common/actions/shared/rupture-pipeline.utils";
@@ -563,25 +564,65 @@ export async function declareCfaEffectifRupture(
     declared_at: now,
     declared_by: userId,
   };
+  const newEffectifId = new ObjectId(effectifId);
 
-  const existing = await missionLocaleEffectifsDb().findOne({
-    effectif_id: new ObjectId(effectifId),
+  const currentStatus =
+    effectif._computed?.statut?.parcours?.filter((s) => s.date <= now).slice(-1)[0] ||
+    effectif._computed?.statut?.parcours?.slice(-1)[0];
+
+  const normalizedIdentifiant =
+    effectif.apprenant.nom && effectif.apprenant.prenom && effectif.apprenant.date_de_naissance
+      ? normalisePersonIdentifiant({
+          nom: effectif.apprenant.nom,
+          prenom: effectif.apprenant.prenom,
+          date_de_naissance: effectif.apprenant.date_de_naissance,
+        })
+      : undefined;
+
+  let existing = await missionLocaleEffectifsDb().findOne({
+    effectif_id: newEffectifId,
     "effectif_snapshot.organisme_id": organismeId,
     soft_deleted: { $ne: true },
   });
 
+  if (!existing && normalizedIdentifiant) {
+    existing = await missionLocaleEffectifsDb().findOne({
+      "identifiant_normalise.nom": normalizedIdentifiant.nom,
+      "identifiant_normalise.prenom": normalizedIdentifiant.prenom,
+      "identifiant_normalise.date_de_naissance": normalizedIdentifiant.date_de_naissance,
+      "effectif_snapshot.organisme_id": organismeId,
+      soft_deleted: { $ne: true },
+    });
+  }
+
   if (existing) {
-    await missionLocaleEffectifsDb().updateOne(
-      { _id: existing._id },
-      {
-        $set: {
-          cfa_rupture_declaration: declaration,
-          "organisme_data.rupture": true,
-          "organisme_data.reponse_at": now,
-          updated_at: now,
-        },
+    const ruptureSet = {
+      cfa_rupture_declaration: declaration,
+      "organisme_data.rupture": true,
+      "organisme_data.reponse_at": now,
+      updated_at: now,
+    };
+    const isMigration = !existing.effectif_id.equals(newEffectifId);
+    const existingIsDeca = isDecaSnapshot(existing.effectif_snapshot);
+    const incomingIsDeca = source === "effectifsDECA";
+
+    if (isMigration && existingIsDeca && !incomingIsDeca) {
+      await migrateMlRecordEffectifId(existing._id, existing.effectif_id, effectif, { extraSet: ruptureSet });
+    } else {
+      if (isMigration) {
+        logger.warn(
+          {
+            ml_record: existing._id,
+            existing_effectif: existing.effectif_id,
+            existing_source: existing.effectif_snapshot?.source,
+            incoming_effectif: newEffectifId,
+            incoming_source: source,
+          },
+          "declareCfaEffectifRupture: mismatch effectif_id sans migration (cas non DECA→ERP)"
+        );
       }
-    );
+      await missionLocaleEffectifsDb().updateOne({ _id: existing._id }, { $set: ruptureSet });
+    }
     scoreEffectifInBackground(existing._id, effectif);
     return { created: false, updated: true };
   }
@@ -600,25 +641,12 @@ export async function declareCfaEffectifRupture(
     throw Boom.badData("Impossible de déclarer en rupture : organisation Mission Locale non trouvée");
   }
 
-  const currentStatus =
-    effectif._computed?.statut?.parcours?.filter((s) => s.date <= now).slice(-1)[0] ||
-    effectif._computed?.statut?.parcours?.slice(-1)[0];
-
-  const normalizedIdentifiant =
-    effectif.apprenant.nom && effectif.apprenant.prenom && effectif.apprenant.date_de_naissance
-      ? normalisePersonIdentifiant({
-          nom: effectif.apprenant.nom,
-          prenom: effectif.apprenant.prenom,
-          date_de_naissance: effectif.apprenant.date_de_naissance,
-        })
-      : undefined;
-
   const organisation = await getOrganisationOrganismeByOrganismeId(organismeId);
 
   try {
     const { insertedId } = await missionLocaleEffectifsDb().insertOne({
       mission_locale_id: mlOrganisation._id,
-      effectif_id: new ObjectId(effectifId),
+      effectif_id: newEffectifId,
       effectif_snapshot: { ...effectif, _id: effectif._id },
       effectif_snapshot_date: now,
       date_rupture: dateRupture,
@@ -650,11 +678,17 @@ export async function declareCfaEffectifRupture(
     if (error instanceof MongoServerError && error.code === 11000) {
       const filter = normalizedIdentifiant
         ? {
-            identifiant_normalise: normalizedIdentifiant,
+            "identifiant_normalise.nom": normalizedIdentifiant.nom,
+            "identifiant_normalise.prenom": normalizedIdentifiant.prenom,
+            "identifiant_normalise.date_de_naissance": normalizedIdentifiant.date_de_naissance,
             mission_locale_id: mlOrganisation._id,
             soft_deleted: { $ne: true },
           }
-        : { effectif_id: new ObjectId(effectifId), mission_locale_id: mlOrganisation._id, soft_deleted: { $ne: true } };
+        : {
+            effectif_id: newEffectifId,
+            mission_locale_id: mlOrganisation._id,
+            soft_deleted: { $ne: true },
+          };
 
       const updated = await missionLocaleEffectifsDb().findOneAndUpdate(
         filter,

--- a/server/src/common/actions/mission-locale/mission-locale.actions.ts
+++ b/server/src/common/actions/mission-locale/mission-locale.actions.ts
@@ -2362,12 +2362,12 @@ const logMissionLocaleSnapshot = (effectif: IEffectif | IEffectifDECA) => {
 };
 
 /** Type guard : distingue un effectif DECA d'un effectif ERP */
-function isDeca(effectif: IEffectif | IEffectifDECA): effectif is IEffectifDECA {
+export function isDeca(effectif: IEffectif | IEffectifDECA): effectif is IEffectifDECA {
   return "is_deca_compatible" in effectif;
 }
 
 /** Même vérification sur un snapshot sérialisé (peut être null en base) */
-function isDecaSnapshot(snapshot: IEffectif | IEffectifDECA | null | undefined): snapshot is IEffectifDECA {
+export function isDecaSnapshot(snapshot: IEffectif | IEffectifDECA | null | undefined): snapshot is IEffectifDECA {
   return !!snapshot && "is_deca_compatible" in snapshot;
 }
 
@@ -2451,6 +2451,36 @@ interface IMissionLocaleSnapshotResult {
   upserted: boolean;
 }
 
+export async function migrateMlRecordEffectifId(
+  mlRecordId: ObjectId,
+  oldEffectifId: ObjectId,
+  newEffectif: IEffectif | IEffectifDECA,
+  options: { skipCurrentStatus?: boolean; extraSet?: Record<string, unknown> } = {}
+): Promise<void> {
+  const now = new Date();
+  const $set: Record<string, unknown> = {
+    effectif_id: newEffectif._id,
+    effectif_snapshot: { ...newEffectif, _id: newEffectif._id },
+    effectif_snapshot_date: now,
+    updated_at: now,
+    ...(options.extraSet ?? {}),
+  };
+
+  if (!options.skipCurrentStatus) {
+    const currentStatus =
+      newEffectif._computed?.statut?.parcours?.filter((s) => s.date <= now).slice(-1)[0] ||
+      newEffectif._computed?.statut?.parcours?.slice(-1)[0];
+    $set.current_status = { value: currentStatus?.valeur ?? null, date: currentStatus?.date ?? null };
+  }
+
+  await missionLocaleEffectifsDb().updateOne({ _id: mlRecordId }, { $set });
+
+  logger.info(
+    { ml_id: mlRecordId, from_effectif: oldEffectifId, to_effectif: newEffectif._id },
+    "ml record: migration effectif_id"
+  );
+}
+
 export const createMissionLocaleSnapshot = async (
   effectif: IEffectif | IEffectifDECA
 ): Promise<IMissionLocaleSnapshotResult | null> => {
@@ -2519,6 +2549,23 @@ export const createMissionLocaleSnapshot = async (
 
   if (!mlData) {
     return null;
+  }
+
+  if (normalizedIdentifiant && !isDeca(effectif)) {
+    const orphan = await missionLocaleEffectifsDb().findOne({
+      "identifiant_normalise.nom": normalizedIdentifiant.nom,
+      "identifiant_normalise.prenom": normalizedIdentifiant.prenom,
+      "identifiant_normalise.date_de_naissance": normalizedIdentifiant.date_de_naissance,
+      "effectif_snapshot.organisme_id": effectif.organisme_id,
+      mission_locale_id: mlData._id,
+      soft_deleted: { $ne: true },
+    });
+
+    if (orphan && !orphan.effectif_id.equals(effectif._id) && isDecaSnapshot(orphan.effectif_snapshot)) {
+      // skipCurrentStatus: le findOneAndUpdate ci-dessous filtre par effectif_id (qui matche désormais
+      // le record migré) et $set current_status — pas la peine de le faire deux fois.
+      await migrateMlRecordEffectifId(orphan._id, orphan.effectif_id, effectif, { skipCurrentStatus: true });
+    }
   }
 
   let duplicateFilter = true;

--- a/server/src/jobs/hydrate/mission-locale/hydrate-mission-locale.ts
+++ b/server/src/jobs/hydrate/mission-locale/hydrate-mission-locale.ts
@@ -13,11 +13,13 @@ import {
   createMissionLocaleSnapshot,
   getAllEffectifForMissionLocaleCursor,
   mergeAndSoftDeleteDuplicates,
+  migrateMlRecordEffectifId,
   sortKeeperPriority,
   updateOrDeleteMissionLocaleSnapshot,
 } from "@/common/actions/mission-locale/mission-locale.actions";
 import { normalisePersonIdentifiant } from "@/common/actions/personV2/personV2.actions";
 import { apiAlternanceClient } from "@/common/apis/apiAlternance/client";
+import logger from "@/common/logger";
 import {
   effectifsDb,
   effectifsQueueDb,
@@ -385,6 +387,143 @@ export const updateMissionLocaleEffectifActivationDate = async () => {
       }
     );
   }
+};
+
+export const migrateOrphanMlRecordsDecaToErp = async () => {
+  let scanned = 0;
+  let migrated = 0;
+  let skippedNoErpTwin = 0;
+  let skippedMlIdMismatch = 0;
+  let skippedPrenomMismatch = 0;
+  let skippedMissingFields = 0;
+
+  type ErpIndex = {
+    _id: ObjectId;
+    mission_locale_id: number | null;
+    normalized: ReturnType<typeof normalisePersonIdentifiant>;
+  };
+  const ORG_CACHE_MAX = 50;
+  const orgErpCache = new Map<string, ErpIndex[]>();
+  const loadOrg = async (orgId: ObjectId): Promise<ErpIndex[]> => {
+    const key = orgId.toString();
+    const cached = orgErpCache.get(key);
+    if (cached) {
+      orgErpCache.delete(key);
+      orgErpCache.set(key, cached);
+      return cached;
+    }
+    const projected = await effectifsDb()
+      .find(
+        { organisme_id: orgId, "apprenant.nom": { $exists: true } },
+        {
+          projection: {
+            _id: 1,
+            "apprenant.nom": 1,
+            "apprenant.prenom": 1,
+            "apprenant.date_de_naissance": 1,
+            "apprenant.adresse.mission_locale_id": 1,
+          },
+        }
+      )
+      .toArray();
+    const indexed: ErpIndex[] = [];
+    for (const e of projected) {
+      if (!e.apprenant?.nom || !e.apprenant?.prenom || !e.apprenant?.date_de_naissance) continue;
+      indexed.push({
+        _id: e._id,
+        mission_locale_id: e.apprenant.adresse?.mission_locale_id ?? null,
+        normalized: normalisePersonIdentifiant({
+          nom: e.apprenant.nom,
+          prenom: e.apprenant.prenom,
+          date_de_naissance: e.apprenant.date_de_naissance,
+        }),
+      });
+    }
+    orgErpCache.set(key, indexed);
+    if (orgErpCache.size > ORG_CACHE_MAX) {
+      const oldest = orgErpCache.keys().next().value;
+      if (oldest) orgErpCache.delete(oldest);
+    }
+    return indexed;
+  };
+
+  const cursor = missionLocaleEffectifsDb()
+    .find({
+      soft_deleted: { $ne: true },
+      "effectif_snapshot.source": "DECA",
+      "identifiant_normalise.nom": { $exists: true },
+    })
+    .sort({ _id: 1 })
+    .addCursorFlag("noCursorTimeout", true);
+
+  try {
+    while (await cursor.hasNext()) {
+      const mlRecord = await cursor.next();
+      if (!mlRecord) continue;
+      scanned++;
+
+      const ddn = mlRecord.identifiant_normalise?.date_de_naissance;
+      const nom = mlRecord.identifiant_normalise?.nom;
+      const prenom = mlRecord.identifiant_normalise?.prenom;
+      const orgId = mlRecord.effectif_snapshot?.organisme_id;
+      if (!ddn || !nom || !prenom || !orgId) {
+        skippedMissingFields++;
+        continue;
+      }
+
+      const candidates = await loadOrg(orgId);
+      const sameNomDdn = candidates.filter(
+        (c) => c.normalized.nom === nom && c.normalized.date_de_naissance.getTime() === ddn.getTime()
+      );
+
+      if (sameNomDdn.length === 0) {
+        skippedNoErpTwin++;
+        continue;
+      }
+
+      const match = sameNomDdn.find((c) => c.normalized.prenom === prenom);
+      if (!match) {
+        skippedPrenomMismatch++;
+        continue;
+      }
+
+      const decaMlId = mlRecord.effectif_snapshot?.apprenant?.adresse?.mission_locale_id;
+      const erpMlId = match.mission_locale_id;
+      if (decaMlId && erpMlId && decaMlId !== erpMlId) {
+        skippedMlIdMismatch++;
+        continue;
+      }
+
+      const erpTwin = await effectifsDb().findOne({ _id: match._id });
+      if (!erpTwin) {
+        skippedNoErpTwin++;
+        continue;
+      }
+
+      await migrateMlRecordEffectifId(mlRecord._id, mlRecord.effectif_id, erpTwin);
+      migrated++;
+
+      if (scanned % 1000 === 0) {
+        logger.info(
+          { scanned, migrated, skippedNoErpTwin, skippedMlIdMismatch, skippedPrenomMismatch, skippedMissingFields },
+          "migrateOrphanMlRecordsDecaToErp progress"
+        );
+      }
+    }
+  } finally {
+    await cursor.close();
+  }
+
+  const summary = {
+    scanned,
+    migrated,
+    skippedNoErpTwin,
+    skippedMlIdMismatch,
+    skippedPrenomMismatch,
+    skippedMissingFields,
+  };
+  logger.info(summary, "migrateOrphanMlRecordsDecaToErp done");
+  return summary;
 };
 
 export const softDeleteDoublonEffectifML = async () => {

--- a/server/src/jobs/jobs.ts
+++ b/server/src/jobs/jobs.ts
@@ -50,6 +50,7 @@ import {
   hydrateMissionLocaleOrganisation,
   hydrateMissionLocaleSnapshot,
   hydrateMissionLocaleStats,
+  migrateOrphanMlRecordsDecaToErp,
   softDeleteDoublonEffectifML,
   updateMissionLocaleEffectifActivationDate,
   updateMissionLocaleEffectifCurrentStatus,
@@ -553,6 +554,11 @@ export async function setupJobProcessor() {
       "tmp:migration:ml-duplication": {
         handler: async () => {
           return softDeleteDoublonEffectifML();
+        },
+      },
+      "tmp:migration:ml-orphan-deca-to-erp": {
+        handler: async () => {
+          return migrateOrphanMlRecordsDecaToErp();
         },
       },
       "tmp:migration:ml-identifiant-normalise": {

--- a/server/tests/integration/common/actions/cfa-effectifs.actions.test.ts
+++ b/server/tests/integration/common/actions/cfa-effectifs.actions.test.ts
@@ -361,5 +361,120 @@ describe("CFA Effectifs Actions", () => {
         declareCfaEffectifRupture(organismeId, effectif._id.toString(), "effectifs", new Date(), userId)
       ).rejects.toThrow("zone Mission Locale non identifiée");
     });
+
+    it("migre un ml record orphelin lié à un effectif jumeau (DECA → ERP)", async () => {
+      const ddn = new Date("2005-06-15T00:00:00Z");
+      const apprenantBase = {
+        nom: "VILLENEUVE",
+        prenom: "Téo",
+        date_de_naissance: ddn,
+        adresse: { mission_locale_id: 337 },
+      };
+
+      const decaEffectif = {
+        _id: new ObjectId(),
+        deca_raw_id: new ObjectId(),
+        ...(await createSampleEffectif({
+          organisme: sampleOrganisme,
+          annee_scolaire: ANNEE_SCOLAIRE,
+          apprenant: apprenantBase,
+          source: "DECA" as any,
+        })),
+        organisme_id: organismeId,
+        is_deca_compatible: true,
+      };
+      await effectifsDECADb().insertOne(decaEffectif as any);
+
+      const mlRecord = createMlEffectifDoc(decaEffectif, {
+        identifiant_normalise: { nom: "VILLENEUVE", prenom: "Téo", date_de_naissance: ddn },
+        soft_deleted: false,
+      });
+      await missionLocaleEffectifsDb().insertOne(mlRecord as any);
+
+      await organisationsDb().insertOne({
+        _id: mlOrganisationId,
+        type: "MISSION_LOCALE",
+        ml_id: 337,
+        nom: "ML Test",
+        created_at: new Date(),
+      } as any);
+      await organisationsDb().insertOne(organisation as any);
+
+      const erpEffectif = await insertEffectif({ apprenant: apprenantBase });
+
+      const dateRupture = new Date("2026-01-10");
+      const result = await declareCfaEffectifRupture(
+        organismeId,
+        erpEffectif._id.toString(),
+        "effectifs",
+        dateRupture,
+        userId
+      );
+
+      expect(result).toEqual({ created: false, updated: true });
+
+      const migrated = await missionLocaleEffectifsDb().findOne({ _id: mlRecord._id });
+      expect(migrated?.effectif_id).toEqual(erpEffectif._id);
+      expect(migrated?.effectif_snapshot?._id).toEqual(erpEffectif._id);
+      expect(migrated?.cfa_rupture_declaration?.date_rupture).toEqual(dateRupture);
+
+      const detail = await getCfaEffectifDetail(organismeId, erpEffectif._id.toString());
+      expect((detail.effectif as any).cfa_rupture_declaration?.date_rupture).toEqual(dateRupture);
+    });
+
+    it("ne migre PAS dans le sens ERP → DECA quand un ml record est déjà bound à un ERP", async () => {
+      const ddn = new Date("2005-06-15T00:00:00Z");
+      const apprenantBase = {
+        nom: "DURAND",
+        prenom: "Léa",
+        date_de_naissance: ddn,
+        adresse: { mission_locale_id: 337 },
+      };
+
+      const erpEffectif = await insertEffectif({ apprenant: apprenantBase });
+      const mlRecord = createMlEffectifDoc(erpEffectif, {
+        identifiant_normalise: { nom: "DURAND", prenom: "Léa", date_de_naissance: ddn },
+        soft_deleted: false,
+      });
+      await missionLocaleEffectifsDb().insertOne(mlRecord as any);
+
+      const decaEffectif = {
+        _id: new ObjectId(),
+        deca_raw_id: new ObjectId(),
+        ...(await createSampleEffectif({
+          organisme: sampleOrganisme,
+          annee_scolaire: ANNEE_SCOLAIRE,
+          apprenant: apprenantBase,
+          source: "DECA" as any,
+        })),
+        organisme_id: organismeId,
+      };
+      await effectifsDECADb().insertOne(decaEffectif as any);
+
+      await organisationsDb().insertOne({
+        _id: mlOrganisationId,
+        type: "MISSION_LOCALE",
+        ml_id: 337,
+        nom: "ML Test",
+        created_at: new Date(),
+      } as any);
+      await organisationsDb().insertOne(organisation as any);
+
+      const dateRupture = new Date("2026-01-10");
+      const result = await declareCfaEffectifRupture(
+        organismeId,
+        decaEffectif._id.toString(),
+        "effectifsDECA",
+        dateRupture,
+        userId
+      );
+
+      expect(result).toEqual({ created: false, updated: true });
+
+      const after = await missionLocaleEffectifsDb().findOne({ _id: mlRecord._id });
+      expect(after?.effectif_id).toEqual(erpEffectif._id);
+      expect(after?.effectif_snapshot?._id).toEqual(erpEffectif._id);
+      expect(after?.cfa_rupture_declaration?.date_rupture).toEqual(dateRupture);
+    });
   });
 });

--- a/server/tests/integration/jobs/hydrate/migrate-orphan-ml-records.test.ts
+++ b/server/tests/integration/jobs/hydrate/migrate-orphan-ml-records.test.ts
@@ -1,0 +1,334 @@
+import { ObjectId } from "bson";
+import { it, expect, describe, beforeAll, beforeEach } from "vitest";
+
+import { effectifsDb, effectifsDECADb, missionLocaleEffectifsDb } from "@/common/model/collections";
+import { createIndexes } from "@/common/model/indexes";
+import { migrateOrphanMlRecordsDecaToErp } from "@/jobs/hydrate/mission-locale/hydrate-mission-locale";
+import { createSampleEffectif, createRandomOrganisme } from "@tests/data/randomizedSample";
+import { useMongo } from "@tests/jest/setupMongo";
+
+const ML_OBJECTID = new ObjectId();
+const ORG_ID = new ObjectId();
+const ANNEE = "2025-2026";
+
+describe("migrateOrphanMlRecordsDecaToErp", () => {
+  useMongo();
+
+  beforeAll(async () => {
+    await createIndexes();
+  });
+
+  beforeEach(async () => {
+    await missionLocaleEffectifsDb().deleteMany({});
+    await effectifsDb().deleteMany({});
+    await effectifsDECADb().deleteMany({});
+  });
+
+  const seedDecaWithOrphanMlRecord = async (overrides: {
+    nom: string;
+    prenom: string;
+    ddn: Date;
+    mlId?: number;
+    organismeId?: ObjectId;
+  }) => {
+    const orgId = overrides.organismeId ?? ORG_ID;
+    const sampleOrganisme = { _id: orgId, ...createRandomOrganisme() };
+    const decaEffectif = {
+      _id: new ObjectId(),
+      deca_raw_id: new ObjectId(),
+      ...(await createSampleEffectif({
+        organisme: sampleOrganisme,
+        annee_scolaire: ANNEE,
+        apprenant: {
+          nom: overrides.nom,
+          prenom: overrides.prenom,
+          date_de_naissance: overrides.ddn,
+          adresse: { mission_locale_id: overrides.mlId ?? 100 },
+        },
+        source: "DECA" as any,
+      })),
+      organisme_id: orgId,
+    };
+    await effectifsDECADb().insertOne(decaEffectif as any);
+
+    const mlRecord = {
+      _id: new ObjectId(),
+      mission_locale_id: ML_OBJECTID,
+      effectif_id: decaEffectif._id,
+      effectif_snapshot: { ...decaEffectif, organisme_id: orgId },
+      effectif_snapshot_date: new Date(),
+      identifiant_normalise: { nom: overrides.nom, prenom: overrides.prenom, date_de_naissance: overrides.ddn },
+      date_rupture: null,
+      created_at: new Date(),
+      current_status: { value: null, date: null },
+      brevo: { token: null, token_created_at: null },
+      soft_deleted: false,
+    };
+    await missionLocaleEffectifsDb().insertOne(mlRecord as any);
+
+    return { decaEffectif, mlRecord, sampleOrganisme };
+  };
+
+  it("repointe le ml record vers l'ERP twin quand il existe", async () => {
+    const ddn = new Date("2005-06-15T00:00:00Z");
+    const { decaEffectif, mlRecord, sampleOrganisme } = await seedDecaWithOrphanMlRecord({
+      nom: "VILLENEUVE",
+      prenom: "Téo",
+      ddn,
+    });
+
+    const erpEffectif = {
+      _id: new ObjectId(),
+      ...(await createSampleEffectif({
+        organisme: sampleOrganisme,
+        annee_scolaire: ANNEE,
+        apprenant: {
+          nom: "VILLENEUVE",
+          prenom: "Téo",
+          date_de_naissance: ddn,
+          adresse: { mission_locale_id: 100 },
+        },
+      })),
+    };
+    await effectifsDb().insertOne(erpEffectif as any);
+
+    const summary = await migrateOrphanMlRecordsDecaToErp();
+
+    expect(summary.scanned).toBe(1);
+    expect(summary.migrated).toBe(1);
+
+    const after = await missionLocaleEffectifsDb().findOne({ _id: mlRecord._id });
+    expect(after?.effectif_id.toString()).toBe(erpEffectif._id.toString());
+    expect(after?.effectif_snapshot?._id?.toString?.()).toBe(erpEffectif._id.toString());
+
+    const decaAfter = await effectifsDECADb().findOne({ _id: decaEffectif._id });
+    expect(decaAfter).toBeTruthy();
+  });
+
+  it("ne fait rien si pas d'ERP twin", async () => {
+    await seedDecaWithOrphanMlRecord({
+      nom: "DUPONT",
+      prenom: "Jean",
+      ddn: new Date("2005-01-01T00:00:00Z"),
+    });
+
+    const summary = await migrateOrphanMlRecordsDecaToErp();
+
+    expect(summary.scanned).toBe(1);
+    expect(summary.migrated).toBe(0);
+    expect(summary.skippedNoErpTwin).toBe(1);
+  });
+
+  it("skip si le ml_id de l'adresse diffère entre DECA et ERP", async () => {
+    const ddn = new Date("2005-06-15T00:00:00Z");
+    const { sampleOrganisme } = await seedDecaWithOrphanMlRecord({
+      nom: "MARTIN",
+      prenom: "Marie",
+      ddn,
+      mlId: 100,
+    });
+
+    const erpEffectif = {
+      _id: new ObjectId(),
+      ...(await createSampleEffectif({
+        organisme: sampleOrganisme,
+        annee_scolaire: ANNEE,
+        apprenant: {
+          nom: "MARTIN",
+          prenom: "Marie",
+          date_de_naissance: ddn,
+          adresse: { mission_locale_id: 200 }, // ML différent
+        },
+      })),
+    };
+    await effectifsDb().insertOne(erpEffectif as any);
+
+    const summary = await migrateOrphanMlRecordsDecaToErp();
+
+    expect(summary.migrated).toBe(0);
+    expect(summary.skippedMlIdMismatch).toBe(1);
+  });
+
+  it("matche un ERP twin avec casse différente (Villeneuve vs VILLENEUVE) et date avec heure", async () => {
+    const ddnNormalized = new Date("2005-06-15T00:00:00Z");
+    const ddnRaw = new Date("2005-06-15T08:30:00Z");
+    const { mlRecord, sampleOrganisme } = await seedDecaWithOrphanMlRecord({
+      nom: "VILLENEUVE",
+      prenom: "Téo",
+      ddn: ddnNormalized,
+    });
+
+    const erpEffectif = {
+      _id: new ObjectId(),
+      ...(await createSampleEffectif({
+        organisme: sampleOrganisme,
+        annee_scolaire: ANNEE,
+        apprenant: {
+          nom: "Villeneuve",
+          prenom: "TÉO",
+          date_de_naissance: ddnRaw,
+          adresse: { mission_locale_id: 100 },
+        },
+      })),
+    };
+    await effectifsDb().insertOne(erpEffectif as any);
+
+    const summary = await migrateOrphanMlRecordsDecaToErp();
+
+    expect(summary.scanned).toBe(1);
+    expect(summary.migrated).toBe(1);
+
+    const after = await missionLocaleEffectifsDb().findOne({ _id: mlRecord._id });
+    expect(after?.effectif_id.toString()).toBe(erpEffectif._id.toString());
+  });
+
+  it("skip si nom+ddn matchent mais prénom diffère", async () => {
+    const ddn = new Date("2005-06-15T00:00:00Z");
+    const { sampleOrganisme } = await seedDecaWithOrphanMlRecord({
+      nom: "DUPONT",
+      prenom: "Marie",
+      ddn,
+    });
+
+    const erpEffectif = {
+      _id: new ObjectId(),
+      ...(await createSampleEffectif({
+        organisme: sampleOrganisme,
+        annee_scolaire: ANNEE,
+        apprenant: {
+          nom: "DUPONT",
+          prenom: "Sophie",
+          date_de_naissance: ddn,
+          adresse: { mission_locale_id: 100 },
+        },
+      })),
+    };
+    await effectifsDb().insertOne(erpEffectif as any);
+
+    const summary = await migrateOrphanMlRecordsDecaToErp();
+
+    expect(summary.scanned).toBe(1);
+    expect(summary.migrated).toBe(0);
+    expect(summary.skippedPrenomMismatch).toBe(1);
+  });
+
+  it("homonyme : 2 ERP même nom+ddn dans le même organisme → choisit celui dont le prénom matche", async () => {
+    const ddn = new Date("2005-06-15T00:00:00Z");
+    const { mlRecord, sampleOrganisme } = await seedDecaWithOrphanMlRecord({
+      nom: "DUPONT",
+      prenom: "Marie",
+      ddn,
+    });
+
+    const erpHomonym = {
+      _id: new ObjectId(),
+      ...(await createSampleEffectif({
+        organisme: sampleOrganisme,
+        annee_scolaire: ANNEE,
+        apprenant: { nom: "DUPONT", prenom: "Sophie", date_de_naissance: ddn, adresse: { mission_locale_id: 100 } },
+      })),
+    };
+    const erpRight = {
+      _id: new ObjectId(),
+      ...(await createSampleEffectif({
+        organisme: sampleOrganisme,
+        annee_scolaire: ANNEE,
+        apprenant: { nom: "DUPONT", prenom: "Marie", date_de_naissance: ddn, adresse: { mission_locale_id: 100 } },
+      })),
+    };
+    await effectifsDb().insertMany([erpHomonym, erpRight] as any[]);
+
+    const summary = await migrateOrphanMlRecordsDecaToErp();
+
+    expect(summary.migrated).toBe(1);
+    expect(summary.skippedPrenomMismatch).toBe(0);
+    const after = await missionLocaleEffectifsDb().findOne({ _id: mlRecord._id });
+    expect(after?.effectif_id.toString()).toBe(erpRight._id.toString());
+  });
+
+  it("multi-organismes : migre chaque ml record vers son ERP twin local sans fuite cross-org", async () => {
+    const ddn1 = new Date("2005-06-15T00:00:00Z");
+    const ddn2 = new Date("2006-03-10T00:00:00Z");
+    const orgA = new ObjectId();
+    const orgB = new ObjectId();
+
+    const { mlRecord: mlA, sampleOrganisme: sampleA } = await seedDecaWithOrphanMlRecord({
+      nom: "MARTIN",
+      prenom: "Lucie",
+      ddn: ddn1,
+      organismeId: orgA,
+    });
+    const { mlRecord: mlB, sampleOrganisme: sampleB } = await seedDecaWithOrphanMlRecord({
+      nom: "BERNARD",
+      prenom: "Paul",
+      ddn: ddn2,
+      organismeId: orgB,
+    });
+
+    const erpA = {
+      _id: new ObjectId(),
+      ...(await createSampleEffectif({
+        organisme: sampleA,
+        annee_scolaire: ANNEE,
+        apprenant: { nom: "Martin", prenom: "Lucie", date_de_naissance: ddn1, adresse: { mission_locale_id: 100 } },
+      })),
+    };
+    const erpB = {
+      _id: new ObjectId(),
+      ...(await createSampleEffectif({
+        organisme: sampleB,
+        annee_scolaire: ANNEE,
+        apprenant: { nom: "Bernard", prenom: "Paul", date_de_naissance: ddn2, adresse: { mission_locale_id: 100 } },
+      })),
+    };
+    const erpDecoy = {
+      _id: new ObjectId(),
+      ...(await createSampleEffectif({
+        organisme: sampleB,
+        annee_scolaire: ANNEE,
+        apprenant: { nom: "Martin", prenom: "Lucie", date_de_naissance: ddn1, adresse: { mission_locale_id: 100 } },
+      })),
+    };
+    await effectifsDb().insertMany([erpA, erpB, erpDecoy] as any[]);
+
+    const summary = await migrateOrphanMlRecordsDecaToErp();
+
+    expect(summary.scanned).toBe(2);
+    expect(summary.migrated).toBe(2);
+
+    const afterA = await missionLocaleEffectifsDb().findOne({ _id: mlA._id });
+    const afterB = await missionLocaleEffectifsDb().findOne({ _id: mlB._id });
+    expect(afterA?.effectif_id.toString()).toBe(erpA._id.toString());
+    expect(afterB?.effectif_id.toString()).toBe(erpB._id.toString());
+  });
+
+  it("est idempotent : un second run sur même état ne migre pas à nouveau", async () => {
+    const ddn = new Date("2005-06-15T00:00:00Z");
+    const { sampleOrganisme } = await seedDecaWithOrphanMlRecord({
+      nom: "DURAND",
+      prenom: "Lucas",
+      ddn,
+    });
+    const erpEffectif = {
+      _id: new ObjectId(),
+      ...(await createSampleEffectif({
+        organisme: sampleOrganisme,
+        annee_scolaire: ANNEE,
+        apprenant: {
+          nom: "DURAND",
+          prenom: "Lucas",
+          date_de_naissance: ddn,
+          adresse: { mission_locale_id: 100 },
+        },
+      })),
+    };
+    await effectifsDb().insertOne(erpEffectif as any);
+
+    const first = await migrateOrphanMlRecordsDecaToErp();
+    expect(first.migrated).toBe(1);
+
+    const second = await migrateOrphanMlRecordsDecaToErp();
+    expect(second.scanned).toBe(0);
+    expect(second.migrated).toBe(0);
+  });
+});

--- a/server/tests/integration/jobs/ingestion/mission-locale-deca.test.ts
+++ b/server/tests/integration/jobs/ingestion/mission-locale-deca.test.ts
@@ -491,6 +491,37 @@ describe("Filtrage DECA pour les snapshots Mission Locale", () => {
       expect(active[0].effectif_id.toString()).toBe(deca1._id.toString());
     });
 
+    it("DECA inséré, puis ERP non-RUPTURANT (FIN_DE_FORMATION) → ml record migré vers ERP", async () => {
+      const decaEffectif = createBaseDecaEffectif({ apprenant: makeApprenant("VILLENEUVE", "Téo", 21) });
+      const decaResult = await createMissionLocaleSnapshot(decaEffectif);
+      expect(decaResult?.upserted).toBe(true);
+
+      const dateFin = new Date("2026-01-10");
+      const erpEffectif = createBaseErpEffectif({
+        _id: new ObjectId(),
+        apprenant: makeApprenant("VILLENEUVE", "Téo", 21),
+        organisme_id: decaEffectif.organisme_id,
+        _computed: {
+          organisme: { uai: UAI, siret: SIRET, region: "11" },
+          statut: {
+            en_cours: STATUT_APPRENANT.FIN_DE_FORMATION,
+            parcours: [
+              { date: new Date("2025-09-01"), valeur: STATUT_APPRENANT.APPRENTI },
+              { date: dateFin, valeur: STATUT_APPRENANT.FIN_DE_FORMATION },
+            ],
+          },
+        },
+      });
+      await createMissionLocaleSnapshot(erpEffectif);
+
+      const allMlEffectifs = await missionLocaleEffectifsDb()
+        .find({ soft_deleted: { $ne: true } })
+        .toArray();
+      expect(allMlEffectifs.length).toBe(1);
+      expect(allMlEffectifs[0].effectif_id.toString()).toBe(erpEffectif._id.toString());
+      expect((allMlEffectifs[0].effectif_snapshot as IEffectifDECA)?.is_deca_compatible).toBeFalsy();
+    });
+
     it("Deux ERP pour même personne, même ML → premier reste, second rejeté", async () => {
       const erp1 = createBaseErpEffectif({ apprenant: makeApprenant("GARCIA", "Lucas", 20) });
       const result1 = await createMissionLocaleSnapshot(erp1);


### PR DESCRIPTION
- Correction de l'erreur de dédup : ml records DECA orphelins quand un jumeau ERP arrive (même nom/prénom/ddn, même organisme)
- createMissionLocaleSnapshot : détecte un orphelin DECA et migre son effectif_id vers l'ERP avant l'insertion, évitant l'erreur de clé dupliquée
- declareCfaEffectifRupture : recherche par identifiant_normalise en repli, puis migration DECA → ERP si nécessaire (jamais l'inverse)
- Helper partagé migrateMlRecordEffectifId (mise à jour effectif_id + snapshot + current_status)
- Job ponctuel tmp:migration:ml-orphan-deca-to-erp pour nettoyer les orphelins existants en base (cache par organisme, correspondance stricte nom + ddn + prénom + ml_id)
- Tests d'intégration : migration via snapshot, via déclaration de rupture CFA, et non-régression dans le sens ERP → DECA