### PR TITLE
fix: montage du volume mongo local sur /data/db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "127.0.0.1:27017:27017"
     volumes:
-      - tdb_mongodb_data:/data
+      - tdb_mongodb_data:/data/db
     healthcheck:
       test: ["CMD", "mongosh", "--eval", '''db.runCommand("ping").ok''', "--quiet"]
       interval: 10s


### PR DESCRIPTION
L'image mongo:7 déclare VOLUME /data/db. Docker raisonne sur la destination exacte : monter le parent /data ne couvre pas ce chemin, il crée donc un volume anonyme par-dessus, qui masque le sous-dossier db/ du volume nommé.

La base vivait donc dans un volume anonyme, abandonné et recréé vide à chaque recréation du conteneur 